### PR TITLE
added sphinx-gallery as documentation requirement

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -17,3 +17,4 @@ requests-toolbelt
 simplejson>=3.10.0
 scikit-image>=0.13.0
 statsmodels>=0.8.0
+sphinx-gallery>=0.1.13


### PR DESCRIPTION
Noticed that matplotlib <2.0 is a condition in doc_requirements.  Ill make a separate PR to fix this.