### PR TITLE
remove overlapping requirements

### DIFF
--- a/allensdk/test/brain_observatory/test_observatory_plots.py
+++ b/allensdk/test/brain_observatory/test_observatory_plots.py
@@ -48,9 +48,9 @@ import allensdk.brain_observatory.stimulus_info as stiminfo
 import allensdk.core.json_utilities as ju
 from pkg_resources import resource_filename  # @UnresolvedImport
 
-if 'TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA' in os.environ:
-    data_file = os.environ['TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA']
-else:
+
+data_file = os.environ.get('TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA', 'skip')
+if data_file == 'default':
     data_file = resource_filename(__name__, 'test_observatory_plots_data.json')
 
 if data_file == 'skip':

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,18 +3,3 @@ flake8>=1.5.0
 pylint>=1.5.4
 numpydoc>=0.6.0
 jupyter>=1.0.0
-h5py>=2.3.1
-matplotlib>=1.4.3
-numpy>=1.9.2
-pandas>=0.17.0
-jinja2>=2.7.3
-scipy>=0.15.1
-six>=1.9.0
-pynrrd>=0.2.1
-future >= 0.14.3
-requests
-requests-toolbelt
-simplejson>=3.10.0
-scikit-image>=0.13.0
-statsmodels>=0.8.0
-tables


### PR DESCRIPTION
Resolves #275 

- Removes from doc_requirements.txt dependencies already specified in requirements.txt
- brain_observatory_plots tests now default to 'skip'. This is so that our tests don't fail by default for external users. The current default behavior can be obtained by setting `TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA=default`.