### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,5 @@ install:
   - pip install .
 
 script:
-  - make test
+  - py.test --cov=allensdk
   - codecov


### PR DESCRIPTION
This resolves #270 by no longer running Travis tests with --boxed either (Appveyor already doesn't because Windows doesn't support it). Testing with pytest-faulthandler showed that all of the segmentation faults occured in[ OSX system calls for getting url proxies](https://travis-ci.org/AllenInstitute/AllenSDK/jobs/440425121). Some investigation indicates that these calls are [not fork safe](https://bugs.python.org/issue30385). I'm not sure why the 3.6 only builds on OSX suddenly started failing, but running the tests not-forked seems to fix it.