### PR TITLE
Add LimsApi method to return eye tracking video paths

### DIFF
--- a/allensdk/internal/api/lims_api.py
+++ b/allensdk/internal/api/lims_api.py
@@ -14,14 +14,14 @@ class LimsApi(PostgresQueryMixin):
 
     def get_behavior_tracking_video_filepath_df(self):
         query = '''
-                SELECT wkf.storage_directory || wkf.filename AS raw_behavior_tracking_video_filepath, attachable_type 
+                SELECT wkf.storage_directory || wkf.filename AS raw_behavior_tracking_video_filepath, attachable_type, attachable_id
                 FROM well_known_files wkf WHERE wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'RawBehaviorTrackingVideo')
                 '''
         return pd.read_sql(query, self.get_connection())
 
     def get_eye_tracking_video_filepath_df(self):
         query = '''
-                SELECT wkf.storage_directory || wkf.filename AS raw_eye_tracking_video_filepath, attachable_type 
+                SELECT wkf.storage_directory || wkf.filename AS raw_eye_tracking_video_filepath, attachable_type, attachable_id
                 FROM well_known_files wkf WHERE wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'RawEyeTrackingVideo')
                 '''
         return pd.read_sql(query, self.get_connection())
@@ -29,5 +29,5 @@ class LimsApi(PostgresQueryMixin):
 if __name__ == "__main__":
 
     api = LimsApi()
-    #print(api.get_behavior_tracking_video_filepath_df())
-    print(api.get_eye_tracking_video_filepath_df())
+    print(api.get_behavior_tracking_video_filepath_df())
+    #  print(api.get_eye_tracking_video_filepath_df())

--- a/allensdk/internal/api/lims_api.py
+++ b/allensdk/internal/api/lims_api.py
@@ -19,7 +19,15 @@ class LimsApi(PostgresQueryMixin):
                 '''
         return pd.read_sql(query, self.get_connection())
 
+    def get_eye_tracking_video_filepath_df(self):
+        query = '''
+                SELECT wkf.storage_directory || wkf.filename AS raw_eye_tracking_video_filepath, attachable_type 
+                FROM well_known_files wkf WHERE wkf.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'RawEyeTrackingVideo')
+                '''
+        return pd.read_sql(query, self.get_connection())
+
 if __name__ == "__main__":
 
     api = LimsApi()
-    print(api.get_behavior_tracking_video_filepath_df())
+    #print(api.get_behavior_tracking_video_filepath_df())
+    print(api.get_eye_tracking_video_filepath_df())

--- a/allensdk/test/internal/api/test_lims_api.py
+++ b/allensdk/test/internal/api/test_lims_api.py
@@ -1,0 +1,11 @@
+from allensdk.internal.api.lims_api import LimsApi
+
+# These tests just confirm that we can access the endpoint, without asserting
+# anything about the output
+def test_behavior_video_df_endpoint():
+    api = LimsApi()
+    bvid_df = api.get_behavior_tracking_video_filepath_df()
+
+def test_eye_tracking_video_df_endpoint():
+    api = LimsApi()
+    etvid_df = api.get_eye_tracking_video_filepath_df()


### PR DESCRIPTION
Copies the implementation of the existing `get_behavior_tracking_video_filepath_df method`. 