### PR TITLE
explicitly use binary psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2>=2.7
+psycopg2-binary>=2.7
 h5py>=2.8
 matplotlib>=1.4.3
 numpy>=1.15.4


### PR DESCRIPTION
as of the latest psycopg2 release, the binaries are now in a seperate package: psycopg2-binary. This is breaking our internal build on axon.

https://github.com/psycopg/psycopg2/releases/tag/2_8
https://github.com/psycopg/psycopg2/issues/674

Some options:
- switch to pg8000
- pin psycopg at the previous version
- install pg_config on axon
- swap the requirements to psycopg2-binary

I went with the latter because it is the simplest and least likely to break something. Might be slightly harder to opt into a from-source psycopg2 build. Thoughts?
