### PR TITLE
pull lick times from pkl instead of sync times

### DIFF
--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -157,7 +157,11 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
 
     @memoize
     def get_licks(self):
-        lick_times = self.get_sync_data()['lick_times']
+        behavior_stimulus_file = self.get_behavior_stimulus_file()
+        data = pd.read_pickle(behavior_stimulus_file)
+        lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_data'][0]
+        stimulus_timestamps_no_monitor_delay = self.get_sync_data()['stimulus_times_no_delay']
+        lick_times  = stimulus_timestamps_no_monitor_delay[lick_frames]
         return pd.DataFrame({'time': lick_times})
 
     @memoize

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -159,7 +159,7 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
     def get_licks(self):
         behavior_stimulus_file = self.get_behavior_stimulus_file()
         data = pd.read_pickle(behavior_stimulus_file)
-        lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_events'][0]
+        lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_events']
         stimulus_timestamps_no_monitor_delay = self.get_sync_data()['stimulus_times_no_delay']
         lick_times  = stimulus_timestamps_no_monitor_delay[lick_frames]
         return pd.DataFrame({'time': lick_times})

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -159,7 +159,7 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
     def get_licks(self):
         behavior_stimulus_file = self.get_behavior_stimulus_file()
         data = pd.read_pickle(behavior_stimulus_file)
-        lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_data'][0]
+        lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_events'][0]
         stimulus_timestamps_no_monitor_delay = self.get_sync_data()['stimulus_times_no_delay']
         lick_times  = stimulus_timestamps_no_monitor_delay[lick_frames]
         return pd.DataFrame({'time': lick_times})


### PR DESCRIPTION
This PR allow the SDK to pull lick data from pkl files instead of from the sync data, making the SDK compatible with ALL production scientifica and mesoscope instead of a subset