### PR TITLE
Exclude aborted trials from correct rejects

### DIFF
--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -170,7 +170,7 @@ def get_trials(data, licks_df, rewards_df, rebase):
         false_alarm = ('false_alarm', "") in event_dict
         trial_data['false_alarm'].append(false_alarm)
 
-        correct_reject = catch and not false_alarm
+        correct_reject = catch and not false_alarm and not aborted
         trial_data['correct_reject'].append(correct_reject)
 
         response_time = event_dict.get(('hit', '')) or event_dict.get(('false_alarm', '')) if hit or false_alarm else float('nan')


### PR DESCRIPTION
Hits, misses,  and false alarms are currently being pulled straight from the trial event log, but correct rejects are being calculated as catch trials that aren't labeled as false alarms: https://github.com/AllenInstitute/AllenSDK/blob/82bf4b20f232486e7b3ee4df58b857af4679b70f/allensdk/brain_observatory/behavior/trials_processing.py#L173

We need to also exclude aborted trials from the correct rejects. 

TODO: 
- [ ] Unit tests for some assertions about the one-hot encoding of trial type. Basically, no trial should have more than one label. We could just sum them up across the labels and verify that the result is all ones. 