### PR TITLE
Update test_requirements.txt to resolve pytest-xdist conflict and deprecated pandas .ix

### DIFF
--- a/allensdk/brain_observatory/locally_sparse_noise.py
+++ b/allensdk/brain_observatory/locally_sparse_noise.py
@@ -359,7 +359,7 @@ class LocallySparseNoise(StimulusAnalysis):
                                                                             mask_off_screen=False)
 
         baseline_trials = np.unique(np.where(lsn_movie[:,-5:,-1] != LocallySparseNoise.LSN_GREY)[0])
-        baseline_df = self.mean_sweep_response.ix[baseline_trials]
+        baseline_df = self.mean_sweep_response.loc[baseline_trials]
         cell_baselines = np.nanmean(baseline_df.values, axis=0)
 
         lsn_movie[:,~lsn_mask] = LocallySparseNoise.LSN_OFF_SCREEN

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pep8==1.7.0
-pytest>=4.1.1
+pytest>=4.4.0
 pytest-cov>=2.2.1
 pytest-cover>=3.0.0
 pytest-pep8>=1.0.6


### PR DESCRIPTION
Internal build failing because:
- [x] of a version conflict with pytest and pytest-xdist.  This PR will remain open until the internal builds are running again, so that the 0.16.2 whl can be published to pypi
- [x] Running pandas 0.24 has error behavior because of .ix notation