### PR TITLE
get_mask in stimulus_info is now saved for repeated calls

### DIFF
--- a/allensdk/brain_observatory/stimulus_info.py
+++ b/allensdk/brain_observatory/stimulus_info.py
@@ -431,7 +431,13 @@ class Monitor(object):
         self._panel_size = panel_size
         self.n_pixels_r = n_pixels_r
         self.n_pixels_c = n_pixels_c
-        self.mask = None
+        self._mask = None
+
+    @property
+    def mask(self):
+        if self._mask is None:
+            self._mask = self.get_mask()
+        return self._mask
 
     @property
     def panel_size(self):
@@ -550,9 +556,6 @@ class Monitor(object):
         number_of_cycles = spatial_frequency*2*np.degrees(np.arctan(self.width/2./distance_from_monitor))
 
         # How many pixels to I have pre-warp to place my cycles on:
-        if self.mask is None:
-            self.mask = self.get_mask()
-
         _, m_col = np.where(self.mask != 0)
         number_of_pixels = (m_col.max() - m_col.min())
 

--- a/allensdk/brain_observatory/stimulus_info.py
+++ b/allensdk/brain_observatory/stimulus_info.py
@@ -431,6 +431,7 @@ class Monitor(object):
         self._panel_size = panel_size
         self.n_pixels_r = n_pixels_r
         self.n_pixels_c = n_pixels_c
+        self.mask = None
 
     @property
     def panel_size(self):
@@ -549,8 +550,10 @@ class Monitor(object):
         number_of_cycles = spatial_frequency*2*np.degrees(np.arctan(self.width/2./distance_from_monitor))
 
         # How many pixels to I have pre-warp to place my cycles on:
-        mask = self.get_mask()
-        _, m_col = np.where(mask != 0)
+        if self.mask is None:
+            self.mask = self.get_mask()
+
+        _, m_col = np.where(self.mask != 0)
         number_of_pixels = (m_col.max() - m_col.min())
 
         return float(number_of_pixels)/number_of_cycles
@@ -704,7 +707,7 @@ class BrainObservatoryMonitor(Monitor):
         return super(BrainObservatoryMonitor, self).pixels_to_visual_degrees(n, self.experiment_geometry.distance, **kwargs)
 
     def visual_degrees_to_pixels(self, vd, **kwargs):
-    
+
         return super(BrainObservatoryMonitor, self).visual_degrees_to_pixels(vd, self.experiment_geometry.distance, **kwargs)
 
 def warp_stimulus_coords(vertices,

--- a/allensdk/test/brain_observatory/test_stimulus_info.py
+++ b/allensdk/test/brain_observatory/test_stimulus_info.py
@@ -305,6 +305,17 @@ def test_get_mask():
     assert mask.sum() == 931286
     assert mask.shape == si.MONITOR_DIMENSIONS
 
+
+def test_mask():
+    m = si.BrainObservatoryMonitor()
+
+    assert(m._mask is None)
+
+    assert(m.mask.sum() == 931286)
+    assert(m.mask.shape == si.MONITOR_DIMENSIONS)
+    assert(m._mask is not None)
+
+
 def test_translate_image_and_fill():
     '''
     [[1 2 3]


### PR DESCRIPTION
I modified the stimulus_info code so that the mask returned by get_mask is saved after the first call and not recomputed on subsequent calls.