### PR TITLE
upping numpy requrements to remove warning message

### DIFF
--- a/allensdk/test/test_deprecated.py
+++ b/allensdk/test/test_deprecated.py
@@ -72,7 +72,7 @@ def test_deprecated(deprecated_method):
         assert expected == str(c[-1].message)
         
         
-def test_deprecated_class(deprecated_class):
+def test_deprecated_class(deprecated_class, deprecated_method):
     expected = 'Class dep_cls is deprecated. msg'
     
     with warnings.catch_warnings(record=True) as c:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
   - conda install statsmodels
+  - pip install pillow
   - conda install -c https://conda.anaconda.org/simpleitk SimpleITK
   - if %PYTHON% == 2.7 conda install scikit-image
   - pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
   - conda install statsmodels
-  - pip install pillow
+  - pip install Pillow
   - conda install -c https://conda.anaconda.org/simpleitk SimpleITK
   - if %PYTHON% == 2.7 conda install scikit-image
   - pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
   - conda install statsmodels
+  - conda install -c https://conda.anaconda.org/simpleitk SimpleITK
   - if %PYTHON% == 2.7 conda install scikit-image
   - pip install codecov
   - pip install -r test_requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ scikit-build
 statsmodels>=0.8.0
 simpleitk
 tables
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 h5py>=2.3.1
 matplotlib>=1.4.3
-numpy>=1.12.1
+numpy>=1.15.1
 pandas>=0.23.0
 jinja2>=2.7.3
 scipy>=0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ requests
 requests-toolbelt
 simplejson>=3.10.0
 scikit-image>=0.14.0
+scikit-build
 statsmodels>=0.8.0
 simpleitk
 tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-h5py>=2.3.1
+h5py>=2.8
 matplotlib>=1.4.3
 numpy>=1.15.1
 pandas>=0.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ scikit-build
 statsmodels>=0.8.0
 simpleitk
 tables
-pillow

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pep8==1.7.0
-pytest>=2.10.0
+pytest>=4.1.1
 pytest-cov>=2.2.1
 pytest-cover>=3.0.0
 pytest-pep8>=1.0.6


### PR DESCRIPTION
Fix warning message:

> RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88

See https://github.com/numpy/numpy/issues/11788