### PR TITLE
PR: Use memoize decorator on API object to reduce strain on server

### DIFF
--- a/allensdk/internal/api/lims_ophys_api.py
+++ b/allensdk/internal/api/lims_ophys_api.py
@@ -1,8 +1,11 @@
 from . import PostgresQueryMixin
 
+from allensdk.api.cache import memoize
+
 class LimsOphysAPI(PostgresQueryMixin):
 
-    def get_ophys_experiment_dir(self, ophys_experiment_id=None, **kwargs):
+    @memoize
+    def get_ophys_experiment_dir(self, ophys_experiment_id=None):
         query = '''
                 SELECT oe.storage_directory
                 FROM ophys_experiments oe


### PR DESCRIPTION
@dyf Are you OK with using the memoize patter on the instance methods of the API class?