### PR TITLE
Fix custom tempdir fixtures

### DIFF
--- a/allensdk/test/api/test_cache.py
+++ b/allensdk/test/api/test_cache.py
@@ -48,8 +48,6 @@ import allensdk.core.json_utilities as ju
 from allensdk.config.manifest import ManifestVersionError
 from allensdk.config.manifest_builder import ManifestBuilder
 
-from allensdk.test_utilities.temp_dir import fn_temp_dir
-
 
 @pytest.fixture
 def cache():

--- a/allensdk/test/core/test_mouse_connectivity_cache.py
+++ b/allensdk/test/core/test_mouse_connectivity_cache.py
@@ -44,7 +44,6 @@ import pandas as pd
 
 from allensdk.core.mouse_connectivity_cache import MouseConnectivityCache
 from allensdk.core.structure_tree import StructureTree
-from allensdk.test_utilities.temp_dir import fn_temp_dir
 
 
 @pytest.fixture(scope='function')

--- a/allensdk/test/core/test_mouse_connectivity_notebook.py
+++ b/allensdk/test/core/test_mouse_connectivity_notebook.py
@@ -36,7 +36,7 @@
 import pytest
 
 import os
-from allensdk.test_utilities.temp_dir import fn_temp_dir
+
 
 @pytest.mark.skipif(os.getenv('TEST_COMPLETE') != 'true',
                     reason="partial testing")

--- a/allensdk/test/core/test_reference_space_cache.py
+++ b/allensdk/test/core/test_reference_space_cache.py
@@ -42,7 +42,6 @@ import nrrd
 import pandas as pd
 
 from allensdk.core.reference_space_cache import ReferenceSpaceCache
-from allensdk.test_utilities.temp_dir import fn_temp_dir
 from allensdk.core.structure_tree import StructureTree
 
 

--- a/allensdk/test/core/test_reference_space_notebook.py
+++ b/allensdk/test/core/test_reference_space_notebook.py
@@ -36,7 +36,7 @@
 import pytest
 
 import os
-from allensdk.test_utilities.temp_dir import fn_temp_dir
+
 
 @pytest.mark.skipif(os.getenv('TEST_COMPLETE') != 'true',
                     reason="partial testing")

--- a/allensdk/test/test_temp_dir.py
+++ b/allensdk/test/test_temp_dir.py
@@ -1,0 +1,39 @@
+import pytest
+import os
+import numpy as np
+from mock import patch, MagicMock
+from allensdk.test_utilities import temp_dir
+
+
+@pytest.fixture
+def mock_request():
+    return MagicMock()
+
+
+@pytest.mark.parametrize("ismount,base_path",[
+    (True, "/dev/shm"),
+    (False, os.path.dirname(temp_dir.__file__))
+])
+@patch("numpy.random.randint", side_effect=([1, 2, 3, 4, 5, 6],
+                                            [1, 2, 3, 4, 5, 7]))
+@patch("os.listdir", return_value=["allensdk_test_123456"])
+@patch("os.makedirs")
+def test_tmp_dir(os_makedirs, os_listdir, randint,
+                 mock_request, ismount, base_path):
+    with patch("os.path.exists", return_value=True):
+        with patch("os.path.ismount", return_value=ismount):
+            path = temp_dir.temp_dir(mock_request)
+    mock_request.addfinalizer.assert_called_once()
+    expected_path = os.path.join(base_path, "allensdk_test_123457")
+    os_makedirs.assert_called_once_with(expected_path)
+    assert path == expected_path
+    with patch("shutil.rmtree") as mock_rmtree:
+        with patch("os.path.exists", return_value=True):
+            with pytest.warns(UserWarning):
+                # run the finalizer
+                mock_request.addfinalizer.call_args[0][0]()
+        mock_rmtree.assert_called_once_with(expected_path)
+        mock_rmtree.reset_mock()
+        with patch("os.path.exists", return_value=False):
+            mock_request.addfinalizer.call_args[0][0]()
+        mock_rmtree.assert_called_once_with(expected_path)

--- a/allensdk/test/test_temp_dir.py
+++ b/allensdk/test/test_temp_dir.py
@@ -11,7 +11,7 @@ def mock_request():
 
 
 @pytest.mark.parametrize("ismount,base_path",[
-    (True, "/dev/shm"),
+    (True, os.path.normpath(os.path.join('/', 'dev', 'shm'))),
     (False, os.path.dirname(temp_dir.__file__))
 ])
 @patch("numpy.random.randint", side_effect=([1, 2, 3, 4, 5, 6],

--- a/allensdk/test_utilities/temp_dir.py
+++ b/allensdk/test_utilities/temp_dir.py
@@ -56,7 +56,7 @@ def temp_dir(request):
     fls = os.listdir(base_path)
     while True:
         dname = ''.join(map(str, np.random.randint(0, 10, 6)))
-        if dname not in fls:
+        if "allensdk_test_{}".format(dname) not in fls:
             break
 
     specific_path = os.path.join(base_path, 'allensdk_test_' + dname)

--- a/allensdk/test_utilities/temp_dir.py
+++ b/allensdk/test_utilities/temp_dir.py
@@ -72,6 +72,4 @@ def temp_dir(request):
     request.addfinalizer(fin)
     
     return specific_path
-    
-fn_temp_dir = pytest.fixture(scope='function')(temp_dir)
-md_temp_dir = pytest.fixture(scope='module')(temp_dir)
+

--- a/allensdk/test_utilities/temp_dir.py
+++ b/allensdk/test_utilities/temp_dir.py
@@ -35,41 +35,38 @@
 #
 import os
 import shutil
+import warnings
 
 import numpy as np
 
-import pytest
 
-
-# This is actually a pytest fixture! See below.
+# Intended as a fixture. Used in conftest.py.
 def temp_dir(request):
 
     tmpfs = os.path.normpath(os.path.join('/', 'dev', 'shm'))
     # would like to check mount type, but that requires system calls
     if os.path.exists(tmpfs) and os.path.ismount(tmpfs):
-    
+
         base_path = tmpfs
-    
+
     else:
-    
+
         base_path = os.path.dirname(__file__)
-        
-        
+
     fls = os.listdir(base_path)
     while True:
         dname = ''.join(map(str, np.random.randint(0, 10, 6)))
         if dname not in fls:
             break
-            
+
     specific_path = os.path.join(base_path, 'allensdk_test_' + dname)
     os.makedirs(specific_path)
-    
+
     def fin():
         shutil.rmtree(specific_path)
         if os.path.exists(specific_path):
             warnings.warn('test dir {0} still exists!', UserWarning)
-        
-    request.addfinalizer(fin)
-    
-    return specific_path
 
+    request.addfinalizer(fin)
+
+    return specific_path

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,7 @@
 import matplotlib
 matplotlib.use('agg')
-import pytest
-from allensdk.test_utilities.temp_dir import temp_dir
+import pytest  # noqa: E402
+from allensdk.test_utilities.temp_dir import temp_dir  # noqa: 402
 
 
 @pytest.fixture(scope="function")

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,7 @@
 import matplotlib
 matplotlib.use('agg')
 import pytest  # noqa: E402
-from allensdk.test_utilities.temp_dir import temp_dir  # noqa: 402
+from allensdk.test_utilities.temp_dir import temp_dir  # noqa: E402
 
 
 @pytest.fixture(scope="function")

--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,14 @@
 import matplotlib
 matplotlib.use('agg')
+import pytest
+from allensdk.test_utilities.temp_dir import temp_dir
+
+
+@pytest.fixture(scope="function")
+def fn_temp_dir(request):
+    return temp_dir(request)
+
+
+@pytest.fixture(scope="module")
+def md_temp_dir(request):
+    return temp_dir(request)


### PR DESCRIPTION
The custom tmpdir fixtures created in allensdk/test_utilities/temp_dir.py Don't function at the correct scope. This seems to be due to pytest caching their results on import. It isn't a problem on internal builds because all tests are run --boxed which makes the functions appear to work correctly. When not --boxed, fn_temp_dir is returning the same directory for every function in the module. Putting the fixture declaration in conftest.py fixes this.

Simple code displaying the problem prior to this PR (py.test test_example.py without --boxed):
test_example.py:

    import pytest
    from allensdk.test_utilities.temp_dir import fn_temp_dir

    def test_1(fn_temp_dir):
        print(fn_temp_dir)
        raise Exception()

    def test_2(fn_temp_dir):
        print(fn_temp_dir)
        raise Exception()

Both tests will have a matching path printed to stdout on the failure report every time it is run (path will change between runs but always matches between functions).