### PR TITLE
Resolves #426 Pinned tables version to overcome pip install issue in tables 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ scikit-image>=0.14.0
 scikit-build
 statsmodels>=0.8.0
 simpleitk
-tables
+tables==3.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 h5py>=2.8
 matplotlib>=1.4.3
-numpy>=1.15.1
+numpy==1.15.4
 pandas>=0.23.0
 jinja2>=2.7.3
 scipy>=0.15.1


### PR DESCRIPTION
pip cannot install pytables 3.5.  Pinning this dependency at 3.4.4, until pytables resolves the issue