### PR TITLE
Matplotlib<2.0.0 not necessary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py>=2.3.1
-matplotlib>=1.4.3,<2.0.0
+matplotlib>=1.4.3
 numpy>=1.9.2
 pandas>=0.16.2,<0.20.0
 jinja2>=2.7.3


### PR DESCRIPTION
Verified installs fine with matplotlib (2.1.0)