### PR TITLE
Return simpler Image objects instead of SimpleITK images from behavior ophys session

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -19,7 +19,7 @@ class BehaviorOphysSession(LazyPropertyMixin):
     Attributes:
         ophys_experiment_id : int (LazyProperty)
             Unique identifier for this experimental session
-        max_projection : SimpleITK.Image (LazyProperty)
+        max_projection : allensdk.brain_observatory.behavior.image_api.Image (LazyProperty)
             2D max projection image
         stimulus_timestamps : numpy.ndarray (LazyProperty)
             Timestamps associated the stimulus presentations on the monitor 
@@ -53,7 +53,7 @@ class BehaviorOphysSession(LazyPropertyMixin):
             A dataframe containing behavioral trial start/stop times, and trial data
         corrected_fluorescence_traces : pandas.DataFrame (LazyProperty)
             The motion-corrected fluorescence traces organized into a dataframe; index is the cell roi ids
-        average_projection : SimpleITK.Image (LazyProperty)
+        average_projection : allensdk.brain_observatory.behavior.image_api.Image (LazyProperty)
             2D image of the microscope field of view, averaged across the experiment
         motion_correction : pandas.DataFrame LazyProperty
             A dataframe containing trace data used during motion correction computation

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -10,6 +10,7 @@ from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_a
 from allensdk.deprecated import legacy
 from allensdk.brain_observatory.behavior.trials_processing import calculate_reward_rate
 from allensdk.brain_observatory.behavior.dprime import get_rolling_dprime, get_trial_count_corrected_false_alarm_rate, get_trial_count_corrected_hit_rate
+from allensdk.brain_observatory.behavior.image_api import ImageApi
 
 
 class BehaviorOphysSession(LazyPropertyMixin):
@@ -72,7 +73,7 @@ class BehaviorOphysSession(LazyPropertyMixin):
         self.api = api
 
         self.ophys_experiment_id = LazyProperty(self.api.get_ophys_experiment_id)
-        self.max_projection = LazyProperty(self.api.get_max_projection)
+        self.max_projection = LazyProperty(self.get_max_projection)
         self.stimulus_timestamps = LazyProperty(self.api.get_stimulus_timestamps)
         self.ophys_timestamps = LazyProperty(self.api.get_ophys_timestamps)
         self.metadata = LazyProperty(self.api.get_metadata)
@@ -87,9 +88,9 @@ class BehaviorOphysSession(LazyPropertyMixin):
         self.task_parameters = LazyProperty(self.api.get_task_parameters)
         self.trials = LazyProperty(self.api.get_trials)
         self.corrected_fluorescence_traces = LazyProperty(self.api.get_corrected_fluorescence_traces)
-        self.average_projection = LazyProperty(self.api.get_average_projection)
+        self.average_projection = LazyProperty(self.get_average_projection)
         self.motion_correction = LazyProperty(self.api.get_motion_correction)
-        self.segmentation_mask_image = LazyProperty(self.api.get_segmentation_mask_image)
+        self.segmentation_mask_image = LazyProperty(self.get_segmentation_mask_image)
 
     @legacy('Consider using "get_dff_timeseries" instead.')
     def get_dff_traces(self, cell_specimen_ids=None):
@@ -117,6 +118,35 @@ class BehaviorOphysSession(LazyPropertyMixin):
         if np.isnan(cell_specimen_ids.astype(float)).sum() == len(self.cell_specimen_table):
             raise ValueError(f'cell_specimen_id values not assigned for {self.ophys_experiment_id}')
         return cell_specimen_ids
+
+    def deserialize_image(self, sitk_image):
+        '''
+        Convert SimpleITK image returned by the api to an Image class:
+
+        Args:
+            sitk_image (SimpleITK image): image object returned by the api
+
+        Returns
+            img (allensdk.brain_observatory.behavior.image_api.Image):
+                Image class with the following attributes:
+                data : np.ndarray
+                    Image data points
+                spacing : tuple
+                    Spacing describes the physical size of each pixel
+                unit : str
+                    Physical unit of the spacing (currently constrained to be isotropic)
+        '''
+        img = ImageApi.deserialize(sitk_image)
+        return img
+
+    def get_max_projection(self):
+        return self.deserialize_image(self.api.get_max_projection())
+
+    def get_average_projection(self):
+        return self.deserialize_image(self.api.get_average_projection())
+
+    def get_segmentation_mask_image(self):
+        return self.deserialize_image(self.api.get_segmentation_mask_image())
 
     def get_reward_rate(self):
         response_latency_list = []

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -127,25 +127,39 @@ class BehaviorOphysSession(LazyPropertyMixin):
             sitk_image (SimpleITK image): image object returned by the api
 
         Returns
-            img (allensdk.brain_observatory.behavior.image_api.Image):
-                Image class with the following attributes:
-                data : np.ndarray
-                    Image data points
-                spacing : tuple
-                    Spacing describes the physical size of each pixel
-                unit : str
-                    Physical unit of the spacing (currently constrained to be isotropic)
+            img (allensdk.brain_observatory.behavior.image_api.Image)
         '''
         img = ImageApi.deserialize(sitk_image)
         return img
 
     def get_max_projection(self):
+        """ Returns an image whose values are the maximum obtained values at each pixel of the ophys movie over time.
+
+        Returns
+        ----------
+        allensdk.brain_observatory.behavior.image_api.Image:
+            array-like interface to max projection image data and metadata
+        """
         return self.deserialize_image(self.api.get_max_projection())
 
     def get_average_projection(self):
+        """ Returns an image whose values are the average obtained values at each pixel of the ophys movie over time.
+
+        Returns
+        ----------
+        allensdk.brain_observatory.behavior.image_api.Image:
+            array-like interface to max projection image data and metadata
+        """
         return self.deserialize_image(self.api.get_average_projection())
 
     def get_segmentation_mask_image(self):
+        """ Returns an image with a pixel value of zero if the pixel is not included in any ROI, and nonzero if included in a segmented ROI.
+
+        Returns
+        ----------
+        allensdk.brain_observatory.behavior.image_api.Image:
+            array-like interface to max projection image data and metadata
+        """
         return self.deserialize_image(self.api.get_segmentation_mask_image())
 
     def get_reward_rate(self):

--- a/allensdk/brain_observatory/behavior/image_api.py
+++ b/allensdk/brain_observatory/behavior/image_api.py
@@ -25,7 +25,7 @@ class Image(NamedTuple):
         return a and b and c
 
     def __array__(self):
-        return self.data
+        return np.array(self.data)
 
 class ImageApi:
 

--- a/allensdk/brain_observatory/behavior/image_api.py
+++ b/allensdk/brain_observatory/behavior/image_api.py
@@ -24,6 +24,8 @@ class Image(NamedTuple):
         c = self.unit == other.unit
         return a and b and c
 
+    def __array__(self):
+        return self.data
 
 class ImageApi:
 


### PR DESCRIPTION
The SimpleITK images returned by the behavior ophys session for the `max_projection`, `average_projection` and `segmentation_mask` attributes are clunky to deal with when doing analysis, due to the additional dependency on simpleitk in the analysis environment for plotting the image. This PR attempts to address #857 by having the behavior ophys session object convert the SimpleITK image into a simpler Image class (already defined in `allensdk.brain_observatory.behavior.image_api`), which has the following attributes: 
* data : Image data (as an np.ndarray)
* spacing : Describes the physical size of each pixel
* unit : Physical unit of the spacing

This way, the useful metadata about the image is preserved, and we are able to simply `plt.imshow(session.max_projection.data)` to plot the image

@matchings do you think this would address the issue? 