### PR TITLE
py3 incompatibility in session analysis

### DIFF
--- a/allensdk/brain_observatory/stimulus_analysis.py
+++ b/allensdk/brain_observatory/stimulus_analysis.py
@@ -519,9 +519,11 @@ class StimulusAnalysis(object):
 
         StimulusAnalysis._log.info('Calculating responses for each sweep')
         sweep_response = pd.DataFrame(index=self.stim_table.index.values, 
-                                      columns=map(str, range(self.numbercells + 1)))
+                                      columns=list(map(str, range(self.numbercells + 1))))
+
         sweep_response.rename(
             columns={str(self.numbercells): 'dx'}, inplace=True)
+
         for index, row in self.stim_table.iterrows():
             start = int(row['start'] - self.interlength)
             end = int(row['start'] + self.sweeplength + self.interlength)


### PR DESCRIPTION
looks like pandas stopped accepting generators as column inputs to the `DataFrame` constructor recently.