### PR TITLE
Align make doc commands in internal and master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ flake8:
 EXAMPLES=doc/_static/examples
 
 doc: FORCE
-	cp -r doc_template $(DOCDIR)
+	mkdir -p $(DOCDIR)
+	cp -r doc_template/* $(DOCDIR)
 	cd $(DOCDIR); sphinx-build -b html . _build/html
 
 notebooks:


### PR DESCRIPTION
Patch in a fix from internal -> master allowing the documentation to be built from each branch using the same configuration.