### PR TITLE
Resolve 495 by adding add_stimulus_timestamps

### DIFF
--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -15,7 +15,7 @@ from allensdk.config.manifest import Manifest
 from allensdk.brain_observatory.running_speed import RunningSpeed
 
 from ._schemas import InputSchema, OutputSchema
-from allensdk.brain_observatory.nwb import add_running_speed_to_nwbfile, add_stimulus_presentations
+from allensdk.brain_observatory.nwb import add_running_speed_to_nwbfile, add_stimulus_presentations, add_stimulus_timestamps
 from allensdk.brain_observatory.argschema_utilities import write_or_print_outputs
 
 
@@ -336,6 +336,7 @@ def write_ecephys_nwb(
     )
 
     stimulus_table = read_stimulus_table(stimulus_table_path)
+    nwbfile = add_stimulus_timestamps(nwbfile, stimulus_table['start_time'].values) # TODO: patch until full timestamps are output by stim table module
     nwbfile = add_stimulus_presentations(nwbfile, stimulus_table)
 
     channel_tables = []

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -146,14 +146,7 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_epoch'):
     '''
     stimulus_table = stimulus_table.copy()
 
-    ts = pynwb.base.TimeSeries(
-        name='stimulus_times',
-        timestamps=stimulus_table['start_time'].values,
-        data=stimulus_table['stop_time'].values - stimulus_table['start_time'].values,
-        unit='s',
-        description='start times (timestamps) and durations (data) of stimulus presentation epochs'
-    )
-    nwbfile.add_acquisition(ts)
+    ts = nwbfile.modules['stimulus'].get_data_interface('timestamps')
 
     for colname, series in stimulus_table.items():
         types = set(series.map(type))
@@ -166,5 +159,20 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_epoch'):
 
     container = pynwb.epoch.TimeIntervals.from_dataframe(stimulus_table, 'epochs')
     nwbfile.epochs = container
+
+    return nwbfile
+
+
+def add_stimulus_timestamps(nwbfile, stimulus_timestamps, module_name='stimulus'):
+
+    stimulus_ts = TimeSeries(
+        name='timestamps',
+        timestamps=stimulus_timestamps,
+        unit='s'
+    )
+
+    stim_mod = ProcessingModule(module_name, 'Stimulus Times processing')
+    nwbfile.add_processing_module(stim_mod)
+    stim_mod.add_data_interface(stimulus_ts)
 
     return nwbfile

--- a/allensdk/test/brain_observatory/conftest.py
+++ b/allensdk/test/brain_observatory/conftest.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime
 import pynwb
 import pandas as pd
+import numpy as np
 
 
 @pytest.fixture
@@ -43,3 +44,8 @@ def roundtripper(tmpdir_factory):
 
         return api(nwb_path)
     return f
+
+
+@pytest.fixture
+def stimulus_timestamps():
+    return np.array([1., 2., 3.])

--- a/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
+++ b/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
@@ -31,6 +31,7 @@ def spike_times():
 
 
 def test_add_stimulus_presentations(nwbfile, stimulus_presentations, roundtripper):
+    write_nwb.add_stimulus_timestamps(nwbfile, [0, 1])
     write_nwb.add_stimulus_presentations(nwbfile, stimulus_presentations)
 
     api = roundtripper(nwbfile, EcephysNwbApi)


### PR DESCRIPTION
- [x] Nile need update test_add_stimulus_presentations to use a call like nwb.add_stimulus_timestamps(nwbfile, stimulus_timestamps) before writing the stimulus_presentations table