### PR TITLE
make neuropil decontamination run with Python3

### DIFF
--- a/allensdk/brain_observatory/r_neuropil.py
+++ b/allensdk/brain_observatory/r_neuropil.py
@@ -55,7 +55,7 @@ def ab_from_diagonals(mat_dict):
     -------
     ab: value for scipy.linalg.solve_banded
     '''
-    offsets = mat_dict.keys()
+    offsets = list(mat_dict.keys())
     l = -np.min(offsets)
     u = np.max(offsets)
 


### PR DESCRIPTION
Hello,

This is a minor fix that I did to use the neuropil decontamination with Python 3.5.
I know that this is not a supported version, so please consider it as a simple suggestion ;-).

Another way to fix this incompatibility is to change `np.min` and `np.max` with `min` and `max` (lines 59 and 60 in `r_neuropil.py`), which should be ok (in terms of performance) if there are few diagonals.