### PR TITLE
spike detection, passing args to subfunction

### DIFF
--- a/allensdk/ephys/ephys_extractor.py
+++ b/allensdk/ephys/ephys_extractor.py
@@ -111,7 +111,7 @@ class EphysSweepFeatureExtractor:
         peaks = ft.find_peak_indexes(v, t, putative_spikes, self.end)
         putative_spikes, peaks = ft.filter_putative_spikes(v, t, putative_spikes, peaks,
                                                            self.min_height, self.min_peak, 
-                                                           filter=self.filter)
+                                                           dvdt=dvdt, filter=self.filter)
 
         if not putative_spikes.size:
             # Save time if no spikes detected

--- a/allensdk/ephys/ephys_extractor.py
+++ b/allensdk/ephys/ephys_extractor.py
@@ -110,7 +110,8 @@ class EphysSweepFeatureExtractor:
                                                     self.filter, self.dv_cutoff)
         peaks = ft.find_peak_indexes(v, t, putative_spikes, self.end)
         putative_spikes, peaks = ft.filter_putative_spikes(v, t, putative_spikes, peaks,
-                                                           self.min_height, self.min_peak)
+                                                           self.min_height, self.min_peak, 
+                                                           filter=self.filter)
 
         if not putative_spikes.size:
             # Save time if no spikes detected

--- a/allensdk/ephys/ephys_features.py
+++ b/allensdk/ephys/ephys_features.py
@@ -1136,7 +1136,7 @@ def estimate_adjusted_detection_parameters(v_set, t_set, interval_start, interva
     for v, t, dv in zip(v_set, t_set, dv_set):
         putative_spikes = detect_putative_spikes(v, t, dv_cutoff=new_dv_cutoff, filter=filter)
         peaks = find_peak_indexes(v, t, putative_spikes)
-        putative_spikes, peaks = filter_putative_spikes(v, t, putative_spikes, peaks)
+        putative_spikes, peaks = filter_putative_spikes(v, t, putative_spikes, peaks, dvdt=dv, filter=filter)
         upstrokes = find_upstroke_indexes(v, t, putative_spikes, peaks, dvdt=dv)
         if upstrokes.size:
             all_upstrokes = np.append(all_upstrokes, dv[upstrokes])


### PR DESCRIPTION
The pre-calculated dvdt and filter parameters aren't being passed to a function that accepts them as keyword args.   This was fine when everyone was using defaults for everything, but not in the GLIF pipeline, where filtering is done beforehand.