### PR TITLE
Resolves #120 add six.moves for reduce and xrange

### DIFF
--- a/allensdk/core/mouse_connectivity_cache.py
+++ b/allensdk/core/mouse_connectivity_cache.py
@@ -49,6 +49,7 @@ from allensdk.config.manifest import Manifest
 import warnings
 import operator as op
 import functools
+from six.moves import reduce
 
 
 class MouseConnectivityCache(ReferenceSpaceCache):

--- a/allensdk/core/structure_tree.py
+++ b/allensdk/core/structure_tree.py
@@ -37,7 +37,6 @@ from __future__ import division, print_function, absolute_import
 import re
 import operator as op
 from six import iteritems, string_types
-from six.moves import xrange
 
 import numpy as np
 
@@ -377,7 +376,7 @@ class StructureTree( SimpleTree ):
         if hex_color[0] == '#':
             hex_color = hex_color[1:]
         
-        return [int(hex_color[a * 2: a*2 + 2], 16) for a in xrange(3)] 
+        return [int(hex_color[a * 2: a*2 + 2], 16) for a in range(3)] 
     
 
     @staticmethod

--- a/allensdk/core/structure_tree.py
+++ b/allensdk/core/structure_tree.py
@@ -37,6 +37,7 @@ from __future__ import division, print_function, absolute_import
 import re
 import operator as op
 from six import iteritems, string_types
+from six.moves import xrange
 
 import numpy as np
 

--- a/allensdk/test/core/test_mouse_connectivity_cache.py
+++ b/allensdk/test/core/test_mouse_connectivity_cache.py
@@ -69,13 +69,12 @@ def old_nodes():
              'color_hex_triplet': '000000', 'acronym': 'rt', 
              'name': 'root', 'parent_structure_id': 12}]
 
-
 @pytest.fixture(scope='function')
 def experiments():
 
     return [{'num-voxels': 100, 'injection-volume': 99, 'sum': 98, 
              'name': 'foo', 'transgenic-line': 'most_creish', 
-             'structure-id': 97,}]
+             'structure-id': 97}]
 
 
 @pytest.fixture(scope='function')
@@ -281,6 +280,10 @@ def test_filter_experiments(mcc, fn_temp_dir, experiments):
     assert len(pass_line) == 1
     assert len(fail_line) == 0
 
+    sid_line = mcc.filter_experiments(experiments, cre=True,
+                                      injection_structure_ids=[97,98])
+
+    assert len(sid_line) == 1
 
 def test_rank_structures(mcc, top_injection_unionizes, fn_temp_dir):
 
@@ -336,6 +339,11 @@ def test_filter_structure_unionizes(mcc, unionizes):
 
     assert obtained.loc[0, 'volume'] == 0.016032
 
+    obt_sid = mcc.filter_structure_unionizes(pd.DataFrame(unionizes),
+                                              hemisphere_ids=[1],
+                                              structure_ids=[1,60,90])
+
+    assert obtained.loc[0, 'volume'] == 0.016032
 
 def test_get_structure_unionizes(mcc, unionizes):
 


### PR DESCRIPTION
`six.moves` for `reduce` in `filter_` methods of `core.mouse_connectivity_cache.MouseConnectivityCahce`

and for `xrange` in `core.structure_tree.StructrueTree`

Brief tests appended to current test methods for `filter_` methods