### PR TITLE
Fast only bamboo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA=skip
     - TEST_API_ENDPOINT=http://api.brain-map.org 
     - TEST_COMPLETE=false
+    - TEST_BAMBOO=false
 
 matrix:
   include:

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -16,7 +16,7 @@ from allensdk.brain_observatory.behavior.write_nwb.__main__ import BehaviorOphys
 from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi, equals
 
 
-@pytest.mark.nightly
+@pytest.mark.requires_bamboo
 @pytest.mark.parametrize('oeid1, oeid2, expected', [
     pytest.param(789359614, 789359614, True),
     pytest.param(789359614, 739216204, False)
@@ -27,7 +27,7 @@ def test_equal(oeid1, oeid2, expected):
 
     assert equals(d1, d2) == expected
 
-@pytest.mark.nightly
+@pytest.mark.requires_bamboo
 def test_session_from_json(tmpdir_factory, session_data):
     oeid = 789359614
 
@@ -37,7 +37,7 @@ def test_session_from_json(tmpdir_factory, session_data):
     assert equals(d1, d2)
 
 
-@pytest.mark.nightly
+@pytest.mark.requires_bamboo
 def test_nwb_end_to_end(tmpdir_factory):
     oeid = 789359614
     nwb_filepath = os.path.join(str(tmpdir_factory.mktemp('test_nwb_end_to_end')), 'nwbfile.nwb')
@@ -49,7 +49,7 @@ def test_nwb_end_to_end(tmpdir_factory):
     assert equals(d1, d2)
 
 
-@pytest.mark.nightly
+@pytest.mark.requires_bamboo
 def test_visbeh_ophys_data_set():
 
     ophys_experiment_id = 789359614

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
   TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA: skip
   TEST_API_ENDPOINT: http://api.brain-map.org 
   TEST_COMPLETE: "false"
+  TEST_BAMBOO: "false"
   matrix:
     - MINICONDA: "C:\\Miniconda-x64"
       PYTHON: 2.7

--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,11 @@ def pytest_collection_modifyitems(config, items):
             'and install, so you must opt in to running this test'
     )
 
+    skip_outside_bamboo_test = pytest.mark.skipif(
+        os.environ.get('TEST_BAMBOO') != 'true',
+        reason='this test depends on the resources only available to Bamboo agents, but are still fast.  If they are slow, mark with nightly'
+    )
+
     for item in items:
         if 'requires_api_endpoint' in item.keywords:
             item.add_marker(skip_api_endpoint_test)
@@ -65,3 +70,6 @@ def pytest_collection_modifyitems(config, items):
 
         if 'requires_neuron' in item.keywords:
             item.add_marker(skip_neuron_test)
+
+        if 'requires_bamboo' in item.keywords:
+            item.add_marker(skip_outside_bamboo_test)


### PR DESCRIPTION
Many of the integration tests for the brain_observatory/behavior module are only run nightly, but are still fast enough to build continuously and yet rely on infrastructure (i.e. LIMS) internal to AIBS, and therefore only on Bamboo build agents.

This PR adds an environment variable to turn on tests that are decorated with @pytest.mark.requires_bamboo only when the environment variable TEST_BAMBOO=true in the build environment, and sets this variable to false for travis and appveyor.  This variable is set true for the nightly and continuous build plans (all stages) 