### PR TITLE
#685 use os-safe paths in behavior ophys apis

### DIFF
--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -18,6 +18,7 @@ from allensdk.brain_observatory.behavior.image_api import ImageApi
 from allensdk.internal.api import PostgresQueryMixin
 from allensdk.brain_observatory.behavior.behavior_ophys_api import BehaviorOphysApiBase
 from allensdk.brain_observatory.behavior.trials_processing import get_extended_trials
+from allensdk.internal.core.lims_utilities import safe_system_path
 
 
 class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
@@ -69,7 +70,7 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
                 LEFT JOIN well_known_files stim ON stim.attachable_id=bs.id AND stim.attachable_type = 'BehaviorSession' AND stim.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'StimulusPickle')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     def get_behavior_session_uuid(self):
         behavior_stimulus_file = self.get_behavior_stimulus_file()
@@ -232,7 +233,7 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
                 LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'BehaviorOphysNwb')
                 WHERE oe.id = {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     def get_stimulus_rebase_function(self):
         stimulus_timestamps_no_monitor_delay = self.get_sync_data()['stimulus_frames_no_delay']

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -10,6 +10,7 @@ from allensdk.internal.api import PostgresQueryMixin, OneOrMoreResultExpectedErr
 from allensdk.api.cache import memoize
 from allensdk.brain_observatory.behavior.image_api import ImageApi
 import allensdk.brain_observatory.roi_masks as roi
+from allensdk.internal.core.lims_utilities import safe_system_path
 
 
 class OphysLimsApi(PostgresQueryMixin):
@@ -28,7 +29,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 FROM ophys_experiments oe
                 WHERE oe.id = {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_nwb_filepath(self):
@@ -38,7 +39,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'NWBOphys')
                 WHERE oe.id = {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_sync_file(self, ophys_experiment_id=None):
@@ -49,7 +50,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files sync ON sync.attachable_id=os.id AND sync.attachable_type = 'OphysSession' AND sync.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysRigSync')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_segmentation_mask_image_file(self):
@@ -60,7 +61,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files wkf ON wkf.attachable_id=ocsr.id AND wkf.attachable_type = 'OphysCellSegmentationRun' AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysMaxIntImage')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_segmentation_mask_image(self, image_api=None):
@@ -197,7 +198,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files dff ON dff.attachable_id=oe.id AND dff.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysDffTraceFile')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_cell_roi_ids(self):
@@ -214,7 +215,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files obj ON obj.attachable_id=ocsr.id AND obj.attachable_type = 'OphysCellSegmentationRun' AND obj.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysSegmentationObjects')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_demix_file(self):
@@ -224,7 +225,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files wkf ON wkf.attachable_id=oe.id AND wkf.attachable_type = 'OphysExperiment' AND wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'DemixedTracesFile')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_average_intensity_projection_image_file(self):
@@ -235,7 +236,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files avg ON avg.attachable_id=ocsr.id AND avg.attachable_type = 'OphysCellSegmentationRun' AND avg.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysAverageIntensityProjectionImage')
                 WHERE oe.id = {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_rigid_motion_transform_file(self):
@@ -245,7 +246,7 @@ class OphysLimsApi(PostgresQueryMixin):
                 LEFT JOIN well_known_files tra ON tra.attachable_id=oe.id AND tra.attachable_type = 'OphysExperiment' AND tra.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysMotionXyOffsetData')
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
-        return self.fetchone(query, strict=True)
+        return safe_system_path(self.fetchone(query, strict=True))
 
     @memoize
     def get_foraging_id(self):

--- a/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from allensdk.internal.api import OneResultExpectedError, OneOrMoreResultExpectedError
@@ -42,7 +44,7 @@ def test_get_ophys_experiment_dir(ophys_experiment_id, api_data):
     f = ophys_lims_api.get_ophys_experiment_dir
     key = 'ophys_dir'
     if ophys_experiment_id in api_data:
-        assert f() == api_data[ophys_experiment_id][key]
+        assert f() == os.path.normpath(api_data[ophys_experiment_id][key])
     else:
         expected_fail(f)
 


### PR DESCRIPTION
addresses #685 

A todo for another issue: collapse the well known file path extraction to a single function.