### PR TITLE
migrate lazyprop

### DIFF
--- a/allensdk/core/lazy_property/__init__.py
+++ b/allensdk/core/lazy_property/__init__.py
@@ -1,3 +1,3 @@
 from .lazy_property import LazyProperty
-from .lazy_property_mixin import LazyPropertyMixin
+from .lazy_property_mixin import LazyPropertyMixin 
 

--- a/allensdk/core/lazy_property/__init__.py
+++ b/allensdk/core/lazy_property/__init__.py
@@ -1,0 +1,3 @@
+from .lazy_property import LazyProperty
+from .lazy_property_mixin import LazyPropertyMixin
+

--- a/allensdk/core/lazy_property/lazy_property.py
+++ b/allensdk/core/lazy_property/lazy_property.py
@@ -1,0 +1,22 @@
+class LazyProperty(object):
+    
+    def __init__(self, api_method, *args, **kwargs):
+
+        self.api_method = api_method
+        self.args = args
+        self.kwargs = kwargs
+        self.value = None
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+
+        if self.value is None:
+            self.value = self.calculate()
+        return self.value
+
+    def __set__(self, obj, value):
+        raise AttributeError("Can't set LazyLoadable attribute")
+
+    def calculate(self):
+        return self.api_method(*self.args, **self.kwargs)

--- a/allensdk/core/lazy_property/lazy_property_mixin.py
+++ b/allensdk/core/lazy_property/lazy_property_mixin.py
@@ -1,0 +1,29 @@
+from .lazy_property import LazyProperty
+
+
+class LazyPropertyMixin(object):
+
+    @property
+    def LazyProperty(self):
+        return LazyProperty
+
+    def __getattribute__(self, name):
+
+        lazy_class = super(LazyPropertyMixin, self).__getattribute__('LazyProperty')
+        curr_attr = super(LazyPropertyMixin, self).__getattribute__(name)
+        if isinstance(curr_attr, lazy_class):
+            return curr_attr.__get__(curr_attr)
+        else:
+            return super(LazyPropertyMixin, self).__getattribute__(name)
+
+
+    def __setattr__(self, name, value):
+        if not hasattr(self, name):
+            super(LazyPropertyMixin, self).__setattr__(name, value)
+        else:
+            curr_attr = super(LazyPropertyMixin, self).__getattribute__(name)
+            lazy_class = super(LazyPropertyMixin, self).__getattribute__('LazyProperty')
+            if isinstance(curr_attr, lazy_class):
+                curr_attr.__set__(curr_attr, value)
+            else:
+                super(LazyPropertyMixin, self).__setattr__(name, value)

--- a/allensdk/test/core/test_lazy_property.py
+++ b/allensdk/test/core/test_lazy_property.py
@@ -18,11 +18,12 @@ class DataClass(LazyPropertyMixin):
         self.data = self.LazyProperty(self.api.get_data, original_data=self.original_data)
 
 
-@pytest.mark.parametrize('original_data', [1, '1', [None]])
+@pytest.mark.parametrize('original_data', [{'a': 'b'}, [None]])
 def test_first_compute(original_data):
     data_obj = DataClass(original_data)
     assert data_obj.data == original_data
-
+    assert data_obj.data is not original_data
+    
 
 @pytest.mark.parametrize('original_data', [1, '1', [None]])
 def test_is_lazy(original_data):

--- a/allensdk/test/core/test_lazy_property.py
+++ b/allensdk/test/core/test_lazy_property.py
@@ -1,0 +1,41 @@
+import pytest
+import copy as cp
+
+from allensdk.core.lazy_property import LazyProperty, LazyPropertyMixin
+
+
+class CopyApi(object):
+    def get_data(self, original_data):
+        return cp.copy(original_data)
+
+
+class DataClass(LazyPropertyMixin):
+
+    def __init__(self, original_data, api=None):
+        self.api = CopyApi() if api is None else api
+        self.original_data = original_data
+
+        self.data = self.LazyProperty(self.api.get_data, original_data=self.original_data)
+
+
+@pytest.mark.parametrize('original_data', [1, '1', [None]])
+def test_first_compute(original_data):
+    data_obj = DataClass(original_data)
+    assert data_obj.data == original_data
+
+
+@pytest.mark.parametrize('original_data', [1, '1', [None]])
+def test_is_lazy(original_data):
+    data_obj = DataClass(original_data)
+
+    first = data_obj.data
+    second = data_obj.data
+    assert first is second
+
+
+@pytest.mark.parametrize('original_data', [1, '1', [None]])
+def test_not_settable(original_data):
+    data_obj = DataClass(original_data)
+    with pytest.raises(AttributeError) as err:
+        data_obj.data = '12345'
+        assert "Can't set LazyLoadable attribute" in err


### PR DESCRIPTION
Resolves #369
Simple migration of lazy property and lazy property mixin. Only changes are to tests.