### PR TITLE
Resolve 464 use WFK locations for api: demixed_traces, maxInt_a13a, input_extract_traces

### DIFF
--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -237,8 +237,9 @@ class OphysLimsApi(PostgresQueryMixin):
     @memoize
     def get_demix_file(self, ophys_experiment_id=None):
         query = '''
-                SELECT oe.storage_directory || 'demix/' || oe.id || '_demixed_traces.h5' AS demix_file
+                SELECT wkf.storage_directory || wkf.filename AS demix_file
                 FROM ophys_experiments oe
+                LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.attachable_type = 'OphysExperiment' AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'DemixedTracesFile')
                 WHERE oe.id= {};
                 '''.format(ophys_experiment_id)        
         return self.fetchone(query, strict=True)

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -209,8 +209,9 @@ class OphysLimsApi(PostgresQueryMixin):
     @memoize
     def get_input_extract_traces_file(self, ophys_experiment_id=None):
         query = '''
-                SELECT oe.storage_directory || 'processed/' || oe.id || '_input_extract_traces.json'
+                SELECT wkf.storage_directory || wkf.filename AS input_extract_traces_file
                 FROM ophys_experiments oe
+                LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.attachable_type = 'OphysExperiment' AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysExtractedTracesInputJson')
                 WHERE oe.id= {};
                 '''.format(ophys_experiment_id)        
         return self.fetchone(query, strict=True)

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -47,16 +47,18 @@ class OphysLimsApi(PostgresQueryMixin):
                 '''.format(ophys_experiment_id)        
         return self.fetchone(query, strict=True)
 
+
     @memoize
     def get_maxint_file(self, ophys_experiment_id=None):
         query = '''
-                SELECT obj.storage_directory || 'maxInt_a13a.png' AS maxint_file
+                SELECT wkf.storage_directory || wkf.filename AS maxint_file
                 FROM ophys_experiments oe
                 LEFT JOIN ophys_cell_segmentation_runs ocsr ON ocsr.ophys_experiment_id = oe.id AND ocsr.current = 't'
-                LEFT JOIN well_known_files obj ON obj.attachable_id=ocsr.id AND obj.attachable_type = 'OphysCellSegmentationRun' AND obj.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysSegmentationObjects')
+                LEFT JOIN well_known_files wkf ON wkf.attachable_id=ocsr.id AND wkf.attachable_type = 'OphysCellSegmentationRun' AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysMaxIntImage')
                 WHERE oe.id= {};
-                '''.format(ophys_experiment_id)        
+                '''.format(ophys_experiment_id)
         return self.fetchone(query, strict=True)
+
 
     @memoize
     def get_max_projection(self, ophys_experiment_id=None):

--- a/allensdk/test/internal/test_ophys_lims_api.py
+++ b/allensdk/test/internal/test_ophys_lims_api.py
@@ -16,6 +16,7 @@ def api_data():
                        'maxint_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/ophys_cell_segmentation_run_814561221/maxInt_a13a.png',
                        'avgint_a1X_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/ophys_cell_segmentation_run_814561221/avgInt_a1X.png',
                        'rigid_motion_transform_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/702134928_rigid_motion_transform.csv',
+                       'input_extract_traces_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/702134928_input_extract_traces.json',
                        'targeted_structure':'VISal',
                        'imaging_depth':175,
                        'stimulus_name':None,
@@ -54,6 +55,17 @@ def test_get_ophys_experiment_dir(ophys_experiment_id, api_data, ophys_lims_api)
 def test_get_demix_file(ophys_experiment_id, api_data, ophys_lims_api):
     f = ophys_lims_api.get_demix_file
     key = 'demix_file'
+    if ophys_experiment_id in api_data:
+        assert f(ophys_experiment_id=ophys_experiment_id) == api_data[ophys_experiment_id][key]
+    else:
+        expected_fail(f, ophys_experiment_id=ophys_experiment_id)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize('ophys_experiment_id', [702134928, 0])
+def test_get_input_extract_traces_file(ophys_experiment_id, api_data, ophys_lims_api):
+    f = ophys_lims_api.get_input_extract_traces_file
+    key = 'input_extract_traces_file'
     if ophys_experiment_id in api_data:
         assert f(ophys_experiment_id=ophys_experiment_id) == api_data[ophys_experiment_id][key]
     else:

--- a/allensdk/test/internal/test_ophys_lims_api.py
+++ b/allensdk/test/internal/test_ophys_lims_api.py
@@ -13,6 +13,7 @@ def api_data():
      return {702134928:
                       {'ophys_dir':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/',
                        'demix_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/demix/702134928_demixed_traces.h5',
+                       'maxint_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/ophys_cell_segmentation_run_814561221/maxInt_a13a.png',
                        'avgint_a1X_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/ophys_cell_segmentation_run_814561221/avgInt_a1X.png',
                        'rigid_motion_transform_file':'/allen/programs/braintv/production/neuralcoding/prod0/specimen_652073919/ophys_session_702013508/ophys_experiment_702134928/processed/702134928_rigid_motion_transform.csv',
                        'targeted_structure':'VISal',
@@ -53,6 +54,17 @@ def test_get_ophys_experiment_dir(ophys_experiment_id, api_data, ophys_lims_api)
 def test_get_demix_file(ophys_experiment_id, api_data, ophys_lims_api):
     f = ophys_lims_api.get_demix_file
     key = 'demix_file'
+    if ophys_experiment_id in api_data:
+        assert f(ophys_experiment_id=ophys_experiment_id) == api_data[ophys_experiment_id][key]
+    else:
+        expected_fail(f, ophys_experiment_id=ophys_experiment_id)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize('ophys_experiment_id', [702134928, 0])
+def test_get_maxint_file(ophys_experiment_id, api_data, ophys_lims_api):
+    f = ophys_lims_api.get_maxint_file
+    key = 'maxint_file'
     if ophys_experiment_id in api_data:
         assert f(ophys_experiment_id=ophys_experiment_id) == api_data[ophys_experiment_id][key]
     else:


### PR DESCRIPTION
maxInt_a13a input_extract_traces  didn't have a unit test, added these too