### PR TITLE
Fix readthedocs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # The Allen SDK
 
 [![Join the chat at https://gitter.im/AllenInstitute/AllenSDK](https://badges.gitter.im/AllenInstitute/AllenSDK.svg)](https://gitter.im/AllenInstitute/AllenSDK?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Documentation Status](https://readthedocs.org/projects/allensdk/badge/?version=latest)](https://allensdk.readthedocs.io/en/latest/?badge=latest)
+
 
 This repository contains code for processing and analyzing data
 in the [Allen Brain Atlas](http://brain-map.org/).

--- a/allensdk/config/app/application_config.py
+++ b/allensdk/config/app/application_config.py
@@ -40,6 +40,7 @@ import io
 import logging
 import logging.config as lc
 from pkg_resources import resource_filename  # @UnresolvedImport
+
 try:
     from configparser import ConfigParser  # @UnresolvedImport
 except:
@@ -55,19 +56,20 @@ class ApplicationConfig(object):
     _log = logging.getLogger(__name__)
     _DEFAULT_LOG_CONFIG = os.getenv(
         'LOG_CFG', resource_filename(__name__, 'logging.conf'))
-    lc.fileConfig(_DEFAULT_LOG_CONFIG)
 
     def __init__(self,
                  defaults,
                  name="app",
                  halp="Run application.",
                  default_log_config=None):
+
         self.application_name = name
         self.help = halp
         self.debug_enabled = False
 
         if default_log_config is None:
             default_log_config = ApplicationConfig._DEFAULT_LOG_CONFIG
+            lc.fileConfig(_DEFAULT_LOG_CONFIG)
 
         ApplicationConfig._log.info(
             "default log config: %s" % (default_log_config))

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,3 +4,7 @@ pylint>=1.5.4
 numpydoc>=0.6.0
 jupyter>=1.0.0
 matplotlib>=1.4.3
+simplejson
+h5py
+pandas
+scipy

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -9,6 +9,6 @@ h5py
 pandas
 scipy
 requests_toolbelt
-nrrd
+pynrrd
 SimpleITK
 scikit-image

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -8,3 +8,7 @@ simplejson
 h5py
 pandas
 scipy
+requests_toolbelt
+nrrd
+SimpleITK
+scikit-image

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,3 +3,4 @@ flake8>=1.5.0
 pylint>=1.5.4
 numpydoc>=0.6.0
 jupyter>=1.0.0
+matplotlib>=1.4.3

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -12,3 +12,4 @@ requests_toolbelt
 pynrrd
 SimpleITK
 scikit-image
+statsmodels


### PR DESCRIPTION
The readthedocs build was broken largely because dependencies needed to read the source code were not installed.  Unclear why this changed 4m ago.  Working now.