### PR TITLE
added noplot mode in Makefile, for fast execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ doc: FORCE
 	cp -r doc_template $(DOCDIR)
 	cd $(DOCDIR); sphinx-build -b html . _build/html
 
+doc-noplot: FORCE
+	cp -r doc_template $(DOCDIR)
+	cd $(DOCDIR); sphinx-build -D plot_gallery=0 -b html . _build/html
+
 notebooks:
 	cd doc_template/examples/nb && find . -maxdepth 1 -name '*.ipynb' -exec jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=1800 {} \;
 	cd doc_template/examples/nb/summer_workshop_2015 && find . -maxdepth 1 -name '*.ipynb' -exec jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=1800 {} \;


### PR DESCRIPTION
This option is for building the docs faster, whithout evaluating each script.  If no changes are made to the figures that are generated, this will just update the text and layout.  The dev workflow would then be:

1. make clean
2. make doc (slow, but generates figures and thumbnails)
3. (edit some text, layout, etc)
4. make doc-noplot (fast, incorporates changes from above but without running the files/regenerating plots)
5. (edit some text, layout, etc)
6. ...
