### PR TITLE
Attempt to address issue 766 by returning full genotype instead of each genotype part

### DIFF
--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -249,15 +249,12 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
 
         api = PostgresQueryMixin()
         query = '''
-                SELECT oec.visual_behavior_experiment_container_id as container_id, oec.ophys_experiment_id, oe.workflow_state, g.name as driver_line, id.depth, st.acronym
+                SELECT oec.visual_behavior_experiment_container_id as container_id, oec.ophys_experiment_id, oe.workflow_state, d.full_genotype as full_genotype, id.depth, st.acronym
                 FROM ophys_experiments_visual_behavior_experiment_containers oec
                 LEFT JOIN ophys_experiments oe ON oe.id = oec.ophys_experiment_id
                 LEFT JOIN ophys_sessions os ON oe.ophys_session_id = os.id
                 LEFT JOIN specimens sp ON sp.id=os.specimen_id
                 LEFT JOIN donors d ON d.id=sp.donor_id
-                LEFT JOIN donors_genotypes dg ON dg.donor_id=d.id
-                LEFT JOIN genotypes g ON g.id=dg.genotype_id
-                LEFT JOIN genotype_types gt ON gt.id=g.genotype_type_id AND gt.name = 'driver'
                 LEFT JOIN imaging_depths id ON id.id=os.imaging_depth_id
                 LEFT JOIN structures st ON st.id=oe.targeted_structure_id
                 '''


### PR DESCRIPTION
Here is an attempt to address #766 by returning a column with just the `full_genotype` of the donor animal instead of joining with the genotypes table, which seemed to be causing 3 rows to be included for each experiment (one per genotype in the full cross).

I don't know if this is the best way to do this - @matchings, @dougollerenshaw is there something better than `full_genotype` to return in this method? 

@nicain what would be the best way to make a unit test for this? 