### PR TITLE
production py36 environment

### DIFF
--- a/.bamboo/deploy_allensdk.sh
+++ b/.bamboo/deploy_allensdk.sh
@@ -18,10 +18,6 @@ conda create -y -${bamboo_VERBOSITY} --prefix ${bamboo_NEXT_PRODUCTION_ENVIRONME
 
 source activate ${bamboo_NEXT_PRODUCTION_ENVIRONMENT}
 
-# needs mpicc to compile with pip
-conda install -y mpi4py 
-conda install -y -c conda-forge opencv
-
 files=( artifacts/*.whl )
 pip install ${files[0]}
 

--- a/.bamboo/deploy_allensdk.sh
+++ b/.bamboo/deploy_allensdk.sh
@@ -1,0 +1,33 @@
+set -eu
+
+export HOME=${bamboo_PRODUCTION_HOME}
+export TMPDIR=${bamboo_PRODUCTION_HOME}/tmp
+export PATH=/allen/aibs/technology/conda/shared/miniconda/bin:$PATH
+
+export CONDA_PATH_BACKUP=${CONDA_PATH_BACKUP:-$PATH}
+export CONDA_PREFIX=${CONDA_PREFIX:-}
+export CONDA_PS1_BACKUP=${CONDA_PS1_BACKUP:-}
+
+export PYTHON_VERSION=${bamboo_PYTHON_VERSION:-"3.6"}
+
+NUM_EXISTING_ENVS=`conda env list | grep ${bamboo_NEXT_PRODUCTION_ENVIRONMENT} | wc -l`
+if [ ${NUM_EXISTING_ENVS} != 0 ] ; then
+    conda remove -y -${bamboo_VERBOSITY} --prefix ${bamboo_NEXT_PRODUCTION_ENVIRONMENT} --all
+fi
+conda create -y -${bamboo_VERBOSITY} --prefix ${bamboo_NEXT_PRODUCTION_ENVIRONMENT} python=$PYTHON_VERSION
+
+source activate ${bamboo_NEXT_PRODUCTION_ENVIRONMENT}
+
+# needs mpicc to compile with pip
+conda install -y mpi4py 
+conda install -y -c conda-forge opencv
+
+pip install -e .
+pip install -r internal_requirements.txt
+
+files=( artifacts/*.whl )
+pip install ${files[0]}
+
+source deactivate
+
+chmod -R 777 ${bamboo_NEXT_PRODUCTION_ENVIRONMENT}

--- a/.bamboo/deploy_allensdk.sh
+++ b/.bamboo/deploy_allensdk.sh
@@ -1,7 +1,7 @@
 set -eu
 
 export HOME=${bamboo_PRODUCTION_HOME}
-export TMPDIR=${bamboo_PRODUCTION_HOME}/tmp
+export TMPDIR=${bamboo_build_working_directory}/tmp
 export PATH=/allen/aibs/technology/conda/shared/miniconda/bin:$PATH
 
 export CONDA_PATH_BACKUP=${CONDA_PATH_BACKUP:-$PATH}
@@ -22,11 +22,10 @@ source activate ${bamboo_NEXT_PRODUCTION_ENVIRONMENT}
 conda install -y mpi4py 
 conda install -y -c conda-forge opencv
 
-pip install -e .
-pip install -r internal_requirements.txt
-
 files=( artifacts/*.whl )
 pip install ${files[0]}
+
+pip install -r internal_requirements.txt
 
 source deactivate
 

--- a/.bamboo/deploy_allensdk.sh
+++ b/.bamboo/deploy_allensdk.sh
@@ -25,8 +25,6 @@ conda install -y -c conda-forge opencv
 files=( artifacts/*.whl )
 pip install ${files[0]}
 
-pip install -r internal_requirements.txt
-
 source deactivate
 
 chmod -R 777 ${bamboo_NEXT_PRODUCTION_ENVIRONMENT}

--- a/internal_requirements.txt
+++ b/internal_requirements.txt
@@ -1,3 +1,3 @@
 pg8000
 deap
-scikit-learn==0.16.0
+scikit-learn>=0.16.0

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,10 @@ def prepend_find_packages(*roots):
 with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()
 
+if os.environ.get('ALLENSDK_INTERNAL_REQUIREMENTS', 'false') == 'true':
+    with open('internal_requirements.txt', 'r') as f:
+        required.extend(f.read().splitlines())
+
 with open('test_requirements.txt', 'r') as f:
     test_required = f.read().splitlines()
 


### PR DESCRIPTION
issue 503

Adds:
- production deploy script for allensdk
- switch for building wheels that include internal requirements

Modifies:
- sklearn internal req is now a minimum

Also see deployment:
http://bamboo.corp.alleninstitute.org/deploy/viewDeploymentProjectEnvironments.action?id=164855836
and build:
http://bamboo.corp.alleninstitute.org/browse/INFN-AIC21