### PR TITLE
debugged a missing leq in get_stimulus/BinarySerachTree with the-moliver

### DIFF
--- a/allensdk/brain_observatory/stimulus_info.py
+++ b/allensdk/brain_observatory/stimulus_info.py
@@ -193,7 +193,7 @@ class BinaryIntervalSearchTree(object):
 
         # Check that the intervals are non-overlapping (except potentially at the end point)
         for x, y in zip(search_list[:-1], search_list[1:]):
-            assert x[1] < y[0]
+            assert x[1] <= y[0]
 
 
         self.data = {}

--- a/allensdk/test/brain_observatory/test_stimulus_info.py
+++ b/allensdk/test/brain_observatory/test_stimulus_info.py
@@ -31,6 +31,13 @@ def test_BinaryIntervalSearchTree():
     assert bist.search(2.5)[2] == 'C'
     assert bist.search(3.5)[2] == 'D'
 
+def test_BinaryIntervalSearchTree_shared_endpoint():
+    
+    bist = si.BinaryIntervalSearchTree([(0, 1, 'A'), (1, 2, 'B')])
+    assert bist.search(0)[2] == 'A'
+    assert bist.search(1)[2] == 'A'
+    assert bist.search(1.5)[2] == 'B'
+
 def test_pixels_to_visual_degrees():
     m = si.BrainObservatoryMonitor()
     np.testing.assert_almost_equal(m.pixels_to_visual_degrees(1), 0.103270443661,10)


### PR DESCRIPTION
Resolves #142 

Note that the addition of the less-than-equal is consistent with the existing documentation:

>  If two intervals share an endpoint, the left-side wins the tie.

New test examines the case where the intervals meet, and tests for left-side-wins condition.  Before PR, this test (test_BinaryIntervalSearchTree_shared_endpoint) fails; after, this test succeeds