### PR TITLE
test-generated cached files moved to tmpdir_factory dir

### DIFF
--- a/allensdk/test/brain_observatory/test_notebook.py
+++ b/allensdk/test/brain_observatory/test_notebook.py
@@ -47,9 +47,10 @@ import os
 
 
 @pytest.fixture
-def boc():
+def boc(tmpdir_factory):
+    manifest_file = tmpdir_factory.mktemp('data').join(os.path.join('boc','manifest.json'))
     endpoint = os.environ['TEST_API_ENDPOINT'] if 'TEST_API_ENDPOINT' in os.environ else 'http://twarehouse-backup'
-    return BrainObservatoryCache(manifest_file='boc/manifest.json', base_uri=endpoint)
+    return BrainObservatoryCache(manifest_file=manifest_file, base_uri=endpoint)
 
 @pytest.mark.skipif(os.getenv('TEST_COMPLETE') != 'true',
                     reason="partial testing")

--- a/allensdk/test/brain_observatory/test_notebook.py
+++ b/allensdk/test/brain_observatory/test_notebook.py
@@ -50,7 +50,7 @@ import os
 def boc(tmpdir_factory):
     manifest_file = tmpdir_factory.mktemp('data').join(os.path.join('boc','manifest.json'))
     endpoint = os.environ['TEST_API_ENDPOINT'] if 'TEST_API_ENDPOINT' in os.environ else 'http://twarehouse-backup'
-    return BrainObservatoryCache(manifest_file=manifest_file, base_uri=endpoint)
+    return BrainObservatoryCache(manifest_file=str(manifest_file), base_uri=endpoint)
 
 @pytest.mark.skipif(os.getenv('TEST_COMPLETE') != 'true',
                     reason="partial testing")

--- a/allensdk/test/core/test_brain_observatory_cache.py
+++ b/allensdk/test/core/test_brain_observatory_cache.py
@@ -107,7 +107,7 @@ def brain_observatory_cache(md_temp_dir):
                    mock_open(read_data=manifest_data)):
             # Download a list of all targeted areas
             manifest_file = os.path.join(md_temp_dir, "boc", "manifest.json")
-            boc = BrainObservatoryCache(manifest_file=manifest_file,
+            boc = BrainObservatoryCache(manifest_file=str(manifest_file),
                                         base_uri='http://api.brain-map.org')
 
     return boc

--- a/allensdk/test/core/test_mouse_connectivity_notebook.py
+++ b/allensdk/test/core/test_mouse_connectivity_notebook.py
@@ -40,7 +40,7 @@ import os
 
 @pytest.mark.skipif(os.getenv('TEST_COMPLETE') != 'true',
                     reason="partial testing")
-def test_notebook(fn_temp_dir):
+def test_notebook(tmpdir_factory):
 
     # coding: utf-8
 
@@ -60,7 +60,8 @@ def test_notebook(fn_temp_dir):
     # the data that has already been downloaded onto the hard drives.
     # If you supply a relative path, it is assumed to be relative to your
     # current working directory.
-    mcc = MouseConnectivityCache(manifest_file='connectivity/mouse_connectivity_manifest.json')
+    manifest_file = tmpdir_factory.mktemp('mcc').join('manifest.json')
+    mcc = MouseConnectivityCache(manifest_file=str(manifest_file))
 
     # open up a list of all of the experiments
     all_experiments = mcc.get_experiments(dataframe=True)


### PR DESCRIPTION
These tests were generating files in the CWD, which is not nice for our dockerized test environment.