### PR TITLE
allows defining the brain observatory cache manifest in env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,7 @@ Saskia de Vries @saskiad
 Derric Williams @derricw
 
 Jed Perkins @jfperkins
- 
+
 Joe Knox @jknox13
+
+Justin Kiggins @neuromusic

--- a/allensdk/api/cache.py
+++ b/allensdk/api/cache.py
@@ -68,7 +68,7 @@ class Cache(object):
     def __init__(self,
                  manifest=None,
                  cache=True,
-                 version=None, 
+                 version=None,
                  **kwargs):
         self.cache = cache
         self.load_manifest(manifest, version)
@@ -119,8 +119,8 @@ class Cache(object):
 
             try:
                 self.manifest = Manifest(
-                    ju.read(file_name)['manifest'], 
-                    os.path.dirname(file_name), 
+                    ju.read(file_name)['manifest'],
+                    os.path.dirname(file_name),
                     version=version)
             except ManifestVersionError as e:
                 if e.outdated is True:
@@ -152,14 +152,14 @@ class Cache(object):
 
         manifest_builder = ManifestBuilder()
         manifest_builder.set_version(self.MANIFEST_VERSION)
-        
+
         manifest_builder = self.add_manifest_paths(manifest_builder)
 
         manifest_builder.write_json_file(file_name)
 
 
     def add_manifest_paths(self, manifest_builder):
-        '''Add cache-class specific paths to the manifest. In derived classes, 
+        '''Add cache-class specific paths to the manifest. In derived classes,
         should call super.
         '''
         manifest_builder.add_path('BASEDIR', '.')
@@ -186,7 +186,7 @@ class Cache(object):
         '''
         if keys is None:
             keys = []
-        
+
         for key in keys:
             del data[key]
 
@@ -276,7 +276,7 @@ class Cache(object):
                *args,
                **kwargs):
         '''make an rma query, save it and return the dataframe.
-    
+
         Parameters
         ----------
         fn : function reference
@@ -357,10 +357,10 @@ class Cache(object):
     @staticmethod
     def csv_writer(pth, gen):
         csv_writer = None
-    
+
         first_row = True
         row_count = 1
-    
+
         with open(pth, 'w') as output:
             for row in gen:
                 if first_row:
@@ -427,7 +427,7 @@ class Cache(object):
                    path_keyword=None):
         '''helper method to find path argument in legacy methods written
         prior to the @cacheable decorator.  Do not use for new @cacheable methods.
-        
+
         Parameters
         ----------
         file_name_position : integer
@@ -436,7 +436,7 @@ class Cache(object):
             zero indexed position in the decorated method args where tha file path may be found.
         path_keyword : string
             kwarg that may have the file path.
-        
+
         Notes
         -----
         This method is only intended to provide backward-compatibility for some
@@ -453,7 +453,7 @@ class Cache(object):
                     file_name = args[file_name_position]
 
                 if (file_name is None and
-                    secondary_file_name_position and 
+                    secondary_file_name_position and
                     secondary_file_name_position < len(args)):
                     file_name = args[secondary_file_name_position]
 
@@ -468,7 +468,7 @@ class Cache(object):
              rename=None,
              **kwargs):
         '''make an rma query, save it and return the dataframe.
-    
+
         Parameters
         ----------
         fn : function reference
@@ -487,12 +487,12 @@ class Cache(object):
             (new, old) columns to rename
         kwargs : objects
             passed through to the query function
-    
+
         Returns
         -------
         dict or DataFrame
             data type depends on return_dataframe option.
-    
+
         Notes
         -----
         Column renaming happens after the file is reloaded for json
@@ -525,7 +525,7 @@ class Cache(object):
         else:
             raise ValueError(
                 'save_as_json=False cannot be used with return_dataframe=False')
-    
+
         return data
 
 
@@ -586,7 +586,7 @@ def cacheable(strategy=None,
 
             if pathfinder and not 'path' in kwargs:
                 found_path = pathfinder(*args, **kwargs)
-                
+
                 if found_path:
                     kwargs['path'] = found_path
             if decor.strategy and not 'strategy' in kwargs:
@@ -604,6 +604,13 @@ def cacheable(strategy=None,
                                   *args,
                                   **kwargs)
             return result
-        
+
         return w
     return decor
+
+
+def get_default_manifest_file(cache_name):
+    return os.environ(
+        '{}_MANIFEST'.format(cache_name.upper()),
+        '{}/manifest.json'.format(cache_name.lower())
+    )

--- a/allensdk/core/cell_types_cache.py
+++ b/allensdk/core/cell_types_cache.py
@@ -37,7 +37,7 @@ import os
 from six import string_types
 
 from allensdk.config.manifest_builder import ManifestBuilder
-from allensdk.api.cache import Cache
+from allensdk.api.cache import Cache, get_default_manifest_file
 from allensdk.api.queries.cell_types_api import CellTypesApi
 
 from . import json_utilities as json_utilities
@@ -85,7 +85,11 @@ class CellTypesCache(Cache):
     MARKER_KEY = 'MARKER'
     MANIFEST_VERSION = "1.1"
 
-    def __init__(self, cache=True, manifest_file='cell_types_manifest.json', base_uri=None):
+    def __init__(self, cache=True, manifest_file=None, base_uri=None):
+
+        if manifest_file is None:
+            manifest_file = get_default_manifest_file('cell_types')
+
         super(CellTypesCache, self).__init__(
             manifest=manifest_file, cache=cache, version=self.MANIFEST_VERSION)
         self.api = CellTypesApi(base_uri=base_uri)
@@ -127,7 +131,7 @@ class CellTypesCache(Cache):
         cells = self.api.list_cells_api(path=file_name,
                                         strategy='lazy',
                                         **Cache.cache_json())
-        
+
         if isinstance(reporter_status, string_types):
             reporter_status = [reporter_status]
 
@@ -138,12 +142,12 @@ class CellTypesCache(Cache):
                                           reporter_status,
                                           species,
                                           simple)
-    
-                
+
+
         return cells
-                
-       
-        
+
+
+
 
     def get_ephys_sweeps(self, specimen_id, file_name=None):
         """
@@ -159,9 +163,9 @@ class CellTypesCache(Cache):
         file_name = self.get_cache_path(
             file_name, self.EPHYS_SWEEPS_KEY, specimen_id)
 
-        sweeps = self.api.get_ephys_sweeps(specimen_id, 
-                                           strategy='lazy', 
-                                           path=file_name, 
+        sweeps = self.api.get_ephys_sweeps(specimen_id,
+                                           strategy='lazy',
+                                           path=file_name,
                                            **Cache.cache_json())
 
         return sweeps
@@ -253,7 +257,7 @@ class CellTypesCache(Cache):
             Only return ephys and morphology features for cells that have
             reconstructions. Default True.
         """
-        
+
         ephys_features = pd.DataFrame(self.get_ephys_features())
         morphology_features = pd.DataFrame(self.get_morphology_features())
 

--- a/allensdk/core/mouse_connectivity_cache.py
+++ b/allensdk/core/mouse_connectivity_cache.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 from allensdk.config.manifest_builder import ManifestBuilder
-from allensdk.api.cache import Cache
+from allensdk.api.cache import Cache, get_default_manifest_file
 from allensdk.api.queries.mouse_connectivity_api import MouseConnectivityApi
 from allensdk.deprecated import deprecated
 
@@ -79,9 +79,9 @@ class MouseConnectivityCache(ReferenceSpaceCache):
         50, 100).  Default is 25.
 
     ccf_version: string
-        Desired version of the Common Coordinate Framework.  This affects the annotation 
-        volume (get_annotation_volume) and structure masks (get_structure_mask). 
-        Must be one of (MouseConnectivityApi.CCF_2015, MouseConnectivityApi.CCF_2016). 
+        Desired version of the Common Coordinate Framework.  This affects the annotation
+        volume (get_annotation_volume) and structure masks (get_structure_mask).
+        Must be one of (MouseConnectivityApi.CCF_2015, MouseConnectivityApi.CCF_2016).
         Default: MouseConnectivityApi.CCF_2016
 
     cache: boolean
@@ -120,10 +120,13 @@ class MouseConnectivityCache(ReferenceSpaceCache):
     def __init__(self,
                  resolution=None,
                  cache=True,
-                 manifest_file='mouse_connectivity_manifest.json',
+                 manifest_file=None,
                  ccf_version=None,
-                 base_uri=None, 
+                 base_uri=None,
                  version=None):
+
+        if manifest_file is None:
+            manifest_file = get_default_manifest_file('mouse_connectivity')
 
         if version is None:
             version = self.MANIFEST_VERSION
@@ -133,9 +136,9 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
         if ccf_version is None:
             ccf_version = MouseConnectivityApi.CCF_VERSION_DEFAULT
-        
+
         super(MouseConnectivityCache, self).__init__(
-            resolution, reference_space_key=ccf_version, cache=cache, 
+            resolution, reference_space_key=ccf_version, cache=cache,
             manifest=manifest_file, version=version)
 
         self.api = MouseConnectivityApi(base_uri=base_uri)
@@ -160,12 +163,12 @@ class MouseConnectivityCache(ReferenceSpaceCache):
             file_name will be pulled out of the manifest.  Default is None.
 
         """
-        
+
         file_name = self.get_cache_path(file_name,
                                         self.PROJECTION_DENSITY_KEY,
                                         experiment_id,
                                         self.resolution)
-                                        
+
         self.api.download_projection_density(
             file_name, experiment_id, self.resolution, strategy='lazy')
 
@@ -191,7 +194,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
             file_name will be pulled out of the manifest.  Default is None.
 
         """
-        
+
         file_name = self.get_cache_path(file_name,
                                         self.INJECTION_DENSITY_KEY,
                                         experiment_id,
@@ -298,7 +301,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
             # renaming id
             e['id'] = e['data_set_id']
             del e['data_set_id']
-            
+
             # simplify trangsenic line
             tl = e.get('transgenic_line', None)
             if tl:
@@ -353,15 +356,15 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
             descendant_ids = reduce(op.add, self.get_structure_tree()\
                                     .descendant_ids(injection_structure_ids))
-            experiments = [e for e in experiments 
+            experiments = [e for e in experiments
                            if e['structure_id'] in descendant_ids]
 
         return experiments
 
-    def get_experiment_structure_unionizes(self, experiment_id, 
-                                           file_name=None, 
+    def get_experiment_structure_unionizes(self, experiment_id,
+                                           file_name=None,
                                            is_injection=None,
-                                           structure_ids=None, 
+                                           structure_ids=None,
                                            include_descendants=False,
                                            hemisphere_ids=None):
         """
@@ -398,20 +401,20 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
         """
 
-        file_name = self.get_cache_path(file_name, 
-                                        self.STRUCTURE_UNIONIZES_KEY, 
+        file_name = self.get_cache_path(file_name,
+                                        self.STRUCTURE_UNIONIZES_KEY,
                                         experiment_id)
-                   
-        filter_fn = functools.partial(self.filter_structure_unionizes, 
-                                      is_injection=is_injection, 
-                                      structure_ids=structure_ids, 
-                                      include_descendants=include_descendants, 
+
+        filter_fn = functools.partial(self.filter_structure_unionizes,
+                                      is_injection=is_injection,
+                                      structure_ids=structure_ids,
+                                      include_descendants=include_descendants,
                                       hemisphere_ids=hemisphere_ids)
-                                      
+
         col_rn = lambda x: pd.DataFrame(x).rename(columns={
             'section_data_set_id': 'experiment_id'})
-                                      
-        return self.api.get_structure_unionizes([experiment_id], 
+
+        return self.api.get_structure_unionizes([experiment_id],
                                                 path=file_name,
                                                 strategy='lazy',
                                                 pre=col_rn,
@@ -419,7 +422,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
                                                 writer=lambda p, x : pd.DataFrame(x).to_csv(p),
                                                 reader=pd.DataFrame.from_csv)
 
-    def rank_structures(self, experiment_ids, is_injection, structure_ids=None, hemisphere_ids=None, 
+    def rank_structures(self, experiment_ids, is_injection, structure_ids=None, hemisphere_ids=None,
                         rank_on='normalized_projection_volume', n=5, threshold=10**-2):
         '''Produces one or more (per experiment) ranked lists of brain structures, using a specified data field.
 
@@ -430,11 +433,11 @@ class MouseConnectivityCache(ReferenceSpaceCache):
         is_injection : boolean
             Use data from only injection (or non-injection) unionizes.
         structure_ids : list of int, optional
-            Consider only these structures. It is a good idea to make sure that these structures are not spatially 
-            overlapping; otherwise your results will contain redundant information. Defaults to the summary 
+            Consider only these structures. It is a good idea to make sure that these structures are not spatially
+            overlapping; otherwise your results will contain redundant information. Defaults to the summary
             structures - a brain-wide list of nonoverlapping mid-level structures.
         hemisphere_ids : list of int, optional
-            Consider only these hemispheres (1: left, 2: right, 3: both). Like with structures, 
+            Consider only these hemispheres (1: left, 2: right, 3: both). Like with structures,
             you might get redundant results if you select overlapping options. Defaults to [1, 2].
         rank_on : str, optional
             Rank unionize data using this field (descending). Defaults to normalized_projection_volume.
@@ -445,9 +448,9 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
         Returns
         -------
-        list : 
+        list :
             Each element (1 for each input experiment) is a list of dictionaries. The dictionaries describe the top
-            injection structures in descending order. They are specified by their structure and hemisphere id fields and 
+            injection structures in descending order. They are specified by their structure and hemisphere id fields and
             additionally report the value specified by the rank_on parameter.
 
         '''
@@ -460,12 +463,12 @@ class MouseConnectivityCache(ReferenceSpaceCache):
         if structure_ids is None:
             structure_ids = self.default_structure_ids
 
-        unionizes = self.get_structure_unionizes(experiment_ids, 
-                                                 is_injection=is_injection, 
-                                                 structure_ids=structure_ids, 
-                                                 hemisphere_ids=hemisphere_ids, 
+        unionizes = self.get_structure_unionizes(experiment_ids,
+                                                 is_injection=is_injection,
+                                                 structure_ids=structure_ids,
+                                                 hemisphere_ids=hemisphere_ids,
                                                  include_descendants=False)
-        unionizes = unionizes[unionizes[rank_on] > threshold] 
+        unionizes = unionizes[unionizes[rank_on] > threshold]
 
         results = []
         for eid in experiment_ids:
@@ -473,7 +476,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
             this_experiment_unionizes = unionizes[unionizes['experiment_id'] == eid]
             this_experiment_unionizes = this_experiment_unionizes.sort_values(by=rank_on, ascending=False)
             this_experiment_unionizes = this_experiment_unionizes.select(filter_fields, axis=1)
-            
+
             records = this_experiment_unionizes.to_dict('record')
             if len(records) > n:
                 records = records[:n]
@@ -481,9 +484,9 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
         return results
 
-    def filter_structure_unionizes(self, unionizes, 
-                                   is_injection=None, 
-                                   structure_ids=None, 
+    def filter_structure_unionizes(self, unionizes,
+                                   is_injection=None,
+                                   structure_ids=None,
                                    include_descendants=False,
                                    hemisphere_ids=None):
         """
@@ -530,9 +533,9 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
         return unionizes
 
-    def get_structure_unionizes(self, experiment_ids, 
-                                is_injection=None, 
-                                structure_ids=None, 
+    def get_structure_unionizes(self, experiment_ids,
+                                is_injection=None,
+                                structure_ids=None,
                                 include_descendants=False,
                                 hemisphere_ids=None):
         """
@@ -571,10 +574,10 @@ class MouseConnectivityCache(ReferenceSpaceCache):
 
         return pd.concat(unionizes, ignore_index=True)
 
-    def get_projection_matrix(self, experiment_ids, 
+    def get_projection_matrix(self, experiment_ids,
                               projection_structure_ids=None,
-                              hemisphere_ids=None, 
-                              parameter='projection_volume', 
+                              hemisphere_ids=None,
+                              parameter='projection_volume',
                               dataframe=False):
 
         if projection_structure_ids is None:
@@ -604,7 +607,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
         cidx = 0
         hlabel = {1: '-L', 2: '-R', 3: ''}
 
-        acronym_map = self.get_structure_tree().value_map(lambda x: x['id'], 
+        acronym_map = self.get_structure_tree().value_map(lambda x: x['id'],
                                                           lambda x: x['acronym'])
 
         for hid in hemisphere_ids:
@@ -632,7 +635,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
             return {'matrix': matrix, 'rows': rows_df, 'columns': cols_df}
         else:
             return {'matrix': matrix, 'rows': experiment_ids, 'columns': columns}
-    
+
 
     def add_manifest_paths(self, manifest_builder):
         """

--- a/allensdk/test/api/test_cache.py
+++ b/allensdk/test/api/test_cache.py
@@ -42,7 +42,7 @@ import numpy as np
 import pytest
 from mock import MagicMock, mock_open, patch
 
-from allensdk.api.cache import Cache, memoize
+from allensdk.api.cache import Cache, memoize, get_default_manifest_file
 from allensdk.api.queries.rma_api import RmaApi
 import allensdk.core.json_utilities as ju
 from allensdk.config.manifest import ManifestVersionError
@@ -84,10 +84,10 @@ vn 0.0753706 0.16324 -0.983703
 
 I should be a comment, but am not
 
-f 1//1 2//2 3//3 
-f 4//4 1//1 3//3 
-f 3//3 2//2 5//5 
-f 6//6 3//3 5//5 
+f 1//1 2//2 3//3
+f 4//4 1//1 3//3
+f 3//3 2//2 5//5
+f 6//6 3//3 5//5
 
     '''
 
@@ -95,9 +95,9 @@ f 6//6 3//3 5//5
 @pytest.fixture
 def dummy_cache():
     class DummyCache(Cache):
-        
+
         VERSION = None
-    
+
         def build_manifest(self, file_name):
             manifest_builder = ManifestBuilder()
             manifest_builder.set_version(DummyCache.VERSION)
@@ -110,9 +110,9 @@ def test_version_update(fn_temp_dir, dummy_cache):
 
     mpath = os.path.join(fn_temp_dir, 'manifest.json')
     dc = dummy_cache(manifest=mpath)
-    
+
     same_dc = dummy_cache(manifest=mpath)
-    
+
     with pytest.raises(ManifestVersionError):
         new_dc = dummy_cache(manifest=mpath, version=1.0)
 
@@ -187,3 +187,9 @@ def test_memoize():
         for ii in range(2):
             t0 = time.time()
             fb.f(0), time.time() - t0
+
+
+def test_get_default_manifest_file():
+    assert get_default_manifest_file('brain_observatory') == 'brain_observatory/manifest.json'
+    assert get_default_manifest_file('cell_types') == 'cell_type/manifest.json'
+    assert get_default_manifest_file('mouse_connectivity') == 'mouse_connectivity/manifest.json'

--- a/doc_template/examples_root/examples/nb/brain_observatory.ipynb
+++ b/doc_template/examples_root/examples/nb/brain_observatory.ipynb
@@ -41,7 +41,7 @@
     "# All downloaded files will be stored relative to the directory holding the manifest\n",
     "# file.  If 'manifest_file' is a relative path (as it is below), it will be \n",
     "# saved relative to your working directory.  It can also be an absolute path.\n",
-    "boc = BrainObservatoryCache(manifest_file='boc/manifest.json')\n",
+    "boc = BrainObservatoryCache()\n",
     "\n",
     "# Download a list of all targeted areas\n",
     "targeted_structures = boc.get_all_targeted_structures()\n",

--- a/doc_template/examples_root/examples/nb/brain_observatory_analysis.ipynb
+++ b/doc_template/examples_root/examples/nb/brain_observatory_analysis.ipynb
@@ -17,7 +17,7 @@
    "outputs": [],
    "source": [
     "from allensdk.core.brain_observatory_cache import BrainObservatoryCache\n",
-    "boc =  BrainObservatoryCache(manifest_file='boc/manifest.json')"
+    "boc =  BrainObservatoryCache()"
    ]
   },
   {

--- a/doc_template/examples_root/examples/nb/brain_observatory_monitor.ipynb
+++ b/doc_template/examples_root/examples/nb/brain_observatory_monitor.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import allensdk.brain_observatory.stimulus_info as si\n",
     "from allensdk.core.brain_observatory_cache import BrainObservatoryCache\n",
-    "boc =  BrainObservatoryCache(manifest_file='boc/manifest.json')"
+    "boc =  BrainObservatoryCache()"
    ]
   },
   {

--- a/doc_template/examples_root/examples/nb/brain_observatory_stimuli.ipynb
+++ b/doc_template/examples_root/examples/nb/brain_observatory_stimuli.ipynb
@@ -60,7 +60,7 @@
      "collapsed": false,
      "input": [
       "from allensdk.core.brain_observatory_cache import BrainObservatoryCache\n",
-      "boc = BrainObservatoryCache(manifest_file='boc/manifest.json')\n",
+      "boc = BrainObservatoryCache()\n",
       "data_set = boc.get_ophys_experiment_data(501940850)\n",
       "\n",
       "# this is a pandas DataFrame. find trials with a given stimulus condition.\n",

--- a/doc_template/examples_root/examples/nb/cell_specimen_mapping.ipynb
+++ b/doc_template/examples_root/examples/nb/cell_specimen_mapping.ipynb
@@ -145,7 +145,7 @@
     "from matplotlib.colors import ListedColormap\n",
     "%matplotlib inline\n",
     "\n",
-    "boc = BrainObservatoryCache(manifest_file='boc/manifest.json')\n",
+    "boc = BrainObservatoryCache()\n",
     "\n",
     "cell_ids = {}\n",
     "cell_ids[\"three_session_B\"] = int(table[table.old_cell_id == old_cell_id].session_B_new_cell_id)\n",

--- a/doc_template/examples_root/examples/nb/cell_types.ipynb
+++ b/doc_template/examples_root/examples/nb/cell_types.ipynb
@@ -25,7 +25,7 @@
     "# tells it where to store the manifest, which is a JSON file that tracks\n",
     "# file paths.  If you supply a relative path (like this), it will go\n",
     "# into your current working directory\n",
-    "ctc = CellTypesCache(manifest_file='cell_types/manifest.json')\n",
+    "ctc = CellTypesCache(')\n",
     "\n",
     "# this saves the NWB file to 'cell_types/specimen_464212183/ephys.nwb'\n",
     "cell_specimen_id = 464212183\n",

--- a/doc_template/examples_root/examples/nb/mouse_connectivity.ipynb
+++ b/doc_template/examples_root/examples/nb/mouse_connectivity.ipynb
@@ -59,7 +59,7 @@
     "# the data that has already been downloaded onto the hard drives.\n",
     "# If you supply a relative path, it is assumed to be relative to your\n",
     "# current working directory.\n",
-    "mcc = MouseConnectivityCache(manifest_file='connectivity/mouse_connectivity_manifest.json')\n",
+    "mcc = MouseConnectivityCache(')\n",
     "\n",
     "# open up a list of all of the experiments\n",
     "all_experiments = mcc.get_experiments(dataframe=True)\n",

--- a/doc_template/examples_root/examples/nb/receptive_fields.ipynb
+++ b/doc_template/examples_root/examples/nb/receptive_fields.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "cell_specimen_id = 587377366\n",
     "\n",
-    "boc = BrainObservatoryCache(manifest_file='boc/manifest.json')\n",
+    "boc = BrainObservatoryCache()\n",
     "\n",
     "exps = boc.get_ophys_experiments(cell_specimen_ids=[cell_specimen_id],\n",
     "                                 stimuli=['locally_sparse_noise'])\n",


### PR DESCRIPTION
This PR allows a user to define the location of the brain observatory manifest with an environment variable.

This supports the following use cases:
- a user has defined a custom location for the Brain Observatory cache on their local machine. Any new scripts or 
- The same example notebooks or scripts will work in the cloud or locally by relying on the environment variable to define the location of the cache