### PR TITLE
Bump numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 h5py>=2.3.1
 matplotlib>=1.4.3
-numpy>=1.9.2
+numpy>=1.12.1
 pandas>=0.16.2,<0.20.0
 jinja2>=2.7.3
 scipy>=0.15.1


### PR DESCRIPTION
Resolves #114 

Increase the explicitly required numpy version to 1.12.1