### PR TITLE
Resolve 559 support passive sessions

### DIFF
--- a/allensdk/brain_observatory/behavior/__init__.py
+++ b/allensdk/brain_observatory/behavior/__init__.py
@@ -1,2 +1,5 @@
 
-IMAGE_SETS = {'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl'}
+IMAGE_SETS = {'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl',
+              'Natural_Images_Lum_Matched_set_training_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'}
+
+assert len(IMAGE_SETS) == len(set(IMAGE_SETS.keys())) == len(set(IMAGE_SETS.values()))

--- a/allensdk/brain_observatory/behavior/__init__.py
+++ b/allensdk/brain_observatory/behavior/__init__.py
@@ -1,5 +1,9 @@
 
 IMAGE_SETS = {'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl',
-              'Natural_Images_Lum_Matched_set_training_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'}
+              'Natural_Images_Lum_Matched_set_training_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl',
+              'Natural_Images_Lum_Matched_set_training_2017.07.14_2': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl',
+              'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14_2': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl'}
+
+
 
 assert len(IMAGE_SETS) == len(set(IMAGE_SETS.keys())) == len(set(IMAGE_SETS.values()))

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -39,7 +39,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         unit_dict = {'v_sig': 'V', 'v_in': 'V', 'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
         nwb.add_running_data_df_to_nwbfile(nwbfile, session_object.running_data_df, unit_dict)
 
-        # # Add ophys to NWB in-memory object:
+        # Add ophys to NWB in-memory object:
         nwb.add_ophys_timestamps(nwbfile, session_object.ophys_timestamps)
 
         # Add stimulus template data to NWB in-memory object:

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -42,16 +42,26 @@ if __name__ == "__main__":
 
     from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi
 
-    # api_list = []
-    # df = BehaviorOphysLimsApi.get_ophys_experiment_df()
-    # for cid in [791352433, 814796698, 814796612, 814796558, 814797528]:
-    #     df2 = df[(df['container_id'] == cid) & (df['workflow_state'] == 'passed')]
-    #     api_list += [BehaviorOphysLimsApi(oeid) for oeid in df2['ophys_experiment_id'].values]
+    blacklist = []
+    df = BehaviorOphysLimsApi.get_ophys_experiment_df()
+    for cid in [791352433, 814796698, 814796612, 814796558, 814797528]:
+        df2 = df[(df['container_id'] == cid) & (df['workflow_state'] == 'passed')]
+        api_list = [BehaviorOphysLimsApi(oeid) for oeid in df2['ophys_experiment_id'].values]
 
-    # for api in api_list:
-    #     session = BehaviorOphysSession(api=api)
-    #     print(session.task_parameters)
-    #     print(session.running_speed)
+        # print()
+        # print('cid', cid)
+        for api in api_list:
+            session = BehaviorOphysSession(api=api)
+            try:
+                session.task_parameters
+                # print('    ', api.get_ophys_experiment_id(), )
+            except KeyError:
+                # print('    ', api.get_ophys_experiment_id(), 'fail')
+                blacklist.append(api.get_ophys_experiment_id())
+    
+    print(blacklist)
+
+        # print(session.running_speed)
 
 
     # nwb_filepath = '/home/nicholasc/projects/allensdk/tmp.nwb'

--- a/allensdk/brain_observatory/behavior/rewards_processing.py
+++ b/allensdk/brain_observatory/behavior/rewards_processing.py
@@ -4,14 +4,14 @@ from collections import defaultdict
 
 def get_rewards(data, time, stimulus_rebase_function):
     trial_df = pd.DataFrame(data["items"]["behavior"]['trial_log'])
-    rewards_dict = defaultdict(dict)
+    rewards_dict = {'volume': [], 'timestamps': [], 'autorewarded': []}
     for idx, trial in trial_df.iterrows():
         rewards = trial["rewards"]  # as i write this there can only ever be one reward per trial
         if rewards:
-            rewards_dict["volume"][idx] = rewards[0][0]
-            rewards_dict["timestamps"][idx] = stimulus_rebase_function(time[rewards[0][2]])
-            rewards_dict["autorewarded"][idx] = 'auto_rewarded' in trial['trial_params']
+            rewards_dict["volume"].append(rewards[0][0])
+            rewards_dict["timestamps"].append(stimulus_rebase_function(time[rewards[0][2]]))
+            rewards_dict["autorewarded"].append('auto_rewarded' in trial['trial_params'])
 
-    df = pd.DataFrame(data=rewards_dict)[['volume', 'timestamps', 'autorewarded']].set_index('timestamps', drop=True)
+    df = pd.DataFrame(rewards_dict).set_index('timestamps', drop=True)
 
     return df

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -2,8 +2,20 @@ import numpy as np
 import pandas as pd
 import pickle
 from allensdk.brain_observatory.behavior import IMAGE_SETS
+import os
 
-IMAGE_SETS_REV = {val:key for key, val in IMAGE_SETS.items()}
+IMAGE_SETS_REV = {val: key for key, val in IMAGE_SETS.items()}
+
+def convert_filepath_caseinsensitive(filename_in):
+
+    if filename_in == '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl'
+    elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'
+    elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_TRAINING_2017.07.14.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'
+    else:
+        raise NotImplementedError(filename_in)
 
 
 def load_pickle(pstream):
@@ -31,7 +43,10 @@ def get_images_dict(pkl):
     # Sometimes the source is a zipped pickle:
     metadata = {'image_set': pkl["items"]["behavior"]["stimuli"]["images"]["image_path"]}
 
-    image_set = load_pickle(open(metadata['image_set'], 'rb'))
+    # Get image file name; these are encoded case-insensitive in the pickle file :/
+    filename = convert_filepath_caseinsensitive(metadata['image_set'])
+
+    image_set = load_pickle(open(filename, 'rb'))
     images = []
     images_meta = []
 
@@ -61,7 +76,7 @@ def get_images_dict(pkl):
 def get_stimulus_templates(pkl):
 
     images = get_images_dict(pkl)
-    image_set_filename = images['metadata']['image_set']
+    image_set_filename = convert_filepath_caseinsensitive(images['metadata']['image_set'])
     return {IMAGE_SETS_REV[image_set_filename]: np.array(images['images'])}
 
 
@@ -69,7 +84,8 @@ def get_stimulus_metadata(pkl):
 
     images = get_images_dict(pkl)
     stimulus_index_df = pd.DataFrame(images['image_attributes'])
-    stimulus_index_df['image_set'] = IMAGE_SETS_REV[images['metadata']['image_set']]
+    image_set_filename = convert_filepath_caseinsensitive(images['metadata']['image_set'])
+    stimulus_index_df['image_set'] = IMAGE_SETS_REV[image_set_filename]
     stimulus_index_df.set_index(['image_index'], inplace=True, drop=True)
     return stimulus_index_df
 

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -14,6 +14,10 @@ def convert_filepath_caseinsensitive(filename_in):
         return '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'
     elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_TRAINING_2017.07.14.pkl':
         return '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'
+    elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'
+    elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl'
     else:
         raise NotImplementedError(filename_in)
 

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -92,7 +92,7 @@ def get_trials(data, stimulus_timestamps_no_monitor_delay, licks_df, rewards_df,
         false_alarm = ('false_alarm', "") in event_dict
         trial_data['false_alarm'].append(false_alarm)
 
-        response_time = event_dict.get(('hit', '')) or event_dict.get(('false_alarm', '')) if hit or false_alarm else None
+        response_time = event_dict.get(('hit', '')) or event_dict.get(('false_alarm', '')) if hit or false_alarm else float('nan')
         trial_data['response_time'].append(response_time)
 
         miss = ('miss', "") in event_dict
@@ -107,7 +107,7 @@ def get_trials(data, stimulus_timestamps_no_monitor_delay, licks_df, rewards_df,
         stimulus_change = True if ('stimulus_changed', '') in event_dict else False
         trial_data['stimulus_change'].append(stimulus_change)
 
-        change_time = event_dict.get(('stimulus_changed', '')) or event_dict.get(('sham_change', '')) if stimulus_change or sham_change else None
+        change_time = event_dict.get(('stimulus_changed', '')) or event_dict.get(('sham_change', '')) if stimulus_change or sham_change else float('nan')
         trial_data['change_time'].append(change_time)
 
         if not (sham_change or stimulus_change):

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -207,6 +207,8 @@ def add_trials(nwbfile, trials, description_dict={}):
         if data.dtype == '<U1':
             data = trials[c].values
         if not len(data) == len(order):
+            if len(data) == 0:
+                data = ['']
             nwbfile.add_trial_column(name=c, description=description_dict.get(c, 'NOT IMPLEMENTED: %s' % c), data=data, index=index)
         else:
             nwbfile.add_trial_column(name=c, description=description_dict.get(c, 'NOT IMPLEMENTED: %s' % c), data=data)

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -225,13 +225,29 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
 
         return pd.read_sql(query, api.get_connection()).rename(columns={'visual_behavior_experiment_container_id':'container_id'}).drop('id', axis=1)
 
+    @classmethod
+    def get_api_list_by_container_id(cls, container_id):
+
+        df = cls.get_ophys_experiment_df()
+        oeid_list = df[df['container_id'] == container_id]['ophys_experiment_id'].values
+        return [cls(oeid) for oeid in oeid_list]
+
+
+
+
 if __name__ == "__main__":
 
 
 
 
+    pass
+    # print(BehaviorOphysLimsApi.get_api_by_container(838105949))
 
-    L = BehaviorOphysLimsApi.get_ophys_experiment_df()
-    print(L)
+    # ophys_experiment_id = df['ophys_experiment_id'].iloc[0]
+    # print(ophys_experiment_id)
+    # BehaviorOphysLimsApi
+    # print(L)
+    # for c in sorted(L.columns):
+    #     print(c)
     # for x in [791352433, 814796698, 814796612, 814796558, 814797528]:
     #     print(x in L)

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -6,7 +6,7 @@ import h5py
 import pytz
 import pandas as pd
 
-from . import PostgresQueryMixin, OneOrMoreResultExpectedError
+from allensdk.internal.api import PostgresQueryMixin, OneOrMoreResultExpectedError
 from allensdk.api.cache import memoize
 from allensdk.brain_observatory.behavior.image_api import ImageApi
 import allensdk.brain_observatory.roi_masks as roi
@@ -340,3 +340,18 @@ class OphysLimsApi(PostgresQueryMixin):
                 WHERE oe.id = {};
                 '''.format(self.get_ophys_experiment_id())
         return self.fetchone(query, strict=True)
+
+
+    @memoize
+    def get_workflow_state(self):
+        query = '''
+                SELECT oe.workflow_state
+                FROM ophys_experiments oe
+                WHERE oe.id = {};
+                '''.format(self.get_ophys_experiment_id())
+        return self.fetchone(query, strict=True)
+
+if __name__ == "__main__":
+
+    api = OphysLimsApi(842510825)
+    print(api.get_workflow_state())

--- a/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
@@ -19,7 +19,8 @@ def api_data():
                        'reporter_line': ['Ai148(TIT2L-GC6f-ICL-tTA2)'],
                        'driver_line': ['Vip-IRES-Cre'],
                        'LabTracks_ID': 363887,
-                       'full_genotype': 'Vip-IRES-Cre/wt;Ai148(TIT2L-GC6f-ICL-tTA2)/wt'
+                       'full_genotype': 'Vip-IRES-Cre/wt;Ai148(TIT2L-GC6f-ICL-tTA2)/wt',
+                       'workflow_state': 'passed',
                        }
             }
 
@@ -172,6 +173,17 @@ def test_get_full_genotype(ophys_experiment_id, api_data):
     ophys_lims_api = OphysLimsApi(ophys_experiment_id)
     f = ophys_lims_api.get_full_genotype
     key = 'full_genotype'
+    if ophys_experiment_id in api_data:
+        assert f() == api_data[ophys_experiment_id][key]
+    else:
+        expected_fail(f)
+
+@pytest.mark.nightly
+@pytest.mark.parametrize('ophys_experiment_id', [702134928, 0])
+def test_get_workflow_state(ophys_experiment_id, api_data):
+    ophys_lims_api = OphysLimsApi(ophys_experiment_id)
+    f = ophys_lims_api.get_workflow_state
+    key = 'workflow_state'
     if ophys_experiment_id in api_data:
         assert f() == api_data[ophys_experiment_id][key]
     else:

--- a/allensdk/tmp.py
+++ b/allensdk/tmp.py
@@ -1,0 +1,19 @@
+import os
+
+from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi
+from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession
+
+
+basedir = '/allen/aibs/technology/nicholasc/behavior_ophys'
+
+rel_filepath_list = ['behavior_ophys_session_805784331.nwb',
+                     'behavior_ophys_session_789359614.nwb',
+                     'behavior_ophys_session_803736273.nwb',
+                     'behavior_ophys_session_808621958.nwb',
+                     'behavior_ophys_session_795948257.nwb']
+
+for rel_filepath in rel_filepath_list:
+
+    full_filepath = os.path.join(basedir, rel_filepath)
+    session = BehaviorOphysSession(api=BehaviorOphysNwbApi(full_filepath))
+    print(session.metadata['ophys_experiment_id'])


### PR DESCRIPTION
- [x] More stimuli in well known locations
- [x] escape lick and reward writing, when none are present
- [x] get_api_list_by_container_id api endpoint
- [x] case-insensitive lookup of source image files
- [x] get_workflow_state api endpoint and test