### PR TITLE
fix session analysis regression locally sparse noise test

### DIFF
--- a/allensdk/brain_observatory/stimulus_info.py
+++ b/allensdk/brain_observatory/stimulus_info.py
@@ -65,6 +65,7 @@ NATURAL_SCENES = 'natural_scenes'
 NATURAL_SCENES_SHORT = 'ns'
 NATURAL_SCENES_COLOR = '#e31a1c'
 
+# note that this stimulus is equivalent to LOCALLY_SPARSE_NOISE_4DEG in session C2 files
 LOCALLY_SPARSE_NOISE = 'locally_sparse_noise'
 LOCALLY_SPARSE_NOISE_SHORT = 'lsn'
 LOCALLY_SPARSE_NOISE_COLOR = '#fdbf6f'

--- a/allensdk/test/brain_observatory/test_session_analysis_regression.py
+++ b/allensdk/test/brain_observatory/test_session_analysis_regression.py
@@ -87,7 +87,7 @@ def ns(nwb_b, analysis_b):
 # session c
 @pytest.fixture(scope="module")
 def lsn(nwb_c, analysis_c):
-    return LocallySparseNoise.from_analysis_file(BODS(nwb_c), analysis_c, si.LOCALLY_SPARSE_NOISE_8DEG)
+    return LocallySparseNoise.from_analysis_file(BODS(nwb_c), analysis_c, si.LOCALLY_SPARSE_NOISE)
 
 @pytest.fixture(scope="module")
 def nm1c(nwb_c, analysis_c):


### PR DESCRIPTION
Resolves #311 

Fixture previously tried to load 'locally_sparse_noise_8deg' from a session C file, but session C files have only 'locally_sparse_noise' corresponding to session C2's 'locally_sparse_noise_4deg'.