### PR TITLE
Fix testing framework for AllenSDK .ipynb notebook tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ doc: FORCE
 	cd $(DOCDIR); sphinx-build -b html . _build/html;
 
 notebooks:
-	cd doc_template/examples_root/examples/nb && find . -maxdepth 1 -name '*.ipynb' -exec jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=1800 {} \;
-	cd doc_template/examples_root/examples/nb/summer_workshop_2015 && find . -maxdepth 1 -name '*.ipynb' -exec jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=1800 {} \;
+	find doc_template/examples_root/examples/nb -maxdepth 1 -name '*.ipynb' -exec jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=$(python_kernel) {} \+
+	find doc_template/examples_root/examples/nb/summer_workshop_2015 -maxdepth 1 -name '*.ipynb' -exec jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=-1 --ExecutePreprocessor.kernel_name=$(python_kernel) {} \+
 
 FORCE:
 


### PR DESCRIPTION
Okay, this commit (and the changes I made to the bamboo nightly plan) should get notebook tests successfully failing (?).

Examples:
http://bamboo.corp.alleninstitute.org/browse/IFR-TEST0-JOB1-10/log
http://bamboo.corp.alleninstitute.org/browse/IFR-TEST0-PYT-10/log 

These logs are for a temporary plan that I will be deleting (basically it skips straight to the notebook conversions).