### PR TITLE
Tests and specimen query for biophysical api

### DIFF
--- a/allensdk/api/queries/biophysical_api.py
+++ b/allensdk/api/queries/biophysical_api.py
@@ -72,7 +72,28 @@ class BiophysicalApi(RmaTemplate):
 
     @cacheable()
     def get_neuronal_models(self, specimen_ids, num_rows='all', count=False, model_type_ids=None, **kwargs):
-        '''
+        '''Fetch all of the biophysically detailed model records associated with 
+        a particular specimen_id
+
+        Parameters
+        ----------
+        specimen_ids : list
+            One or more integer ids identifying specimen records.
+        num_rows : int, optional
+            how many records to retrieve. Default is 'all'.
+        count : bool, optional
+            If True, return a count of the lines found by the query. Default is False.
+        model_type_ids : list, optional
+            One or more integer ids identifying categories of neuronal model. Defaults 
+            to all-active and perisomatic biophysical_models.
+
+        Returns
+        -------
+        List of dict
+            Each element is a biophysical model record, containing a unique integer 
+            id, the id of the associated specimen, and the id of the model type to 
+            which this model belongs.
+  
         '''
 
         if model_type_ids is None:

--- a/allensdk/api/queries/biophysical_api.py
+++ b/allensdk/api/queries/biophysical_api.py
@@ -348,7 +348,7 @@ class BiophysicalApi(RmaTemplate):
             neuronal_model_id)
 
         if not well_known_file_id_dict or \
-           (not any(well_known_file_id_dict.values())):
+           (not any(list(well_known_file_id_dict.values()))):
             raise(Exception("No data found for neuronal model id %d" %
                             (neuronal_model_id)))
 
@@ -360,22 +360,22 @@ class BiophysicalApi(RmaTemplate):
         modfile_dir = os.path.join(working_directory, 'modfiles')
         Manifest.safe_mkdir(modfile_dir)
 
-        for key, id_dict in well_known_file_id_dict.items():
+        for key, id_dict in list(well_known_file_id_dict.items()):
             if (not self.cache_stimulus) and (key == 'stimulus'):
                 continue
 
-            for well_known_id, filename in id_dict.items():
+            for well_known_id, filename in list(id_dict.items()):
                 well_known_file_url = self.construct_well_known_file_download_url(
                     well_known_id)
                 cached_file_path = os.path.join(working_directory, filename)
                 self.retrieve_file_over_http(
                     well_known_file_url, cached_file_path)
 
-        fit_path = self.ids['fit'].values()[0]
-        stimulus_filename = self.ids['stimulus'].values()[0]
-        swc_morphology_path = self.ids['morphology'].values()[0]
+        fit_path = list(self.ids['fit'].values())[0]
+        stimulus_filename = list(self.ids['stimulus'].values())[0]
+        swc_morphology_path = list(self.ids['morphology'].values())[0]
         marker_path = \
-            self.ids['marker'].values()[0] if 'marker' in self.ids else ''
+            list(self.ids['marker'].values())[0] if 'marker' in self.ids else ''
         sweeps = sorted(self.sweeps)
 
         self.create_manifest(fit_path,
@@ -386,5 +386,5 @@ class BiophysicalApi(RmaTemplate):
                              sweeps)
 
         manifest_path = os.path.join(working_directory, 'manifest.json')
-        with open(manifest_path, 'wb') as f:
-            f.write(json.dumps(self.manifest, indent=2))
+        with open(manifest_path, 'w') as f:
+            json.dump(self.manifest, f, indent=2)

--- a/allensdk/api/queries/biophysical_api.py
+++ b/allensdk/api/queries/biophysical_api.py
@@ -360,11 +360,11 @@ class BiophysicalApi(RmaTemplate):
         modfile_dir = os.path.join(working_directory, 'modfiles')
         Manifest.safe_mkdir(modfile_dir)
 
-        for key, id_dict in list(well_known_file_id_dict.items()):
+        for key, id_dict in well_known_file_id_dict.items():
             if (not self.cache_stimulus) and (key == 'stimulus'):
                 continue
 
-            for well_known_id, filename in list(id_dict.items()):
+            for well_known_id, filename in id_dict.items():
                 well_known_file_url = self.construct_well_known_file_download_url(
                     well_known_id)
                 cached_file_path = os.path.join(working_directory, filename)

--- a/allensdk/test/api/response_test_data/472451419_response.json
+++ b/allensdk/test/api/response_test_data/472451419_response.json
@@ -1,0 +1,227 @@
+{
+  "total_rows": 9440, 
+  "success": true, 
+  "msg": [
+    {
+      "name": "Biophysical - perisomatic_Nr5a1-Cre;Ai14-177334.05.01.01", 
+      "specimen_id": 386049446, 
+      "specimen": {
+        "rna_integrity_number": null, 
+        "weight": 9000, 
+        "parent_y_coord": 0, 
+        "ephys_sweeps": [
+          {
+            "stimulus_interval": null, 
+            "stimulus_name": "Long Square", 
+            "num_spikes": 2, 
+            "id": 396429050, 
+            "pre_vm_mv": -85.3548278808594, 
+            "stimulus_duration": 0.999995, 
+            "stimulus_start_time": 1.02, 
+            "slow_noise_rms_mv": 0.0742162764072418, 
+            "peak_deflection": null, 
+            "stimulus_description": "C1LSFINEST150112[0]", 
+            "stimulus_units": "Amps", 
+            "specimen_id": 386049446, 
+            "sweep_number": 42, 
+            "vm_delta_mv": 0.374382019042969, 
+            "leak_pa": -3.0070378780365, 
+            "pre_noise_rms_mv": 0.0360921323299408, 
+            "post_noise_rms_mv": 0.0375288389623165, 
+            "bridge_balance_mohm": 18.0097675323486, 
+            "post_vm_mv": -85.7292098999023, 
+            "stimulus_absolute_amplitude": 110.000002162547, 
+            "slow_vm_mv": -85.3548278808594, 
+            "stimulus_relative_amplitude": 1.1
+          }
+        ], 
+        "parent_x_coord": 0, 
+        "ephys_result_id": 386049444, 
+        "is_cell_specimen": true, 
+        "id": 386049446, 
+        "neuron_reconstructions": [
+          {
+            "max_euclidean_distance": 346.003240593379, 
+            "number_tips": 22, 
+            "max_path_distance": 377.118073486042, 
+            "overall_depth": 70.56, 
+            "neuron_reconstruction_type": "dendrite-only", 
+            "number_bifurcations": 17, 
+            "total_volume": 403.245425875963, 
+            "scale_factor_z": 0.28, 
+            "scale_factor_y": 0.1144, 
+            "scale_factor_x": 0.1144, 
+            "number_nodes": 1947, 
+            "tags": "3D Neuron Reconstruction morphology", 
+            "average_parent_daughter_ratio": 0.882944233914226, 
+            "id": 491459171, 
+            "average_diameter": 0.439679792761665, 
+            "well_known_files": [
+              {
+                "well_known_file_type": {
+                  "id": 303941301, 
+                  "name": "3DNeuronReconstruction"
+                }, 
+                "attachable_type": "NeuronReconstruction", 
+                "download_link": "/api/v2/well_known_file_download/491459173", 
+                "well_known_file_type_id": 303941301, 
+                "path": "/external/mousecelltypes/prod256/specimen_386049446/Nr5a1-Cre_Ai14-177334.05.01.01_491459171_m.swc", 
+                "attachable_id": 491459171, 
+                "id": 491459173
+              }, 
+              {
+                "well_known_file_type": {
+                  "id": 486753749, 
+                  "name": "3DNeuronMarker"
+                }, 
+                "attachable_type": "NeuronReconstruction", 
+                "download_link": "/api/v2/well_known_file_download/496607103", 
+                "well_known_file_type_id": 486753749, 
+                "path": "/external/mousecelltypes/prod256/specimen_386049446/Nr5a1-Cre_Ai14-177334.05.01.01_491459171_marker_m.swc", 
+                "attachable_id": 491459171, 
+                "id": 496607103
+              }
+            ], 
+            "specimen_id": 386049446, 
+            "total_length": 2268.08172534129, 
+            "overall_width": 271.753540218214, 
+            "number_stems": 5, 
+            "average_bifurcation_angle_local": 70.6136901015225, 
+            "number_branches": 39, 
+            "average_fragmentation": 53.3823529411765, 
+            "average_contraction": 0.924610944456856, 
+            "average_bifurcation_angle_remote": null, 
+            "hausdorff_dimension": null, 
+            "total_surface": 3133.71153328341, 
+            "max_branch_order": 6.0, 
+            "soma_surface": 290.085763487108, 
+            "overall_height": 429.56158255954
+          }
+        ], 
+        "pinned_radius": null, 
+        "sphinx_id": 256671, 
+        "parent_id": 383680643, 
+        "is_ish": false, 
+        "cortex_layer_id": null, 
+        "ephys_result": {
+          "failed": false, 
+          "well_known_files": [
+            {
+              "well_known_file_type": {
+                "id": 488673261, 
+                "name": "EphysInstantaneousThresholdThumbnail"
+              }, 
+              "attachable_type": "EphysResult", 
+              "download_link": "/api/v2/well_known_file_download/491383263", 
+              "well_known_file_type_id": 488673261, 
+              "path": "/external/mousecelltypes/prod207/Ephys_Specimen_Roi_plan_386049444/ephys_inst_threshold.png", 
+              "attachable_id": 386049444, 
+              "id": 491383263
+            }, 
+            {
+              "well_known_file_type": {
+                "id": 480715721, 
+                "name": "MorphologyThumbnail"
+              }, 
+              "attachable_type": "EphysResult", 
+              "download_link": "/api/v2/well_known_file_download/487660477", 
+              "well_known_file_type_id": 480715721, 
+              "path": "/external/mousecelltypes/prod207/Ephys_Specimen_Roi_plan_386049444/morphology_summary.png", 
+              "attachable_id": 386049444, 
+              "id": 487660477
+            }, 
+            {
+              "well_known_file_type": {
+                "id": 481007198, 
+                "name": "NWBDownload"
+              }, 
+              "attachable_type": "EphysResult", 
+              "download_link": "/api/v2/well_known_file_download/491198851", 
+              "well_known_file_type_id": 481007198, 
+              "path": "/external/mousecelltypes/prod207/Ephys_Specimen_Roi_plan_386049444/386049444_ephys.nwb", 
+              "attachable_id": 386049444, 
+              "id": 491198851
+            }, 
+            {
+              "well_known_file_type": {
+                "id": 478840678, 
+                "name": "NWBUncompressed"
+              }, 
+              "attachable_type": "EphysResult", 
+              "download_link": "/api/v2/well_known_file_download/491198854", 
+              "well_known_file_type_id": 478840678, 
+              "path": "/external/mousecelltypes/prod207/Ephys_Specimen_Roi_plan_386049444/386049444_uncompressed.nwb", 
+              "attachable_id": 386049444, 
+              "id": 491198854
+            }, 
+            {
+              "well_known_file_type": {
+                "id": 480715749, 
+                "name": "EphysSummaryThumbnail"
+              }, 
+              "attachable_type": "EphysResult", 
+              "download_link": "/api/v2/well_known_file_download/487614229", 
+              "well_known_file_type_id": 480715749, 
+              "path": "/external/mousecelltypes/prod207/Ephys_Specimen_Roi_plan_386049444/ephys_summary.png", 
+              "attachable_id": 386049444, 
+              "id": 487614229
+            }
+          ], 
+          "id": 386049444, 
+          "sampling_rate": 200000
+        }, 
+        "failed_facet": 734881840, 
+        "treatment_id": 598634036, 
+        "tissue_ph": null, 
+        "hemisphere": "left", 
+        "cell_reporter_id": 491913822, 
+        "cell_prep_sample_id": null, 
+        "data": null, 
+        "structure_id": 721, 
+        "parent_z_coord": 1, 
+        "name": "Nr5a1-Cre;Ai14-177334.05.01.01", 
+        "specimen_id_path": "/339692365/383309938/383680643/386049446/", 
+        "donor_id": 339692362, 
+        "external_specimen_name": null
+      }, 
+      "neuronal_model_template": {
+        "well_known_files": [
+          {
+            "well_known_file_type": {
+              "id": 292178729, 
+              "name": "BiophysicalModelDescription"
+            }, 
+            "attachable_type": "Product", 
+            "download_link": "/api/v2/well_known_file_download/395337293", 
+            "well_known_file_type_id": 292178729, 
+            "path": "/external/mousecelltypes/prod210/project_in vitro Single Cell Characterization_T301/SK.mod", 
+            "attachable_id": 305094322, 
+            "id": 395337293
+          }
+        ], 
+        "description": "Biophysical Neuronal Model Template", 
+        "name": "Biophysical - perisomatic", 
+        "id": 329230710
+      }, 
+      "neuronal_model_template_id": 329230710, 
+      "well_known_files": [
+        {
+          "well_known_file_type": {
+            "id": 329230374, 
+            "name": "NeuronalModelParameters"
+          }, 
+          "attachable_type": "NeuronalModel", 
+          "download_link": "/api/v2/well_known_file_download/497235805", 
+          "well_known_file_type_id": 329230374, 
+          "path": "/external/mousecelltypes/prod297/neuronal_model_472451419/386049446_fit.json", 
+          "attachable_id": 472451419, 
+          "id": 497235805
+        }
+      ], 
+      "id": 472451419
+    }
+  ], 
+  "num_rows": 1, 
+  "start_row": 0, 
+  "id": 0
+}

--- a/allensdk/test/api/test_biophysical_api.py
+++ b/allensdk/test/api/test_biophysical_api.py
@@ -1,8 +1,20 @@
 import os
+import json
 
+import numpy as np
 import pytest
 from mock import MagicMock
 
+
+@pytest.fixture
+def neuronal_model_response():
+    dirname = os.path.dirname(__file__)
+    path = os.path.join(dirname, 'response_test_data', '472451419_response.json')
+
+    with open(path, 'r') as jf:
+        data = json.load(jf)
+
+    return data
 
 
 def make_biophys_api():
@@ -63,3 +75,14 @@ def test_get_neuronal_models(biophys_api):
         "q=model::NeuronalModel,rma::criteria,[neuronal_model_template_id$in491455321,32923071],"
         "[specimen_id$in386049446,469753383],rma::options[num_rows$eq'all'][count$eqfalse]")
 
+
+def test_read_json(biophys_api, neuronal_model_response):
+    
+    obt = biophys_api.read_json(neuronal_model_response)
+
+    assert(obt['stimulus']['491198851'] == "386049444.nwb")
+    assert(obt['morphology']['491459173'] == "Nr5a1-Cre_Ai14-177334.05.01.01_491459171_m.swc")
+    assert(obt['fit']['497235805'] == '386049446_fit.json')
+    assert(obt['marker']['496607103'] == 'Nr5a1-Cre_Ai14-177334.05.01.01_491459171_marker_m.swc')
+    assert(obt['modfiles']['395337293'] == 'modfiles/SK.mod')
+    assert(np.allclose(biophys_api.sweeps, [42]))

--- a/allensdk/test/api/test_biophysical_api.py
+++ b/allensdk/test/api/test_biophysical_api.py
@@ -15,6 +15,7 @@ def make_biophys_api():
 @pytest.fixture
 def biophys_api():
     bio = make_biophys_api()
+    bio.retrieve_file_over_http = MagicMock(name='retrieve_file_over_http')
     bio.json_msg_query = MagicMock(name='json_msg_query')
 
     return bio
@@ -44,8 +45,21 @@ def test_build_rma(model_id, fmt, biophys_api):
           'well_known_files(well_known_file_type)'
     exp = exp.format(fmt_exp, model_id)
 
-    print(exp)
-    print(obt)
-
-
     assert obt == exp
+
+
+def test_is_well_known_file_type(biophys_api):
+    wkf = {'well_known_file_type': {'name': 'fish'}}
+
+    assert(biophys_api.is_well_known_file_type(wkf, 'fish'))
+    assert(not biophys_api.is_well_known_file_type(wkf, 'fowl'))
+
+
+def test_get_neuronal_models(biophys_api):
+    mck = biophys_api.get_neuronal_models([386049446,469753383])
+
+    biophys_api.json_msg_query.assert_called_once_with(
+        "http://twarehouse-backup/api/v2/data/query.json?"
+        "q=model::NeuronalModel,rma::criteria,[neuronal_model_template_id$in491455321,32923071],"
+        "[specimen_id$in386049446,469753383],rma::options[num_rows$eq'all'][count$eqfalse]")
+

--- a/allensdk/test/api/test_biophysical_api.py
+++ b/allensdk/test/api/test_biophysical_api.py
@@ -1,0 +1,51 @@
+import os
+
+import pytest
+from mock import MagicMock
+
+
+
+def make_biophys_api():
+    from allensdk.api.queries.biophysical_api import BiophysicalApi
+
+    endpoint = os.environ['TEST_API_ENDPOINT'] if 'TEST_API_ENDPOINT' in os.environ else 'http://twarehouse-backup'
+    return BiophysicalApi(endpoint)
+
+
+@pytest.fixture
+def biophys_api():
+    bio = make_biophys_api()
+    bio.json_msg_query = MagicMock(name='json_msg_query')
+
+    return bio
+
+
+@pytest.mark.parametrize('model_id', [3])
+@pytest.mark.parametrize('fmt', [None, 'json', 'xml'])
+def test_build_rma(model_id, fmt, biophys_api):
+    
+    if fmt is None:
+        fmt_exp = 'json'
+        obt = biophys_api.build_rma(model_id)
+    else:
+        fmt_exp = fmt
+        obt = biophys_api.build_rma(model_id, fmt_exp)
+
+    exp = 'http://twarehouse-backup/api/v2/data/query.{}?'\
+          'q=model::NeuronalModel,'\
+          'rma::criteria,[id$eq{}],'\
+          'neuronal_model_template(well_known_files(well_known_file_type)),'\
+          'specimen(ephys_result(well_known_files(well_known_file_type)),'\
+          'neuron_reconstructions(well_known_files(well_known_file_type)),ephys_sweeps),'\
+          'well_known_files(well_known_file_type),'\
+          'rma::include,neuronal_model_template(well_known_files(well_known_file_type)),'\
+          'specimen(ephys_result(well_known_files(well_known_file_type)),'\
+          'neuron_reconstructions(well_known_files(well_known_file_type)),ephys_sweeps),'\
+          'well_known_files(well_known_file_type)'
+    exp = exp.format(fmt_exp, model_id)
+
+    print(exp)
+    print(obt)
+
+
+    assert obt == exp


### PR DESCRIPTION
Resolves #124 

Adds a method for fetching biphysical model records by specimen ids.
Adds tests and python3 compatibility fixes to the biophysical_api.