### PR TITLE
grid fixes

### DIFF
--- a/allensdk/mouse_connectivity/grid/__main__.py
+++ b/allensdk/mouse_connectivity/grid/__main__.py
@@ -67,6 +67,9 @@ def run_grid(args):
         si['polygon_info'] = si['polygons']
         del si['polygons']
     sub_images = sorted(sub_images, key=lambda si: si['specimen_tissue_index'])
+    logging.info('{} sub images with indices: {}'.format(
+        len(sub_images), [si['specimen_tissue_index'] for si in sub_images])
+    )
 
     output_dimensions = [args['reference_dimensions']['slice'], 
                          args['reference_dimensions']['row'], 

--- a/allensdk/mouse_connectivity/grid/_schemas.py
+++ b/allensdk/mouse_connectivity/grid/_schemas.py
@@ -1,7 +1,7 @@
 from marshmallow import RAISE
 from argschema import ArgSchema, ArgSchemaParser 
 from argschema.schemas import DefaultSchema
-from argschema.fields import Nested, InputDir, String, Float, Dict, Int, List, Bool
+from argschema.fields import Nested, InputDir, String, Float, Dict, Int, List, Bool, LogLevel
 import numpy as np
 
 
@@ -52,6 +52,7 @@ class InputParameters(ArgSchema):
     class Meta:
         unknown=RAISE
     
+    log_level = LogLevel(default='INFO',description="set the logging level of the module")
     case = String(required=True, validate=lambda s: s in VALID_CASES, help='select a use case to run')
     sub_images = Nested(SubImage, required=True, many=True, help='Sub images composing this image series')
     affine_params = List(Float, help='Parameters of affine image stack to reference space transform.')

--- a/allensdk/mouse_connectivity/grid/utilities/downsampling_utilities.py
+++ b/allensdk/mouse_connectivity/grid/utilities/downsampling_utilities.py
@@ -36,9 +36,12 @@ def apply_divisions(image, window_size):
 
     for axis in xrange(image.ndim):
 
-        slc = [slice(window_size-1, None, window_size) 
-               if ii == axis else slice(0, None) 
-               for ii in xrange(image.ndim)]
+        slc = tuple([
+            slice(window_size-1, None, window_size) 
+            if ii == axis 
+            else slice(0, None) 
+            for ii in xrange(image.ndim)
+        ])
 
         image[slc] = image[slc] / 2
 
@@ -68,9 +71,9 @@ def extract(image, factor, window_size, window_step, output_shape):
 
     for case in it.product(*([[0, 1]] * image.ndim)):     
 
-        inp = [slice(window_size - 2, None, window_step) 
-               if not ii else slice(window_size, None, window_step) for ii in case]
-        out = [slice(0, None, 2) if not ii else slice(1, None, 2) for ii in case]
+        inp = tuple([slice(window_size - 2, None, window_step) 
+               if not ii else slice(window_size, None, window_step) for ii in case])
+        out = tuple([slice(0, None, 2) if not ii else slice(1, None, 2) for ii in case])
 
         output[out] = image[inp]
 

--- a/allensdk/mouse_connectivity/grid/utilities/image_utilities.py
+++ b/allensdk/mouse_connectivity/grid/utilities/image_utilities.py
@@ -228,6 +228,8 @@ def write_volume(volume, name, prefix=None, specify_resolution=None, extension='
         path = os.path.join(prefix, name)
 
     if specify_resolution is not None:
+        if isinstance(specify_resolution, (float, np.floating)) and specify_resolution % 1.0 == 0:
+            specify_resolution = int(specify_resolution)
         path = path + '_{0}'.format(specify_resolution)
 
     path = path + extension

--- a/allensdk/mouse_connectivity/grid/writers/__init__.py
+++ b/allensdk/mouse_connectivity/grid/writers/__init__.py
@@ -2,7 +2,7 @@ import functools
 
 import numpy as np
 
-from ..utilities.image_utilities import write_volume
+from ..utilities.image_utilities import write_volume, image_from_array
 from ..utilities.downsampling_utilities import downsample_average
 
 


### PR DESCRIPTION
Note: a test run is currently going on axon. Please do no merge until that is complete.

A few fixes and improvements related to #297 (grid module)

bugfixes:
- downsampled volumes written out with integer isometric resolutions (if `res % 1.0 == 0`) to match existing format
- fixed missing import in `writers/__init__.py`

improvements:
- convert some multidimensional slices from lists -> tuples for futureproofing
- more logging, logging default again is INFO