### PR TITLE
Fix FutureWarning from pandas about sorting behavior on concat

### DIFF
--- a/allensdk/brain_observatory/locally_sparse_noise.py
+++ b/allensdk/brain_observatory/locally_sparse_noise.py
@@ -309,8 +309,7 @@ class LocallySparseNoise(StimulusAnalysis):
             curr_df = pd.DataFrame.from_dict(massaged_dict)
             df_list.append(curr_df)
 
-            attribute_df = pd.concat(df_list)
-
+            attribute_df = pd.concat(df_list, sort=True)
 
         return attribute_df.sort_values('cell_index')
 

--- a/allensdk/core/brain_observatory_nwb_data_set.py
+++ b/allensdk/core/brain_observatory_nwb_data_set.py
@@ -542,7 +542,7 @@ class BrainObservatoryNwbDataSet(object):
                 curr_subtable['stimulus'] = stimulus
                 table_list.append(curr_subtable)
 
-        new_table = pd.concat(table_list)
+        new_table = pd.concat(table_list, sort=True)
         new_table.reset_index(drop=True, inplace=True)
 
         return new_table

--- a/allensdk/core/mouse_connectivity_cache.py
+++ b/allensdk/core/mouse_connectivity_cache.py
@@ -569,7 +569,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
                                                              hemisphere_ids=hemisphere_ids)
                      for eid in experiment_ids]
 
-        return pd.concat(unionizes, ignore_index=True)
+        return pd.concat(unionizes, ignore_index=True, sort=True)
 
     def get_projection_matrix(self, experiment_ids, 
                               projection_structure_ids=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 h5py>=2.3.1
 matplotlib>=1.4.3
 numpy>=1.12.1
-pandas>=0.17.0
+pandas>=0.23.0
 jinja2>=2.7.3
 scipy>=0.15.1
 six>=1.9.0


### PR DESCRIPTION
Unfortunately pandas is changing the default behavior of this, but the keyword argument didn't show up until 0.23.0, so there is a big minimum version bump on the dependency to get rid of it.