### PR TITLE
Start 1.0.0.dev(n) versioning on internal branch

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '0.16.1'
+__version__ = '1.0.0.dev0'
 
 try:
     from logging import NullHandler


### PR DESCRIPTION
Just checked with David about this; he is OK with using the versioning system:

```
1.0.0.dev0
1.0.0.dev1
1.0.0.dev2
...
```

For the internal branch, while we work towards the 1.0 release.  A major advantage to this is that a pre-release user can pip install a specific tagged dev version the artifactory pypi server.
