### PR TITLE
PR: Add example of compatible API to LIMS internal and BrainObservatory…

### DIFF
--- a/allensdk/core/brain_observatory_cache.py
+++ b/allensdk/core/brain_observatory_cache.py
@@ -421,6 +421,17 @@ class BrainObservatoryCache(Cache):
 
         return cell_specimens
 
+    def get_nwb_filepath(self, ophys_experiment_id=None, file_name=None, none_if_not_exists=True):
+        nwb_filepath = self.get_cache_path(file_name, self.EXPERIMENT_DATA_KEY, ophys_experiment_id)
+        if not none_if_not_exists:
+            return nwb_filepath
+        else:
+            if os.path.exists(nwb_filepath):
+                return nwb_filepath
+            else:
+                return None
+
+
     def get_ophys_experiment_data(self, ophys_experiment_id, file_name=None):
         """ Download the NWB file for an ophys_experiment (if it hasn't already been
         downloaded) and return a data accessor object.
@@ -439,8 +450,7 @@ class BrainObservatoryCache(Cache):
         -------
         BrainObservatoryNwbDataSet
         """
-        file_name = self.get_cache_path(
-            file_name, self.EXPERIMENT_DATA_KEY, ophys_experiment_id)
+        file_name = self.get_nwb_filepath(ophys_experiment_id=ophys_experiment_id, file_name=file_name, none_if_not_exists=False)
 
         self.api.save_ophys_experiment_data(ophys_experiment_id, file_name, strategy='lazy')
 

--- a/allensdk/internal/api/lims_ophys_api.py
+++ b/allensdk/internal/api/lims_ophys_api.py
@@ -12,3 +12,14 @@ class LimsOphysAPI(PostgresQueryMixin):
                 WHERE oe.id = {ophys_experiment_id};
                 '''.format(ophys_experiment_id=ophys_experiment_id)
         return self.fetchone(query, strict=True)
+
+    @memoize
+    def get_nwb_filepath(self, ophys_experiment_id=None):
+
+        query = '''
+                SELECT wkf.storage_directory || wkf.filename AS nwb_file
+                FROM ophys_experiments oe
+                LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'NWBOphys')
+                WHERE oe.id = {ophys_experiment_id};
+                '''.format(ophys_experiment_id=ophys_experiment_id)
+        return self.fetchone(query, strict=True)

--- a/allensdk/test/internal/test_ophys_api.py
+++ b/allensdk/test/internal/test_ophys_api.py
@@ -20,8 +20,26 @@ def test_get_ophys_experiment_dir(ophys_experiment_id, compare_val):
         except OneResultExpectedError:
             expected_fail = True
         assert expected_fail == True
-    
     else:
-        api.get_ophys_experiment_dir(ophys_experiment_id=ophys_experiment_id)
         assert api.get_ophys_experiment_dir(ophys_experiment_id=ophys_experiment_id) == compare_val
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize('ophys_experiment_id, compare_val', [
+    pytest.param(511458874, '/allen/programs/braintv/production/neuralcoding/prod6/specimen_503292442/ophys_experiment_511458874/511458874.nwb'),
+    pytest.param(0, None)
+])
+def test_get_nwb_filepath(ophys_experiment_id, compare_val):
+
+    api = LimsOphysAPI()
+
+    if compare_val is None:
+        expected_fail = False
+        try:
+            api.get_nwb_filepath(ophys_experiment_id)
+        except OneResultExpectedError:
+            expected_fail = True
+        assert expected_fail == True
+    else:
+        assert api.get_nwb_filepath(ophys_experiment_id=ophys_experiment_id) == compare_val
 


### PR DESCRIPTION
…Cache

The same interface, a method named "get_nwb_filepath" is implemetned on LimsOphysAPI and BrainObservatoryCache, to accept an ophys_experiment_id and return the path to the nwb file. For the BrainObservatoryCache, this is a local file, and for LimsOphysAPI, this is the path on the filesystem