### PR TITLE
change dtype on stimulus presentation test fixture

### DIFF
--- a/allensdk/test/brain_observatory/conftest.py
+++ b/allensdk/test/brain_observatory/conftest.py
@@ -28,8 +28,8 @@ def nwbfile():
 def stimulus_presentations():
     return pd.DataFrame({
         'alpha': [0.5, 0.4, 0.3, 0.2, 0.1],
-        'start_time': [1, 2, 4, 5, 6],
-        'stop_time': [2, 4, 5, 6, 8],
+        'start_time': [1., 2., 4., 5., 6.],
+        'stop_time': [2., 4., 5., 6., 8.],
     }, index=pd.Index(name='stimulus_presentations_id', data=[0, 1, 2, 3, 4]))
 
 


### PR DESCRIPTION
must be float32 or float64 to conform to pynwb schema; conform now required after:

https://github.com/hdmf-dev/hdmf/pull/34