### PR TITLE
fix #295 perisomatic model template id

### DIFF
--- a/allensdk/api/queries/biophysical_api.py
+++ b/allensdk/api/queries/biophysical_api.py
@@ -47,7 +47,7 @@ class BiophysicalApi(RmaTemplate):
     _MOD_file_type = 'BiophysicalModelDescription'
     _FIT_file_type = 'NeuronalModelParameters'
     _MARKER_file_type = '3DNeuronMarker'
-    BIOPHYSICAL_MODEL_TYPE_IDS = (491455321, 32923071,)
+    BIOPHYSICAL_MODEL_TYPE_IDS = (491455321, 329230710,)
 
     rma_templates = \
         {"model_queries": [

--- a/allensdk/test/api/test_biophysical_api.py
+++ b/allensdk/test/api/test_biophysical_api.py
@@ -63,7 +63,7 @@ def test_get_neuronal_models(mock_json_msg_query, biophys_api):
 
     mock_json_msg_query.assert_called_once_with(
         "http://twarehouse-backup/api/v2/data/query.json?"
-        "q=model::NeuronalModel,rma::criteria,[neuronal_model_template_id$in491455321,32923071],"
+        "q=model::NeuronalModel,rma::criteria,[neuronal_model_template_id$in491455321,329230710],"
         "[specimen_id$in386049446,469753383],rma::options[num_rows$eq'all'][count$eqfalse]")
 
 


### PR DESCRIPTION
Minor edit, fixing a typo in the model type/template id for perisomatic biophysical models.