### PR TITLE
Reporter querying in BrainObservatoryCache

### DIFF
--- a/allensdk/api/queries/brain_observatory_api.py
+++ b/allensdk/api/queries/brain_observatory_api.py
@@ -428,16 +428,21 @@ class BrainObservatoryApi(RmaTemplate):
 
         if cre_lines is not None:
             tls = [ tl.lower() for tl in cre_lines ]
-            objs = [o for o in objs if find_specimen_cre_line(o['specimen']).lower() in tls]
+            obj_tls = [ find_specimen_cre_line(o['specimen']) for o in objs ]
+            obj_tls = [ o.lower() if o else None for o in obj_tls ]
+            objs = [o for i,o in enumerate(objs) if obj_tls[i] in tls]
 
         if reporter_lines is not None:
             tls = [ tl.lower() for tl in reporter_lines ]
-            objs = [o for o in objs if find_specimen_reporter_line(o['specimen']).lower() in tls]
+            obj_tls = [ find_specimen_reporter_line(o['specimen']) for o in objs ]
+            obj_tls = [ o.lower() if o else None for o in obj_tls ]
+            objs = [o for i,o in enumerate(objs) if obj_tls[i] in tls]
             
         if transgenic_lines is not None:
             tls = set([ tl.lower() for tl in transgenic_lines ])
-            ctls = set([ find_specimen_cre_line(o['specimen']), find_specimen_reporter_line(o['specimen']) ])
-            objs = [ o for o in objs if len(tls & ctls) ]
+            objs = [ o for o in objs 
+                     if len(tls & set([ tl.lower() 
+                                        for tl in find_specimen_transgenic_lines(o['specimen']) ]) ) ]
 
         return objs
 
@@ -698,12 +703,18 @@ def find_specimen_cre_line(specimen):
     except StopIteration:
         return None
 
+
 def find_specimen_reporter_line(specimen):
     try:
         return next(tl['name'] for tl in specimen['donor']['transgenic_lines']
                     if tl['transgenic_line_type_name'] == 'reporter')
     except StopIteration:
         return None
+
+
+def find_specimen_transgenic_lines(specimen):
+    return [ tl['name'] for tl in specimen['donor']['transgenic_lines'] ]
+
 
 def find_experiment_acquisition_age(exp):
     try:

--- a/allensdk/api/queries/brain_observatory_api.py
+++ b/allensdk/api/queries/brain_observatory_api.py
@@ -46,6 +46,7 @@ from .rma_template import RmaTemplate
 from ..cache import cacheable, Cache
 from .rma_pager import pageable
 
+from dateutil.parser import parse as parse_date
 
 class BrainObservatoryApi(RmaTemplate):
     _log = logging.getLogger('allensdk.api.queries.brain_observatory_api')
@@ -384,6 +385,7 @@ class BrainObservatoryApi(RmaTemplate):
 
         self.retrieve_file_over_http(self.api_url + file_url, file_name)
 
+
     @cacheable(strategy='create',
                pathfinder=Cache.pathfinder(file_name_position=2,
                                            path_keyword='file_name'))
@@ -401,31 +403,65 @@ class BrainObservatoryApi(RmaTemplate):
 
         self.retrieve_file_over_http(self.api_url + file_url, file_name)
 
+    def filter_experiments_and_containers(self, objs,
+                                          ids=None,
+                                          targeted_structures=None,
+                                          imaging_depths=None,
+                                          cre_lines=None,
+                                          reporter_lines=None,
+                                          transgenic_lines=None,
+                                          include_failed=False):
+
+        if not include_failed:
+            objs = [o for o in objs if not o.get('failed', False)]
+
+        if ids is not None:
+            objs = [o for o in objs if o['id'] in ids]
+
+        if targeted_structures is not None:
+            objs = [o for o in objs if o[
+                'targeted_structure']['acronym'] in targeted_structures]
+
+        if imaging_depths is not None:
+            objs = [o for o in objs if o[
+                'imaging_depth'] in imaging_depths]
+
+        if cre_lines is not None:
+            tls = [ tl.lower() for tl in cre_lines ]
+            objs = [o for o in objs if find_specimen_cre_line(o['specimen']).lower() in tls]
+
+        if reporter_lines is not None:
+            tls = [ tl.lower() for tl in reporter_lines ]
+            objs = [o for o in objs if find_specimen_reporter_line(o['specimen']).lower() in tls]
+            
+        if transgenic_lines is not None:
+            tls = set([ tl.lower() for tl in transgenic_lines ])
+            ctls = set([ find_specimen_cre_line(o['specimen']), find_specimen_reporter_line(o['specimen']) ])
+            objs = [ o for o in objs if len(tls & ctls) ]
+
+        return objs
+
     def filter_experiment_containers(self, containers,
                                      ids=None,
                                      targeted_structures=None,
                                      imaging_depths=None,
+                                     cre_lines=None,
+                                     reporter_lines=None,
                                      transgenic_lines=None,
-                                     include_failed=False):
+                                     include_failed=False,
+                                     simple=False):
 
-        if not include_failed:
-            containers = [c for c in containers if not c.get('failed', False)]
-
-        if ids is not None:
-            containers = [c for c in containers if c['id'] in ids]
-
-        if targeted_structures is not None:
-            containers = [c for c in containers if c[
-                'targeted_structure']['acronym'] in targeted_structures]
-
-        if imaging_depths is not None:
-            containers = [c for c in containers if c[
-                'imaging_depth'] in imaging_depths]
-
-        if transgenic_lines is not None:
-            tls = [ tl.lower() for tl in transgenic_lines ]
-            containers = [c for c in containers for tl in c['specimen'][
-                'donor']['transgenic_lines'] if tl['name'].lower() in tls]
+        containers = self.filter_experiments_and_containers(containers,
+                                                            ids=ids,
+                                                            targeted_structures=targeted_structures,
+                                                            imaging_depths=imaging_depths,
+                                                            cre_lines=cre_lines,
+                                                            reporter_lines=reporter_lines,
+                                                            transgenic_lines=transgenic_lines,
+                                                            include_failed=include_failed)
+        
+        if simple:
+            containers = self.simplify_experiment_containers(containers)
 
         return containers
 
@@ -434,18 +470,22 @@ class BrainObservatoryApi(RmaTemplate):
                                  experiment_container_ids=None,
                                  targeted_structures=None,
                                  imaging_depths=None,
+                                 cre_lines=None,
+                                 reporter_lines=None,
                                  transgenic_lines=None,
                                  stimuli=None,
                                  session_types=None,
                                  include_failed=False,
-                                 require_eye_tracking=False):
+                                 require_eye_tracking=False,
+                                 simple=False):
 
-        # re-using the code from above
-        experiments = self.filter_experiment_containers(experiments,
-                                                        ids=ids,
-                                                        targeted_structures=targeted_structures,
-                                                        imaging_depths=imaging_depths,
-                                                        transgenic_lines=transgenic_lines)
+        experiments = self.filter_experiments_and_containers(experiments,
+                                                             ids=ids,
+                                                             targeted_structures=targeted_structures,
+                                                             imaging_depths=imaging_depths,
+                                                             cre_lines=cre_lines,
+                                                             reporter_lines=reporter_lines,
+                                                             transgenic_lines=transgenic_lines)
 
         if require_eye_tracking:
             experiments = [e for e in experiments
@@ -465,6 +505,9 @@ class BrainObservatoryApi(RmaTemplate):
         if stimuli is not None:
             experiments = [e for e in experiments
                            if len(set(stimuli) & set(stimulus_info.stimuli_in_session(e['stimulus_name']))) > 0]
+
+        if simple:
+            experiments = self.simplify_ophys_experiments(experiments)
 
         return experiments
 
@@ -613,4 +656,64 @@ class BrainObservatoryApi(RmaTemplate):
             raise Exception("No OphysCellSpecimenIdMapping file found.")
 
         self.retrieve_file_over_http(self.api_url + file_url, file_name)
+
         return pd.read_csv(file_name)
+
+    def simplify_experiment_containers(self, containers):
+        return [{
+            'id': c['id'],
+            'imaging_depth': c['imaging_depth'],
+            'targeted_structure': c['targeted_structure']['acronym'],
+            'cre_line': find_specimen_cre_line(c['specimen']),
+            'reporter_line': find_specimen_reporter_line(c['specimen']),
+            'donor_name': c['specimen']['donor']['external_donor_name'],
+            'specimen_name': c['specimen']['name'],
+            'tags': find_container_tags(c),
+            'failed': c['failed']
+        } for c in containers]
+
+
+    def simplify_ophys_experiments(self, exps):
+        return [{
+            'id': e['id'],
+            'imaging_depth': e['imaging_depth'],
+            'targeted_structure': e['targeted_structure']['acronym'],
+            'cre_line': find_specimen_cre_line(e['specimen']),
+            'reporter_line': find_specimen_reporter_line(e['specimen']),
+            'acquisition_age_days': find_experiment_acquisition_age(e),
+            'experiment_container_id': e['experiment_container_id'],
+            'session_type': e['stimulus_name'],
+            'donor_name': e['specimen']['donor']['external_donor_name'],
+            'specimen_name': e['specimen']['name'],
+                'fail_eye_tracking': e.get('fail_eye_tracking', None)
+        } for e in exps]
+
+
+
+def find_specimen_cre_line(specimen):
+    try:
+        return next(tl['name'] for tl in specimen['donor']['transgenic_lines']
+                    if tl['transgenic_line_type_name'] == 'driver' and
+                    'Cre' in tl['name'])
+    except StopIteration:
+        return None
+
+def find_specimen_reporter_line(specimen):
+    try:
+        return next(tl['name'] for tl in specimen['donor']['transgenic_lines']
+                    if tl['transgenic_line_type_name'] == 'reporter')
+    except StopIteration:
+        return None
+
+def find_experiment_acquisition_age(exp):
+    try:
+        return (parse_date(exp['date_of_acquisition']) - parse_date(exp['specimen']['donor']['date_of_birth'])).days
+    except KeyError as e:
+        return None
+
+
+def find_container_tags(container):
+    """ Custom logic for extracting tags from donor conditions.  Filtering 
+    out tissuecyte tags. """
+    conditions = container['specimen']['donor'].get('conditions', [])
+    return [c['name'] for c in conditions if not c['name'].startswith('tissuecyte')]

--- a/allensdk/test/core/test_brain_observatory_cache.py
+++ b/allensdk/test/core/test_brain_observatory_cache.py
@@ -37,11 +37,7 @@ import pytest
 import os
 import numpy as np
 from mock import patch, mock_open, MagicMock
-from allensdk.core.brain_observatory_cache import (BrainObservatoryCache, 
-                                                   _find_container_tags,
-                                                   _merge_transgenic_lines,
-                                                   _find_specimen_cre_line,
-                                                   _find_specimen_reporter_line)
+from allensdk.core.brain_observatory_cache import BrainObservatoryCache
 from allensdk.api.queries.brain_observatory_api import BrainObservatoryApi
 import json
 import allensdk.brain_observatory.stimulus_info as si
@@ -316,82 +312,6 @@ def test_string_argument_errors(brain_observatory_cache):
 
     with pytest.raises(TypeError):
         boc.get_ophys_experiments(session_types='str')
-
-def test_find_container_tags():
-    # no conditions no tags
-    c = { "specimen": { "donor": { "conditions": [] } } }
-    tags = _find_container_tags(c)
-    assert len(tags) == 0
-
-    # tissue tags are ignored
-    c = { "specimen": { "donor": { "conditions": [ { "name": "tissuecyte" } ] } } }
-    tags = _find_container_tags(c)
-    assert len(tags) == 0
-
-    # no conditions is okay
-    c = { "specimen": { "donor": { } } }
-    tags = _find_container_tags(c)
-    assert len(tags) == 0
-
-    # everything else goes through
-    c = { "specimen": { "donor": { "conditions": [ { "name": "fish" } ] } } }
-    tags = _find_container_tags(c)
-    assert len(tags) == 1
-
-def test_merge_transgenic_lines():
-    # None is allowed and should be ignored
-    t1 = [ "a", "b", "c" ]
-    t2 = None
-    tm = _merge_transgenic_lines(t1,t2)
-    assert sorted(tm) == [ "a", "b", "c"]
-
-    # otherwise it's just a merge
-    t1 = [ "a", "b", "c" ]
-    t2 = [ "c", "d" ]
-    tm = _merge_transgenic_lines(t1,t2)
-    assert sorted(tm) == [ "a", "b", "c", "d"]
-
-    # one list is fine
-    t1 = [ "a", "b", "c" ]
-    tm = _merge_transgenic_lines(t1)
-    assert sorted(tm) == [ "a", "b", "c" ]
-
-def test_find_specimen_cre_line():
-    # None if no TLs
-    s = { "donor": { "transgenic_lines": [ ] } }
-    cre = _find_specimen_cre_line(s)
-    assert cre is None
-
-    # None if no 'Cre'
-    s = { "donor": { "transgenic_lines": [ { "transgenic_line_type_name": "driver", "name": "banana" } ] } }
-    cre = _find_specimen_cre_line(s)
-    assert cre is None
-
-    # None if no 'Cre'
-    s = { "donor": { "transgenic_lines": [ { "transgenic_line_type_name": "driver", "name": "bananaCre" } ] } }
-    cre = _find_specimen_cre_line(s)
-    assert cre == "bananaCre"
-
-    # None if no 'driver'
-    s = { "donor": { "transgenic_lines": [ { "transgenic_line_type_name": "reporter", "name": "bananaCre" } ] } }
-    cre = _find_specimen_cre_line(s)
-    assert cre == None
-
-def test_find_specimen_reporter_line():
-    # None if no TLs
-    s = { "donor": { "transgenic_lines": [ ] } }
-    cre = _find_specimen_reporter_line(s)
-    assert cre is None
-
-    s = { "donor": { "transgenic_lines": [ { "transgenic_line_type_name": "reporter", "name": "banana" } ] } }
-    cre = _find_specimen_reporter_line(s)
-    assert cre == "banana"
-
-    # None if no "reporter"
-    s = { "donor": { "transgenic_lines": [ { "transgenic_line_type_name": "driver", "name": "bananaCre" } ] } }
-    cre = _find_specimen_reporter_line(s)
-    assert cre is None
-
 
 @pytest.mark.skipif(not os.path.exists('/allen/aibs/informatics/module_test_data'), reason='AIBS path not available')
 @pytest.mark.parametrize("path_dict", get_list_of_path_dict())


### PR DESCRIPTION
resolves #234 

This got unexpectedly complicated.  What I did:

1. moved all of filtering logic into BrainObservatoryApi to match the other Cache subclasses
2. separated filtering by cre line, reporter line, and general transgenic lines into separate operations (they were previously all mushed into a generic transgenic lines query, which is no longer correct)
3. exposed reporter_lines arguments
4. updated (and moved) relevant tests
