### PR TITLE
remove ontology reference in mouse connectivity docs

### DIFF
--- a/doc_template/examples_root/examples/connectivity_ex2.py
+++ b/doc_template/examples_root/examples/connectivity_ex2.py
@@ -5,7 +5,7 @@ mcc = MouseConnectivityCache(resolution=25)
 
 # use the structure tree class to get information about the isocortex structure
 structure_tree = mcc.get_structure_tree()
-isocortex_id = structure_tree.get_structures_by_name('Isocortex')[0]['id']
+isocortex_id = structure_tree.get_structures_by_name(['Isocortex'])[0]['id']
 
 # a list of dictionaries containing metadata for non-Cre experiments
 experiments = mcc.get_experiments(file_name='non_cre.json',

--- a/doc_template/examples_root/examples/connectivity_ex2.py
+++ b/doc_template/examples_root/examples/connectivity_ex2.py
@@ -3,9 +3,9 @@ from allensdk.core.mouse_connectivity_cache import MouseConnectivityCache
 # tell the cache class what resolution (in microns) of data you want to download
 mcc = MouseConnectivityCache(resolution=25)
 
-# use the ontology class to get the id of the isocortex structure
-ontology = mcc.get_ontology('ontology.csv')
-isocortex = ontology['Isocortex']
+# use the structure tree class to get information about the isocortex structure
+structure_tree = mcc.get_structure_tree()
+isocortex_id = structure_tree.get_structures_by_name('Isocortex')[0]['id']
 
 # a list of dictionaries containing metadata for non-Cre experiments
 experiments = mcc.get_experiments(file_name='non_cre.json',


### PR DESCRIPTION
Resolves #102. One of the mouse connectivity example scripts used the removed get_ontology() method of mouse connectivity cache. This instead uses get_structure_tree().