### PR TITLE
Resolve GH-643 add licks to stimulus presentations via assign_to_interval

### DIFF
--- a/allensdk/test/brain_observatory/behavior/test_behavior_analysis.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_analysis.py
@@ -1,0 +1,15 @@
+import pytest
+
+from allensdk.brain_observatory.behavior.behavior_ophys_analysis import assign_to_interval
+from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession
+
+
+@pytest.mark.requires_bamboo
+def test_assign_to_interval():
+
+    ophys_experiment_id = 789359614
+    session = BehaviorOphysSession.from_lims(ophys_experiment_id)
+
+    assignment = assign_to_interval(session.licks['time'].values, session.trials)
+    for idx, lt in assignment.iteritems():
+        assert lt in session.trials['lick_times'].loc[idx]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ xarray
 hdmf==1.0.2
 pynwb==1.0.2
 tables==3.5.1 # pinning this because updates tend to not include wheels immediately
+seaborn==0.9.0


### PR DESCRIPTION
Add a function that can assign arbitrary times to intervals encoded in a pandas dataframe