### PR TITLE
deleted i in 229 line.

### DIFF
--- a/allensdk/brain_observatory/r_neuropil.py
+++ b/allensdk/brain_observatory/r_neuropil.py
@@ -226,7 +226,7 @@ class NeuropilSubtract(object):
 
             if r is not None:
                 delta_r = np.abs(r - new_r) / r
-i
+
             r = new_r
             it += 1
 


### PR DESCRIPTION
correcting the error message saying that "unexpected indent in 230 line < r = new_r >

So I deleted typo 'i' in 229 line.

And it worked.