### PR TITLE
Store all running signals in nwb file

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -1,7 +1,9 @@
 import datetime
 from pynwb import NWBFile, NWBHDF5IO
 import pandas as pd
-from allensdk.brain_observatory.nwb import add_running_speed_to_nwbfile
+from allensdk.brain_observatory.nwb import add_running_data_df_to_nwbfile
+from allensdk.brain_observatory import RunningSpeed
+
 
 class BehaviorOphysNwbApi(object):
 
@@ -18,24 +20,31 @@ class BehaviorOphysNwbApi(object):
             file_create_date=datetime.datetime.now()
         )
 
-        unit_dict = {'v_sig':'V', 'v_in':'V', 'speed':'cm/S', 'time':'S', 'dx':'cm'}
-        add_running_speed_to_nwbfile(nwbfile, session_object.running_data_df, unit_dict)
-
+        unit_dict = {'v_sig': 'V', 'v_in': 'V', 'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
+        add_running_data_df_to_nwbfile(nwbfile, session_object.running_data_df, unit_dict)
 
         with NWBHDF5IO(self.nwb_filepath, 'w') as nwb_file_writer:
             nwb_file_writer.write(nwbfile)
-
 
     def get_running_data_df(self, ophys_experiment_id=None, **kwargs):
         with NWBHDF5IO(self.nwb_filepath, 'r') as nwb_file_reader:
             obtained = nwb_file_reader.read()
 
-            return pd.DataFrame({'v_sig':obtained.get_acquisition('v_sig').data.value,
-                                 'v_in':obtained.get_acquisition('v_in').data.value})
+            print (obtained.acquisition)
+            print (obtained.analysis)
+            raise
 
+            return pd.DataFrame({'v_sig': obtained.get_acquisition('v_sig').data.value,
+                                 'v_in': obtained.get_acquisition('v_in').data.value})
 
-    def get_metadata(ophys_experiment_id=None, **kwargs):
+    def get_metadata(self, ophys_experiment_id=None, **kwargs):
         pass
+
+    def get_running_speed(self, ophys_experiment_id=None, **kwargs):
+        
+        running_data_df = self.get_running_data_df(ophys_experiment_id=ophys_experiment_id, **kwargs)
+        return RunningSpeed(timestamps=running_data_df.index.values,
+                            values=running_data_df.speed.values)
 
 
         # stimulus_timestamps = self.get_stimulus_timestamps(ophys_experiment_id=ophys_experiment_id, use_acq_trigger=use_acq_trigger)

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -17,7 +17,8 @@ class BehaviorOphysNwbApi(object):
             file_create_date=datetime.datetime.now()
         )
 
-        add_running_speed_to_nwbfile(nwbfile, session_object.running_speed)
+        unit_dict = {'v_sig':'V', 'v_in':'V', 'speed':'cm/S', 'time':'S', 'dx':'cm'}
+        add_running_speed_to_nwbfile(nwbfile, session_object.running_data_df, unit_dict)
 
 
         with NWBHDF5IO(self.nwb_filepath, 'w') as nwb_file_writer:

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -1,0 +1,24 @@
+import datetime
+from pynwb import NWBFile, NWBHDF5IO
+from allensdk.brain_observatory.nwb import add_running_speed_to_nwbfile
+
+class BehaviorOphysNwbApi(object):
+
+    def __init__(self, nwb_filepath):
+
+        self.nwb_filepath = nwb_filepath
+
+    def save(self, session_object):
+
+        nwbfile = NWBFile(
+            session_description='test foraging2',
+            identifier='behavior_session_uuid',
+            session_start_time=datetime.datetime.now(),
+            file_create_date=datetime.datetime.now()
+        )
+
+        add_running_speed_to_nwbfile(nwbfile, session_object.running_speed)
+
+
+        with NWBHDF5IO(self.nwb_filepath, 'w') as nwb_file_writer:
+            nwb_file_writer.write(nwbfile)

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -1,5 +1,6 @@
 import datetime
 from pynwb import NWBFile, NWBHDF5IO
+import pandas as pd
 from allensdk.brain_observatory.nwb import add_running_speed_to_nwbfile
 
 class BehaviorOphysNwbApi(object):
@@ -11,9 +12,9 @@ class BehaviorOphysNwbApi(object):
     def save(self, session_object):
 
         nwbfile = NWBFile(
-            session_description='test foraging2',
-            identifier='behavior_session_uuid',
-            session_start_time=datetime.datetime.now(),
+            session_description=str(session_object.metadata['session_type']),
+            identifier=str(session_object.metadata['behavior_session_uuid']),
+            session_start_time=session_object.metadata['experiment_date'],
             file_create_date=datetime.datetime.now()
         )
 
@@ -23,3 +24,25 @@ class BehaviorOphysNwbApi(object):
 
         with NWBHDF5IO(self.nwb_filepath, 'w') as nwb_file_writer:
             nwb_file_writer.write(nwbfile)
+
+
+    def get_running_data_df(self, ophys_experiment_id=None, **kwargs):
+        with NWBHDF5IO(self.nwb_filepath, 'r') as nwb_file_reader:
+            obtained = nwb_file_reader.read()
+
+            return pd.DataFrame({'v_sig':obtained.get_acquisition('v_sig').data.value,
+                                 'v_in':obtained.get_acquisition('v_in').data.value})
+
+
+    def get_metadata(ophys_experiment_id=None, **kwargs):
+        pass
+
+
+        # stimulus_timestamps = self.get_stimulus_timestamps(ophys_experiment_id=ophys_experiment_id, use_acq_trigger=use_acq_trigger)
+        # behavior_stimulus_file = self.get_behavior_stimulus_file(ophys_experiment_id=ophys_experiment_id)
+        # data = pd.read_pickle(behavior_stimulus_file)
+        # return get_running_df(data, stimulus_timestamps)
+
+    # def get_running_speed(self, ophys_experiment_id=None):
+    #     running_data_df = self.get_running_data_df(ophys_experiment_id=ophys_experiment_id)
+    #     return running_data_df.time.values, running_data_df.speed.values

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -30,12 +30,11 @@ class BehaviorOphysNwbApi(object):
         with NWBHDF5IO(self.nwb_filepath, 'r') as nwb_file_reader:
             obtained = nwb_file_reader.read()
 
-            print (obtained.acquisition)
-            print (obtained.analysis)
-            raise
-
             return pd.DataFrame({'v_sig': obtained.get_acquisition('v_sig').data.value,
-                                 'v_in': obtained.get_acquisition('v_in').data.value})
+                                 'v_in': obtained.get_acquisition('v_in').data.value,
+                                 'speed': obtained.modules['running'].get_data_interface('speed').data.value,
+                                 'dx': obtained.modules['running'].get_data_interface('dx').data.value},
+                                index=pd.Index(obtained.modules['running'].get_data_interface('timestamps').timestamps.value, name='timestamps'))
 
     def get_metadata(self, ophys_experiment_id=None, **kwargs):
         pass

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -5,6 +5,7 @@ from pandas.util.testing import assert_frame_equal
 from allensdk.core.lazy_property import LazyProperty, LazyPropertyMixin
 from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
 
+
 class BehaviorOphysSession(LazyPropertyMixin):
 
     def __init__(self, ophys_experiment_id, api=None, use_acq_trigger=False):
@@ -60,7 +61,7 @@ class BehaviorOphysSession(LazyPropertyMixin):
         except NotImplementedError as e:
             self_implements_get_field = hasattr(self.api, getattr(type(self), field).getter_name)
             other_implements_get_field = hasattr(other.api, getattr(type(other), field).getter_name)
-            assert self_implements_get_field == other_implements_get_field == False
+            assert self_implements_get_field == other_implements_get_field is False
 
         except (AssertionError, AttributeError) as e:
             return False
@@ -71,17 +72,15 @@ class BehaviorOphysSession(LazyPropertyMixin):
 if __name__ == "__main__":
 
     session = BehaviorOphysSession(789359614)
+    print(session.running_speed)
 
     from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi
     nwb_filepath = './tmp.nwb'
     nwb_api = BehaviorOphysNwbApi(nwb_filepath)
     nwb_api.save(session)
 
-
-    session = BehaviorOphysSession(789359614, api=nwb_api)
-    print session.running_data_df
-
-
+    # session = BehaviorOphysSession(789359614, api=nwb_api)
+    # print(session.running_data_df)
 
     # print session.max_projection
     # print session.stimulus_timestamps

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -68,6 +68,15 @@ class BehaviorOphysSession(LazyPropertyMixin):
 if __name__ == "__main__":
 
     session = BehaviorOphysSession(789359614)
+
+    from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi
+    nwb_filepath = './tmp.nwb'
+    nwb_api = BehaviorOphysNwbApi(nwb_filepath)
+    nwb_api.save(session)
+
+
+
+
     # print session.max_projection
     # print session.stimulus_timestamps
     # print session.ophys_timestamps

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -78,6 +78,9 @@ if __name__ == "__main__":
     nwb_api.save(session)
 
 
+    session = BehaviorOphysSession(789359614, api=nwb_api)
+    print session.running_data_df
+
 
 
     # print session.max_projection

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -20,6 +20,7 @@ class BehaviorOphysSession(LazyPropertyMixin):
         self.dff_traces = LazyProperty(self.api.get_dff_traces, ophys_experiment_id=self.ophys_experiment_id, use_acq_trigger=self.use_acq_trigger)
         self.roi_metrics = LazyProperty(self.api.get_roi_metrics, ophys_experiment_id=self.ophys_experiment_id)
         self.cell_roi_ids = LazyProperty(self.api.get_cell_roi_ids, ophys_experiment_id=self.ophys_experiment_id)
+        self.running_data_df = LazyProperty(self.api.get_running_data_df, ophys_experiment_id=self.ophys_experiment_id, use_acq_trigger=self.use_acq_trigger)
         self.running_speed = LazyProperty(self.api.get_running_speed, ophys_experiment_id=self.ophys_experiment_id, use_acq_trigger=self.use_acq_trigger)
         self.stimulus_table = LazyProperty(self.api.get_stimulus_table, ophys_experiment_id=self.ophys_experiment_id, use_acq_trigger=self.use_acq_trigger)
         self.stimulus_template = LazyProperty(self.api.get_stimulus_template, ophys_experiment_id=self.ophys_experiment_id)
@@ -51,6 +52,8 @@ class BehaviorOphysSession(LazyPropertyMixin):
                     np.testing.assert_array_almost_equal(x1, x2)
                 elif isinstance(x1, (dict, list)):
                     assert x1 == x2
+                elif isinstance(x1, (tuple,)):
+                    [np.testing.assert_array_almost_equal(x1i, x2i) for x1i, x2i in zip(x1, x2)]
                 else:
                     raise Exception('Comparator not implemented')
 
@@ -85,6 +88,7 @@ if __name__ == "__main__":
     # print session.roi_metrics
     # print session.cell_roi_ids
     # print session.running_speed
+    # print session.running_data_df
     # print session.stimulus_table
     # print session.stimulus_template
     # print session.stimulus_metadata

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -72,15 +72,15 @@ class BehaviorOphysSession(LazyPropertyMixin):
 if __name__ == "__main__":
 
     session = BehaviorOphysSession(789359614)
-    print(session.running_speed)
 
     from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi
     nwb_filepath = './tmp.nwb'
     nwb_api = BehaviorOphysNwbApi(nwb_filepath)
     nwb_api.save(session)
 
-    # session = BehaviorOphysSession(789359614, api=nwb_api)
+    session = BehaviorOphysSession(789359614, api=nwb_api)
     # print(session.running_data_df)
+    print(session.running_speed)
 
     # print session.max_projection
     # print session.stimulus_timestamps

--- a/allensdk/brain_observatory/behavior/running_processing.py
+++ b/allensdk/brain_observatory/behavior/running_processing.py
@@ -34,7 +34,6 @@ def get_running_df(data, time):
     speed = deg_to_dist(speed)
     return pd.DataFrame({
         'time': time,
-        'frame': range(len(time)),
         'speed': speed,
         'dx': dx_raw,
         'v_sig': v_sig,

--- a/allensdk/brain_observatory/behavior/running_processing.py
+++ b/allensdk/brain_observatory/behavior/running_processing.py
@@ -33,9 +33,8 @@ def get_running_df(data, time):
     speed = calc_deriv(dx, time)  # speed in degrees/s
     speed = deg_to_dist(speed)
     return pd.DataFrame({
-        'time': time,
         'speed': speed,
         'dx': dx_raw,
         'v_sig': v_sig,
         'v_in': v_in,
-    })
+    }, index=pd.Index(time, name='timestamps'))

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -1,0 +1,68 @@
+from pynwb.base import TimeSeries
+from pynwb.behavior import BehavioralTimeSeries
+
+def add_running_speed_to_nwbfile(nwbfile, running_df, unit='cm/s'):
+    ''' Adds running speed data to an NWBFile as timeseries in acquisition and processing
+
+    Parameters
+    ----------
+    nwbfile : pynwb.NWBFile
+        File to which runnign speeds will be written
+    running_speed : pandas.DataFrame
+        Contains 'speed' and 'times', 'v_in', 'vsig', 'dx'
+    unit : str, optional
+        SI units of running speed values
+
+    Returns
+    -------
+    nwbfile : pynwb.NWBFile
+
+    '''
+
+    # print running_df.columns
+
+    timestamps_ts = TimeSeries(
+        name='running_speed_timestamps',
+        timestamps=running_df['time'].values, 
+        unit=unit
+    )
+
+    running_dx_series = TimeSeries(
+        name='running_dx',
+        data=running_df['dx'].values, 
+        timestamps=timestamps_ts, 
+        unit=unit
+    )
+
+    running_speed_series = TimeSeries(
+        name='running_speed',
+        data=running_df['speed'].values, 
+        timestamps=timestamps_ts, 
+        unit=unit
+    )
+
+    v_sig = TimeSeries(
+        name='v_sig',
+        data=running_df['v_sig'].values, 
+        timestamps=timestamps_ts, 
+        unit=unit
+    )
+
+    v_in = TimeSeries(
+        name='v_in',
+        data=running_df['v_in'].values, 
+        timestamps=timestamps_ts, 
+        unit=unit
+    )
+
+    running_bts = BehavioralTimeSeries()
+    nwbfile.add_analysis(running_bts)
+
+    running_bts.add_timeseries(timestamps_ts)
+    running_bts.add_timeseries(running_speed_series)
+    running_bts.add_timeseries(running_dx_series)
+
+    nwbfile.add_acquisition(v_sig)
+    nwbfile.add_acquisition(v_in)
+
+    return nwbfile

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -1,7 +1,7 @@
 from pynwb.base import TimeSeries
 from pynwb.behavior import BehavioralTimeSeries
 
-def add_running_speed_to_nwbfile(nwbfile, running_df, unit_dict):
+def add_running_data_df_to_nwbfile(nwbfile, running_data_df, unit_dict):
     ''' Adds running speed data to an NWBFile as timeseries in acquisition and processing
 
     Parameters
@@ -18,42 +18,44 @@ def add_running_speed_to_nwbfile(nwbfile, running_df, unit_dict):
     nwbfile : pynwb.NWBFile
 
     '''
+    assert running_data_df.index.name == 'timestamps'
+
 
     timestamps_ts = TimeSeries(
-        name='running_speed_timestamps',
-        timestamps=running_df['time'].values, 
-        unit=unit_dict['time']
+        name='timestamps',
+        timestamps=running_data_df.index.values,
+        unit=unit_dict['timestamps']
     )
 
     running_dx_series = TimeSeries(
-        name='running_dx',
-        data=running_df['dx'].values, 
+        name='dx',
+        data=running_data_df['dx'].values,
         timestamps=timestamps_ts, 
         unit=unit_dict['dx']
     )
 
     running_speed_series = TimeSeries(
-        name='running_speed',
-        data=running_df['speed'].values, 
+        name='speed',
+        data=running_data_df['speed'].values,
         timestamps=timestamps_ts, 
         unit=unit_dict['speed']
     )
 
     v_sig = TimeSeries(
         name='v_sig',
-        data=running_df['v_sig'].values, 
+        data=running_data_df['v_sig'].values,
         timestamps=timestamps_ts, 
         unit=unit_dict['v_sig']
     )
 
     v_in = TimeSeries(
         name='v_in',
-        data=running_df['v_in'].values, 
+        data=running_data_df['v_in'].values,
         timestamps=timestamps_ts, 
         unit=unit_dict['v_in']
     )
 
-    running_bts = BehavioralTimeSeries()
+    running_bts = BehavioralTimeSeries(name='running')
     nwbfile.add_analysis(running_bts)
 
     running_bts.add_timeseries(timestamps_ts)

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -1,7 +1,7 @@
 from pynwb.base import TimeSeries
 from pynwb.behavior import BehavioralTimeSeries
 
-def add_running_speed_to_nwbfile(nwbfile, running_df, unit='cm/s'):
+def add_running_speed_to_nwbfile(nwbfile, running_df, unit_dict):
     ''' Adds running speed data to an NWBFile as timeseries in acquisition and processing
 
     Parameters
@@ -19,40 +19,38 @@ def add_running_speed_to_nwbfile(nwbfile, running_df, unit='cm/s'):
 
     '''
 
-    # print running_df.columns
-
     timestamps_ts = TimeSeries(
         name='running_speed_timestamps',
         timestamps=running_df['time'].values, 
-        unit=unit
+        unit=unit_dict['time']
     )
 
     running_dx_series = TimeSeries(
         name='running_dx',
         data=running_df['dx'].values, 
         timestamps=timestamps_ts, 
-        unit=unit
+        unit=unit_dict['dx']
     )
 
     running_speed_series = TimeSeries(
         name='running_speed',
         data=running_df['speed'].values, 
         timestamps=timestamps_ts, 
-        unit=unit
+        unit=unit_dict['speed']
     )
 
     v_sig = TimeSeries(
         name='v_sig',
         data=running_df['v_sig'].values, 
         timestamps=timestamps_ts, 
-        unit=unit
+        unit=unit_dict['v_sig']
     )
 
     v_in = TimeSeries(
         name='v_in',
         data=running_df['v_in'].values, 
         timestamps=timestamps_ts, 
-        unit=unit
+        unit=unit_dict['v_in']
     )
 
     running_bts = BehavioralTimeSeries()

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -1,5 +1,6 @@
 from pynwb.base import TimeSeries
 from pynwb.behavior import BehavioralTimeSeries
+from pynwb import ProcessingModule
 
 def add_running_data_df_to_nwbfile(nwbfile, running_data_df, unit_dict):
     ''' Adds running speed data to an NWBFile as timeseries in acquisition and processing
@@ -30,14 +31,14 @@ def add_running_data_df_to_nwbfile(nwbfile, running_data_df, unit_dict):
     running_dx_series = TimeSeries(
         name='dx',
         data=running_data_df['dx'].values,
-        timestamps=timestamps_ts, 
+        timestamps=timestamps_ts,
         unit=unit_dict['dx']
     )
 
     running_speed_series = TimeSeries(
         name='speed',
         data=running_data_df['speed'].values,
-        timestamps=timestamps_ts, 
+        timestamps=timestamps_ts,
         unit=unit_dict['speed']
     )
 
@@ -51,16 +52,16 @@ def add_running_data_df_to_nwbfile(nwbfile, running_data_df, unit_dict):
     v_in = TimeSeries(
         name='v_in',
         data=running_data_df['v_in'].values,
-        timestamps=timestamps_ts, 
+        timestamps=timestamps_ts,
         unit=unit_dict['v_in']
     )
 
-    running_bts = BehavioralTimeSeries(name='running')
-    nwbfile.add_analysis(running_bts)
+    running_mod = ProcessingModule('running', 'Running speed processing module')
+    nwbfile.add_processing_module(running_mod)
 
-    running_bts.add_timeseries(timestamps_ts)
-    running_bts.add_timeseries(running_speed_series)
-    running_bts.add_timeseries(running_dx_series)
+    running_mod.add_data_interface(timestamps_ts)
+    running_mod.add_data_interface(running_speed_series)
+    running_mod.add_data_interface(running_dx_series)
 
     nwbfile.add_acquisition(v_sig)
     nwbfile.add_acquisition(v_in)

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -111,11 +111,16 @@ class BehaviorOphysLimsApi(OphysLimsApi):
 
 
     @memoize
-    def get_running_speed(self, ophys_experiment_id=None, use_acq_trigger=False):
+    def get_running_data_df(self, ophys_experiment_id=None, use_acq_trigger=False):
         stimulus_timestamps = self.get_stimulus_timestamps(ophys_experiment_id=ophys_experiment_id, use_acq_trigger=use_acq_trigger)
         behavior_stimulus_file = self.get_behavior_stimulus_file(ophys_experiment_id=ophys_experiment_id)
         data = pd.read_pickle(behavior_stimulus_file)
         return get_running_df(data, stimulus_timestamps)
+
+    @memoize
+    def get_running_speed(self, ophys_experiment_id=None, use_acq_trigger=False):
+        running_data_df = self.get_running_data_df(ophys_experiment_id=ophys_experiment_id, use_acq_trigger=use_acq_trigger)
+        return running_data_df.time.values, running_data_df.speed.values
 
 
     @memoize    

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -13,6 +13,7 @@ from allensdk.brain_observatory.behavior.metadata_processing import get_task_par
 from allensdk.brain_observatory.behavior.running_processing import get_running_df
 from allensdk.brain_observatory.behavior.rewards_processing import get_rewards
 from allensdk.brain_observatory.behavior.trials_processing import get_trials
+from allensdk.brain_observatory import RunningSpeed
 
 
 class BehaviorOphysLimsApi(OphysLimsApi):
@@ -75,7 +76,7 @@ class BehaviorOphysLimsApi(OphysLimsApi):
 
     @memoize
     def get_metadata(self, ophys_experiment_id=None, use_acq_trigger=False):
-        
+
         metadata = {}
         metadata['ophys_experiment_id'] = ophys_experiment_id
         metadata['experiment_container_id'] = self.get_experiment_container_id(ophys_experiment_id=ophys_experiment_id)
@@ -94,7 +95,6 @@ class BehaviorOphysLimsApi(OphysLimsApi):
 
         return metadata
 
-
     @memoize
     def get_dff_traces(self, ophys_experiment_id=None, use_acq_trigger=False):
         dff_traces = self.get_raw_dff_data(ophys_experiment_id)
@@ -102,13 +102,11 @@ class BehaviorOphysLimsApi(OphysLimsApi):
         df = pd.DataFrame({'cell_roi_id':cell_roi_id_list, 'dff':list(dff_traces)})
         return df
 
-
     @memoize
     def get_roi_metrics(self, ophys_experiment_id=None):
         input_extract_traces_file = self.get_input_extract_traces_file(ophys_experiment_id=ophys_experiment_id)
         objectlist_file = self.get_objectlist_file(ophys_experiment_id=ophys_experiment_id)
         return get_roi_metrics(input_extract_traces_file, ophys_experiment_id, objectlist_file)['unfiltered']
-
 
     @memoize
     def get_running_data_df(self, ophys_experiment_id=None, use_acq_trigger=False):
@@ -120,7 +118,9 @@ class BehaviorOphysLimsApi(OphysLimsApi):
     @memoize
     def get_running_speed(self, ophys_experiment_id=None, use_acq_trigger=False):
         running_data_df = self.get_running_data_df(ophys_experiment_id=ophys_experiment_id, use_acq_trigger=use_acq_trigger)
-        return running_data_df.time.values, running_data_df.speed.values
+        assert running_data_df.index.name == 'timestamps'
+        return RunningSpeed(timestamps=running_data_df.index.values,
+                            values=running_data_df.speed.values)
 
 
     @memoize    

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -42,7 +42,7 @@ def test_visbeh_ophys_data_set():
     assert len(data_set.corrected_fluorescence_traces) == 269 and list(data_set.corrected_fluorescence_traces.columns) == ['corrected_fluorescence', 'roi_id']
     assert sorted(data_set.stimulus_metadata['image_category'].unique()) == sorted(data_set.stimulus_table['image_category'].unique())
     assert sorted(data_set.stimulus_metadata['image_name'].unique()) == sorted(data_set.stimulus_table['image_name'].unique())
-    np.testing.assert_array_almost_equal(data_set.running_speed['time'], data_set.stimulus_timestamps)
+    np.testing.assert_array_almost_equal(data_set.running_speed[0], data_set.stimulus_timestamps)
     assert len(data_set.cell_roi_ids) == len(data_set.dff_traces)
     assert data_set.average_image.shape == data_set.max_projection.shape
     assert list(data_set.motion_correction.columns) == ['framenumber', 'x', 'y', 'correlation', 'input_x', 'input_y', 'kalman_x', 'kalman_y', 'algorithm', 'type']


### PR DESCRIPTION
Stores:
Acquisition:
- vsig
- vin
Analysis (in a BehaviorTimeSeries module):
- running_speed
- running_dx

Uses shared timestamps

TODO:
- [x] Use named tuple for running_speed Lazy load (this will force python3)
- [ ] ~Finish get_running_speed api method~ Moved to https://github.com/AllenInstitute/AllenSDK/issues/391