### PR TITLE
Adds a method to image download api for listing section data sets by product

### DIFF
--- a/allensdk/api/queries/image_download_api.py
+++ b/allensdk/api/queries/image_download_api.py
@@ -152,7 +152,7 @@ class ImageDownloadApi(RmaTemplate):
 
         Notes
         -----
-        See :py:meth:`allensdk.api.queries.image_download_api.ImageDownloadApi.get_products` for a list of products.
+        See http://api.brain-map.org/api/v2/data/query.json?criteria=model::Product for a list of products.
 
         '''
 

--- a/allensdk/api/queries/image_download_api.py
+++ b/allensdk/api/queries/image_download_api.py
@@ -85,8 +85,8 @@ class ImageDownloadApi(RmaTemplate):
              'model': 'SectionDataSet',
              'num_rows': 'all',
              'count': False,
-             'criteria': 'products[id$in{{ product_ids }}]',
-             'criteria_params': ['product_ids']
+             'criteria': '[failed$in{{failed}}],products[id$in{{ product_ids }}]',
+             'criteria_params': ['product_ids', 'failed']
               }]}
 
     def __init__(self, base_uri=None):
@@ -133,13 +133,15 @@ class ImageDownloadApi(RmaTemplate):
 
 
     @cacheable()
-    def get_section_data_sets_by_product(self, product_ids, num_rows='all', count=False, **kwargs):
+    def get_section_data_sets_by_product(self, product_ids, include_failed=False, num_rows='all', count=False, **kwargs):
         '''List all of the section data sets produced as part of one or more products
 
         Parameters
         ----------
         product_ids : list of int
             Integer specifiers for Allen Institute products. A product is a set of related data.
+        include_failed : bool, optional
+            If True, find both failed and passed datasets. Default is False
         num_rows : int, optional
             how many records to retrieve. Default is 'all'.
         count : bool, optional
@@ -156,8 +158,14 @@ class ImageDownloadApi(RmaTemplate):
 
         '''
 
+        if include_failed:
+            failed_crit = "\'false\',\'true\'"
+        else:
+            failed_crit = "\'false\'"
+
         return self.template_query('image_queries', 'section_data_sets_by_product_id', 
                                    product_ids=product_ids, 
+                                   failed=failed_crit,
                                    num_rows=num_rows, count=count)
 
 

--- a/allensdk/api/queries/image_download_api.py
+++ b/allensdk/api/queries/image_download_api.py
@@ -79,6 +79,14 @@ class ImageDownloadApi(RmaTemplate):
              'count': False,
              'criteria': '[data_set_id$eq{{ data_set_id }}]',
              'criteria_params': ['data_set_id']
+              },
+            {'name': 'section_data_sets_by_product_id',
+             'description': 'see name',
+             'model': 'SectionDataSet',
+             'num_rows': 'all',
+             'count': False,
+             'criteria': 'products[id$in{{ product_ids }}]',
+             'criteria_params': ['product_ids']
               }]}
 
     def __init__(self, base_uri=None):
@@ -122,6 +130,36 @@ class ImageDownloadApi(RmaTemplate):
             list_ranges.append([ rng['red_lower'], rng['red_upper'], rng['green_lower'], rng['green_upper'], rng['blue_lower'], rng['blue_upper'] ])
 
         return list_ranges
+
+
+    @cacheable()
+    def get_section_data_sets_by_product(self, product_ids, num_rows='all', count=False, **kwargs):
+        '''List all of the section data sets produced as part of one or more products
+
+        Parameters
+        ----------
+        product_ids : list of int
+            Integer specifiers for Allen Institute products. A product is a set of related data.
+        num_rows : int, optional
+            how many records to retrieve. Default is 'all'.
+        count : bool, optional
+            If True, return a count of the lines found by the query. Default is False.
+
+        Returns
+        -------
+        list of dict : 
+            Each returned element is a section data set record.
+
+        Notes
+        -----
+        See :py:meth:`allensdk.api.queries.image_download_api.ImageDownloadApi.get_products` for a list of products.
+
+        '''
+
+        return self.template_query('image_queries', 'section_data_sets_by_product_id', 
+                                   product_ids=product_ids, 
+                                   num_rows=num_rows, count=count)
+
 
     @cacheable()
     def section_image_query(self, section_data_set_id, num_rows='all', count=False, **kwargs):

--- a/allensdk/test/api/test_image_download_api.py
+++ b/allensdk/test/api/test_image_download_api.py
@@ -59,6 +59,16 @@ def test_get_section_image_ranges(image_api):
                                                      'rma::options[only$eq\'blue_lower,blue_upper,red_lower,red_upper,green_lower,green_upper\']'
                                                      '[num_rows$eq\'all\'][count$eqfalse]')
 
+def test_get_section_data_sets_by_product(image_api):
+
+    product_ids = [10, 22]
+    image_api.get_section_data_sets_by_product(product_ids)
+
+    image_api.json_msg_query.assert_called_once_with('http://api.brain-map.org/api/v2/data/query.json?'\
+                                                     'q=model::SectionDataSet,'\
+                                                     'rma::criteria,products[id$in10,22],'\
+                                                     'rma::options[num_rows$eq\'all\'][count$eqfalse]')
+
 def test_get_section_image_ranges_as_list(image_api):
 
     image_api.template_query = MagicMock(return_value=[{'blue_lower': 0, 'blue_upper': 1, 'green_lower': 2, 'green_upper': 3, 'red_lower': 4, 'red_upper': 5}])

--- a/allensdk/test/api/test_image_download_api.py
+++ b/allensdk/test/api/test_image_download_api.py
@@ -66,7 +66,17 @@ def test_get_section_data_sets_by_product(image_api):
 
     image_api.json_msg_query.assert_called_once_with('http://api.brain-map.org/api/v2/data/query.json?'\
                                                      'q=model::SectionDataSet,'\
-                                                     'rma::criteria,products[id$in10,22],'\
+                                                     'rma::criteria,[failed$in\'false\'],products[id$in10,22],'\
+                                                     'rma::options[num_rows$eq\'all\'][count$eqfalse]')
+
+def test_get_section_data_sets_by_product_failedok(image_api):
+
+    product_ids = [10, 22]
+    image_api.get_section_data_sets_by_product(product_ids, include_failed=True)
+
+    image_api.json_msg_query.assert_called_once_with('http://api.brain-map.org/api/v2/data/query.json?'\
+                                                     'q=model::SectionDataSet,'\
+                                                     'rma::criteria,[failed$in\'false\',\'true\'],products[id$in10,22],'\
                                                      'rma::options[num_rows$eq\'all\'][count$eqfalse]')
 
 def test_get_section_image_ranges_as_list(image_api):


### PR DESCRIPTION
Also updates the image download notebook with two changes:
1. an example of using the new api functionality
2. the multi-image download example now plots multiple images

Probably in the long/medium term we want a seperate queries module for product-related queries, but until then ImageDownloadApi is a logical place for this functionality, since we are listing section data sets.