### PR TITLE
Get current stage

### DIFF
--- a/allensdk/internal/api/behavior_lims_api.py
+++ b/allensdk/internal/api/behavior_lims_api.py
@@ -1,0 +1,71 @@
+from allensdk.api.cache import memoize
+
+from . import PostgresQueryMixin
+
+class BehaviorLimsApi(PostgresQueryMixin):
+
+    @memoize
+    def get_behavior_stimulus_file(self, ophys_experiment_id=None):
+        query = '''
+                SELECT stim.storage_directory || stim.filename AS stim_file
+                FROM ophys_experiments oe
+                JOIN ophys_sessions os ON oe.ophys_session_id = os.id
+                JOIN behavior_sessions bs ON bs.ophys_session_id=os.id
+                LEFT JOIN well_known_files stim ON stim.attachable_id=bs.id AND stim.attachable_type = 'BehaviorSession' AND stim.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'StimulusPickle')
+                WHERE oe.id= {};
+                '''.format(ophys_experiment_id)
+        return self.fetchone(query, strict=True)
+
+
+    @memoize
+    def get_core_data(self, ophys_session_id=None):
+        stim_filepath = self.filepath_api.get_behavior_stimulus_file(ophys_experiment_id = ophys_experiment_id)
+        pkl = pd.read_pickle(stim_filepath)
+
+
+
+
+        stimulus_timestamps = self.get_stimulus_timestamps(*args, ophys_experiment_id=ophys_experiment_id, **kwargs)
+        try:
+            core_data = foraging.data_to_change_detection_core(pkl, time=stimulus_timestamps)
+        except KeyError:
+            core_data = foraging2.data_to_change_detection_core(pkl, time=stimulus_timestamps)
+        return core_data
+
+
+# import pandas as pd
+
+# from visual_behavior.translator import foraging2, foraging
+# from allensdk.api.cache import memoize
+
+# from .lims_behavior_api import LimsBehaviorAPI
+
+# class BehaviorApi(object):
+
+#     def __init__(self, filepath_api=None):
+        
+#         if filepath_api is None:
+#             self.filepath_api = LimsBehaviorAPI()
+#         else:
+#             self.filepath_api = filepath_api
+
+#     @memoize
+#     def get_sync_data(self, session_id=None):
+#         sync_path = self.get_sync_file(session_id)
+#         return get_sync_data(sync_path)
+
+
+#     @memoize
+#     def get_core_data(self, session_id=None):
+#         stim_filepath = self.filepath_api.get_behavior_stimulus_file(ophys_experiment_id=ophys_experiment_id)
+#         pkl = pd.read_pickle(stim_filepath)
+
+
+
+
+#         stimulus_timestamps = self.get_stimulus_timestamps(*args, ophys_experiment_id=ophys_experiment_id, **kwargs)
+#         try:
+#             core_data = foraging.data_to_change_detection_core(pkl, time=stimulus_timestamps)
+#         except KeyError:
+#             core_data = foraging2.data_to_change_detection_core(pkl, time=stimulus_timestamps)
+#         return core_data

--- a/allensdk/internal/api/mtrain_api.py
+++ b/allensdk/internal/api/mtrain_api.py
@@ -3,14 +3,94 @@ import pandas as pd
 import requests
 import os
 import json
+import sys
+import itertools
 
 from . import PostgresQueryMixin, one
 
+
 class MtrainApi(PostgresQueryMixin):
 
-    def __init__(self, dbname="mtrain", user="mtrainreader", host="prodmtrain1", password="mtrainro", port=5432, api_base='http://mtrain:5000'):
-        super(MtrainApi, self).__init__(dbname=dbname, user=user, host=host, password=password, port=port)
+    def __init__(self, api_base='http://mtrain:5000'):
         self.api_base = api_base
+
+    def get_page(self, table_name, get_obj=None, filters=[],**kwargs):
+        
+        if get_obj is None:
+            get_obj = requests
+
+        data = {'total_pages':'--'}
+        for ii in itertools.count(1):
+            sys.stdout.flush()
+
+            uri = os.path.join(self.api_base, "api/v1/%s?page=%i&q={\"filters\":%s}" % (table_name, ii, json.dumps(filters)))
+            tmp = get_obj.get(uri, **kwargs)
+            try:
+                data = tmp.json()
+            except TypeError:
+                data = tmp.json
+            if 'message' not in data:
+                df = pd.DataFrame(data["objects"])
+                sys.stdout.flush()
+                yield df
+
+            if 'total_pages' not in data or data['total_pages'] == ii:
+                return
+
+    def get_df(self, table_name, get_obj=None, **kwargs):
+        return pd.concat([df for df in self.get_page(table_name, get_obj=get_obj, **kwargs)], axis=0)
+
+
+    def get_subjects(self):
+        return self.get_df('subjects').LabTracks_ID.values
+
+    def get_session(self, behavior_session_uuid):
+        filters = [{"name":"id","op":"eq","val":behavior_session_uuid}]
+        behavior_df = self.get_df('behavior_sessions', filters=filters).rename(columns={'id':'behavior_session_uuid'})
+        state_df = self.get_df('states').rename(columns={'id':'state_id'})
+        regimen_df = self.get_df('regimens').rename(columns={'id':'regimen_id', 'name':'regimen_name'}).drop(['states', 'active'], axis=1)
+        stage_df = self.get_df('stages').rename(columns={'id':'stage_id'}).drop(['states'], axis=1)
+        
+        behavior_df = pd.merge(behavior_df, state_df, how='left', on='state_id')
+        behavior_df = pd.merge(behavior_df, stage_df, how='left', on='stage_id')
+        behavior_df = pd.merge(behavior_df, regimen_df, how='left', on='regimen_id')
+        behavior_df.drop(['state_id', 'stage_id', 'regimen_id'], inplace=True, axis=1)
+        if len(behavior_df) == 0:
+            raise RuntimeError("Session not found %s:" % behavior_session_uuid)
+        assert len(behavior_df) == 1
+        return behavior_df.iloc[0].to_dict()
+
+
+    def get_behavior_training_df(self, LabTracks_ID=None):
+        if LabTracks_ID is not None:
+            filters = [{"name":"LabTracks_ID","op":"eq","val":LabTracks_ID}]
+        else:
+            filters = []
+        behavior_df = self.get_df('behavior_sessions', filters=filters).rename(columns={'id':'behavior_session_uuid'})
+        
+        state_df = self.get_df('states').rename(columns={'id':'state_id'})
+        regimen_df = self.get_df('regimens').rename(columns={'id':'regimen_id', 'name':'regimen_name'}).drop(['states', 'active'], axis=1)
+        stage_df = self.get_df('stages').rename(columns={'id':'stage_id'}).drop(['states'], axis=1)
+        
+
+        behavior_df = pd.merge(behavior_df, state_df, how='left', on='state_id')
+        behavior_df = pd.merge(behavior_df, stage_df, how='left', on='stage_id')
+        behavior_df = pd.merge(behavior_df, regimen_df, how='left', on='regimen_id')
+        return behavior_df
+        
+
+
+    def get_current_stage(self, LabTracks_ID):
+        sess = requests.Session()
+
+        state_response = sess.get(os.path.join(self.api_base, 'get_script/'), data=json.dumps({'LabTracks_ID':LabTracks_ID}))#.json()#['objects']).keys()
+        return state_response.json()['data']['parameters']['stage']
+
+
+class MtrainSqlApi(PostgresQueryMixin):
+    
+    def __init__(self, dbname="mtrain", user="mtrainreader", host="prodmtrain1", password="mtrainro", port=5432):
+        super(MtrainSqlApi, self).__init__(dbname=dbname, user=user, host=host, password=password, port=port)
 
 
     def get_subjects(self):
@@ -29,10 +109,3 @@ class MtrainApi(PostgresQueryMixin):
                WHERE "LabTracks_ID"={}
             '''.format(LabTracks_ID), connection)
         return dataframe.sort_values(by='date')
-
-
-    def get_current_stage(self, LabTracks_ID):
-        sess = requests.Session()
-
-        state_response = sess.get(os.path.join(self.api_base, 'get_script/'), data=json.dumps({'LabTracks_ID':LabTracks_ID}))#.json()#['objects']).keys()
-        return state_response.json()['data']['parameters']['stage']

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -2,7 +2,7 @@ from . import PostgresQueryMixin
 
 from allensdk.api.cache import memoize
 
-class LimsOphysAPI(PostgresQueryMixin):
+class OphysLimsApi(PostgresQueryMixin):
 
     @memoize
     def get_ophys_experiment_dir(self, ophys_experiment_id=None):
@@ -13,6 +13,7 @@ class LimsOphysAPI(PostgresQueryMixin):
                 '''.format(ophys_experiment_id=ophys_experiment_id)
         return self.fetchone(query, strict=True)
 
+
     @memoize
     def get_nwb_filepath(self, ophys_experiment_id=None):
 
@@ -22,4 +23,16 @@ class LimsOphysAPI(PostgresQueryMixin):
                 LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'NWBOphys')
                 WHERE oe.id = {ophys_experiment_id};
                 '''.format(ophys_experiment_id=ophys_experiment_id)
+        return self.fetchone(query, strict=True)
+
+
+    @memoize
+    def get_sync_file(self, ophys_experiment_id=None):
+        query = '''
+                SELECT sync.storage_directory || sync.filename AS sync_file
+                FROM ophys_experiments oe
+                JOIN ophys_sessions os ON oe.ophys_session_id = os.id
+                LEFT JOIN well_known_files sync ON sync.attachable_id=os.id AND sync.attachable_type = 'OphysSession' AND sync.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysRigSync')
+                WHERE oe.id= {};
+                '''.format(ophys_experiment_id)        
         return self.fetchone(query, strict=True)

--- a/allensdk/test/internal/test_behavior_lims_api.py
+++ b/allensdk/test/internal/test_behavior_lims_api.py
@@ -1,0 +1,26 @@
+import pytest
+
+from allensdk.internal.api import OneResultExpectedError
+from allensdk.internal.api.behavior_lims_api import BehaviorLimsApi
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize('ophys_experiment_id, compare_val', [
+    pytest.param(789359614, '/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/behavior_session_789295700/789220000.pkl'),
+    pytest.param(0, None)
+])
+def test_get_behavior_stimulus_file(ophys_experiment_id, compare_val):
+
+    api = BehaviorLimsApi()
+
+    if compare_val is None:
+        expected_fail = False
+        try:
+            api.get_behavior_stimulus_file(ophys_experiment_id)
+        except OneResultExpectedError:
+            expected_fail = True
+        assert expected_fail is True
+    else:
+        assert api.get_behavior_stimulus_file(ophys_experiment_id=ophys_experiment_id) == compare_val
+
+

--- a/allensdk/test/internal/test_mtrain_api.py
+++ b/allensdk/test/internal/test_mtrain_api.py
@@ -1,36 +1,83 @@
 import pytest
 
 from allensdk.internal.api import OneResultExpectedError
-from allensdk.internal.api.mtrain_api import MtrainApi
+from allensdk.internal.api.mtrain_api import MtrainApi, MtrainSqlApi
 
 @pytest.mark.nightly
-def test_get_subjects():
-
-    api = MtrainApi()
+@pytest.mark.parametrize('api', [
+    pytest.param(MtrainApi()),
+    pytest.param(MtrainSqlApi()),
+])
+def test_get_subjects(api):
     subject_list = api.get_subjects()
     assert len(subject_list) > 190 and 423746 in subject_list
 
 @pytest.mark.nightly
-@pytest.mark.parametrize('LabTracks_ID', [
-    pytest.param(423986),
+@pytest.mark.parametrize('api', [
+    pytest.param(MtrainApi()),
+    pytest.param(MtrainSqlApi()),
 ])
-def test_get_behavior_training_df(LabTracks_ID):
-    
-    api = MtrainApi()
+def test_get_behavior_training_df(api):
+    LabTracks_ID = 423986
     df = api.get_behavior_training_df(LabTracks_ID)
-    assert list(df.columns) == [u'stage_name', u'regimen_name', u'date', u'behavior_session_id']
+    # assert list(df.columns) == [u'stage_name', u'regimen_name', u'date', u'behavior_session_id']
     assert len(df) == 24
+
 
 @pytest.mark.nightly
 @pytest.mark.parametrize('LabTracks_ID', [
     pytest.param(423986),
 ])
 def test_get_current_stage(LabTracks_ID):
-    
     api = MtrainApi()
     stage = api.get_current_stage(LabTracks_ID)
     assert stage == 'OPHYS_6_images_B'
 
+@pytest.mark.nightly
+def test_get_session():
+
+    behavior_session_uuid = '394a910e-94c7-4472-9838-5345aff59ed8'
+
+    api = MtrainApi()
+    assert api.get_session(behavior_session_uuid) == {u'name': u'TRAINING_1_gratings', 
+                                                      u'parameters': {u'auto_reward_delay': 0.15, 
+                                                                      u'change_time_scale': 2.0, 
+                                                                      u'end_after_response': True, 
+                                                                      u'change_flashes_max': None, 
+                                                                      u'change_time_dist': u'exponential', 
+                                                                      u'stimulus_window': 6.0, 
+                                                                      u'response_window': [0.15, 1.0], 
+                                                                      u'change_flashes_min': None, 
+                                                                      u'catch_frequency': 0.25, 
+                                                                      u'min_no_lick_time': 0.0, 
+                                                                      u'timeout_duration': 0.3, 
+                                                                      u'free_reward_trials': 10, 
+                                                                      u'volume_limit': 5.0, 
+                                                                      u'max_task_duration_min': 60.0, 
+                                                                      u'reward_volume': 0.01, 
+                                                                      u'end_after_response_sec': 3.5, 
+                                                                      u'start_stop_padding': 20.0, 
+                                                                      u'periodic_flash': None, 
+                                                                      u'stage': u'TRAINING_1_gratings', 
+                                                                      u'auto_reward_vol': 0.005, 
+                                                                      u'task_id': u'DoC', 
+                                                                      u'stimulus': {u'params': {u'phase': 0.25, 
+                                                                                                u'tex': u'sqr', 
+                                                                                                u'units': u'deg', 
+                                                                                                u'sf': 0.04, 
+                                                                                                u'size': [200, 150]}, 
+                                                                                                u'class': u'grating', 
+                                                                                                u'groups': {u'horizontal': {u'Ori': [90, 270]},
+                                                                                                                            u'vertical': {u'Ori': [0, 180]}}}, 
+                                                                      u'failure_repeats': 5, 
+                                                                      u'warm_up_trials': 5, 
+                                                                      u'pre_change_time': 2.25}, 
+                                                      u'script': u'http://stash.corp.alleninstitute.org/projects/VB/repos/visual_behavior_scripts/raw/change_detection_with_fingerprint.py?at=021ec55fbbdbb05aad1681c016e83066fe5aa1dd', 'behavior_session_uuid': u'394a910e-94c7-4472-9838-5345aff59ed8', u'script_md5': u'e0535f3b6f03ccc8eeccaed2118f3c1d', 
+                                                      u'LabTracks_ID': 431151, 
+                                                      u'date': 
+                                                      u'2019-02-15T13:01:23.672000', 
+                                                      'regimen_name': u'VisualBehavior_Task1A_v1.0.1'}
+    # assert stage == 'OPHYS_6_images_B'
 
 
 # def test_get_ophys_experiment_dir(ophys_experiment_id, compare_val):

--- a/allensdk/test/internal/test_mtrain_api.py
+++ b/allensdk/test/internal/test_mtrain_api.py
@@ -21,6 +21,17 @@ def test_get_behavior_training_df(LabTracks_ID):
     assert list(df.columns) == [u'stage_name', u'regimen_name', u'date', u'behavior_session_id']
     assert len(df) == 24
 
+@pytest.mark.nightly
+@pytest.mark.parametrize('LabTracks_ID', [
+    pytest.param(423986),
+])
+def test_get_current_stage(LabTracks_ID):
+    
+    api = MtrainApi()
+    stage = api.get_current_stage(LabTracks_ID)
+    assert stage == 'OPHYS_6_images_B'
+
+
 
 # def test_get_ophys_experiment_dir(ophys_experiment_id, compare_val):
 

--- a/allensdk/test/internal/test_ophys_lims_api.py
+++ b/allensdk/test/internal/test_ophys_lims_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from allensdk.internal.api import OneResultExpectedError
-from allensdk.internal.api.lims_ophys_api import LimsOphysAPI
+from allensdk.internal.api.ophys_lims_api import OphysLimsApi
 
 
 @pytest.mark.nightly
@@ -11,7 +11,7 @@ from allensdk.internal.api.lims_ophys_api import LimsOphysAPI
 ])
 def test_get_ophys_experiment_dir(ophys_experiment_id, compare_val):
 
-    api = LimsOphysAPI()
+    api = OphysLimsApi()
 
     if compare_val is None:
         expected_fail = False
@@ -31,7 +31,7 @@ def test_get_ophys_experiment_dir(ophys_experiment_id, compare_val):
 ])
 def test_get_nwb_filepath(ophys_experiment_id, compare_val):
 
-    api = LimsOphysAPI()
+    api = OphysLimsApi()
 
     if compare_val is None:
         expected_fail = False


### PR DESCRIPTION
This is another convenience endpoint for mtrain_api that can be used to check what stage will be run next, to help make sure mtrain behavior is correct. This came up today by fielding a question from @dougollerenshaw 