### PR TITLE
Avoid redundant trial type definitions

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '1.0.0.dev13'
+__version__ = '1.0.0.dev14'
 
 try:
     from logging import NullHandler

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -128,7 +128,31 @@ def resolve_initial_image(stimuli, start_frame):
 
 
 def trial_data_from_log(trial):
+    '''
+    Infer trial logic from trial log. Returns a dictionary.
+    
+    * reward volume: volume of water delivered on the trial, in mL
 
+    Each of the following values is boolean:
+
+    Trial category values are mutually exclusive
+    * go: trial was a go trial (trial with a stimulus change)
+    * catch: trial was a catch trial (trial with a sham stimulus change)
+
+    stimulus_change/sham_change are mutually exclusive
+    * stimulus_change: did the stimulus change (True on 'go' trials)
+    * sham_change: stimulus did not change, but response was evaluated (True on 'catch' trials)
+
+    Each trial can be one (and only one) of the following:
+    * hit (stimulus changed, animal responded in response window)
+    * miss (stimulus changed, animal did not respond in response window)
+    * false_alarm (stimulus did not change, animal responded in response window)
+    * correct_reject (stimulus did not change, animal did not respond in response window)
+    * aborted (animal responded before change time)
+    * auto_rewarded (reward was automatically delivered following the change. This will bias the animals choice and should not be categorized as hit/miss)
+    
+    
+    '''
     trial_event_names = [val[0] for val in trial['events']]
     hit = 'hit' in trial_event_names
     false_alarm = 'false_alarm' in trial_event_names
@@ -165,6 +189,7 @@ def trial_data_from_log(trial):
 
 
 def validate_trial_condition_exclusivity(trial_index, **trial_conditions):
+    '''ensure that only one of N possible mutually exclusive trial conditions is True'''
     on = []
     for condition, value in trial_conditions.items():
         if value:
@@ -176,6 +201,7 @@ def validate_trial_condition_exclusivity(trial_index, **trial_conditions):
 
 
 def get_trial_lick_times(lick_times, start_time, stop_time):
+    '''extract lick times in time range'''
     return lick_times[np.where(np.logical_and(
         lick_times >= start_time, 
         lick_times <= stop_time
@@ -183,6 +209,7 @@ def get_trial_lick_times(lick_times, start_time, stop_time):
 
 
 def get_trial_reward_time(rebased_reward_times, start_time, stop_time):
+    '''extract reward times in time range'''
     reward_times = rebased_reward_times[np.where(np.logical_and(
         rebased_reward_times >= start_time, 
         rebased_reward_times <= stop_time
@@ -191,7 +218,7 @@ def get_trial_reward_time(rebased_reward_times, start_time, stop_time):
         
 
 def get_trial_timing(event_dict, hit, false_alarm, stimulus_change, sham_change):
-
+    '''extract trial timing data'''
     start_time = event_dict["trial_start", ""]
     stop_time = event_dict["trial_end", ""]
 

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -270,6 +270,12 @@ def get_trials(data, licks_df, rewards_df, rebase):
         tr_data["lick_times"] = get_trial_lick_times(sync_lick_times, tr_data["start_time"], tr_data["stop_time"])
         tr_data["reward_time"] = get_trial_reward_time(rebased_reward_times, tr_data["start_time"], tr_data["stop_time"])
 
+        # ensure that only one trial condition is True (they are mutually exclusive)
+        condition_dict = {}
+        for key in ['hit','miss','false_alarm','correct_reject','auto_rewarded','aborted']:
+            condition_dict[key] = tr_data[key]
+        validate_trial_condition_exclusivity(idx,**condition_dict)
+
         all_trial_data[idx] = tr_data
 
     trials = pd.DataFrame(all_trial_data).set_index('trial')

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -225,8 +225,8 @@ def get_trial_timing(event_dict, go, catch, hit, false_alarm):
     go, catch, hit, false_alarm must be passed as booleans to disambiguate trial and response type
     '''
 
-    assert not (hit==True and miss==True), "both `hit` and `miss` cannot be True"
-    assert not (go==True and catch==True), "both `go` and `catch` cannot be True"
+    assert not (hit==True and false_alarm==True), "both `hit` and `false_alarm` cannot be True, they are mutually exclusive categories"
+    assert not (go==True and catch==True), "both `go` and `catch` cannot be True, they are mutually exclusive categories"
 
     start_time = event_dict["trial_start", ""]
     stop_time = event_dict["trial_end", ""]

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -127,7 +127,7 @@ def resolve_initial_image(stimuli, start_frame):
     return initial_image_category_name, initial_image_group, initial_image_name
 
 
-def trial_data_from_log(trial, event_dict, stimuli, rebase):
+def trial_data_from_log(trial, event_dict):
 
     hit = ('hit', "") in event_dict
     false_alarm = ('false_alarm', "") in event_dict
@@ -258,7 +258,7 @@ def get_trials(data, licks_df, rewards_df, rebase):
         tr_data = {"trial": trial["index"]}
 
         tr_data.update(get_trial_timing(event_dict))
-        tr_data.update(trial_data_from_log(trial, event_dict, stimuli, rebase))
+        tr_data.update(trial_data_from_log(trial, event_dict))
         tr_data.update(get_trial_image_names(trial, stimuli))
 
         tr_data["lick_times"] = get_trial_lick_times(sync_lick_times, tr_data["start_time"], tr_data["stop_time"])

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -217,8 +217,17 @@ def get_trial_reward_time(rebased_reward_times, start_time, stop_time):
     return float('nan') if len(reward_times) == 0 else one(reward_times)
         
 
-def get_trial_timing(event_dict, hit, false_alarm, stimulus_change, sham_change):
-    '''extract trial timing data'''
+def get_trial_timing(event_dict, go, catch, hit, false_alarm):
+    '''
+    extract trial timing data
+    
+    content of trial log depends on trial type depends on trial type and response type
+    go, catch, hit, false_alarm must be passed as booleans to disambiguate trial and response type
+    '''
+
+    assert not (hit==True and miss==True), "both `hit` and `miss` cannot be True"
+    assert not (go==True and catch==True), "both `go` and `catch` cannot be True"
+
     start_time = event_dict["trial_start", ""]
     stop_time = event_dict["trial_end", ""]
 
@@ -229,14 +238,14 @@ def get_trial_timing(event_dict, hit, false_alarm, stimulus_change, sham_change)
     else:
         response_time = float("nan")
 
-    if stimulus_change:
+    if go:
         change_time = event_dict.get(('stimulus_changed', ''))
-    elif sham_change:
+    elif catch:
         change_time = event_dict.get(('sham_change', ''))
     else:
         change_time = float("nan")
 
-    if not (sham_change or stimulus_change):
+    if not (go or catch):
         response_latency = None
     else:
         if hit or false_alarm:
@@ -287,10 +296,10 @@ def get_trials(data, licks_df, rewards_df, rebase):
         tr_data.update(trial_data_from_log(trial))
         tr_data.update(get_trial_timing(
             event_dict,
+            tr_data['go'],
+            tr_data['catch'],
             tr_data['hit'],
             tr_data['false_alarm'],
-            tr_data['stimulus_change'],
-            tr_data['sham_change'],
         ))
         tr_data.update(get_trial_image_names(trial, stimuli))
 

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -127,13 +127,15 @@ def resolve_initial_image(stimuli, start_frame):
     return initial_image_category_name, initial_image_group, initial_image_name
 
 
-def trial_data_from_log(trial, event_dict):
+def trial_data_from_log(trial):
 
-    hit = ('hit', "") in event_dict
-    false_alarm = ('false_alarm', "") in event_dict
-    miss = ('miss', "") in event_dict
-    sham_change = ('sham_change', '') in event_dict
-    stimulus_change = ('stimulus_changed', '') in event_dict
+    trial_event_names = [val[0] for val in trial['events']]
+    hit = 'hit' in trial_event_names
+    false_alarm = 'false_alarm' in trial_event_names
+    miss = 'miss' in trial_event_names
+    sham_change = 'sham_change' in trial_event_names
+    stimulus_change = 'stimulus_changed' in trial_event_names
+    aborted = 'abort' in trial_event_names
 
     if hit:
         response_time = event_dict.get(("hit", ""))

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -218,6 +218,15 @@ def get_trials(data, licks_df, rewards_df, rebase):
         trial_data['initial_image_name'].append(initial_image_name)
         trial_data['change_image_name'].append(change_image_name)
 
+    # ensure that there aren't redundant trial outcome labels 
+    for idx,row in trials[trials['auto_rewarded']==True].iterrows():
+        # if the trial is autorewarded, none of these other columns can be True
+        for col in ['hit','miss','false_alarm','correct_reject']:
+            trials.at[idx, col] = False 
+        # if the trial was aborted, we shouldn't also call it auto_rewarded
+        if row['aborted']:
+            trials.at[idx,'auto_rewarded'] = False 
+
     trials = pd.DataFrame(trial_data).set_index('trial')
     trials.index = trials.index.rename('trials_id')
 

--- a/allensdk/test/brain_observatory/behavior/test_trials_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_trials_processing.py
@@ -80,7 +80,7 @@ def test_calculate_reward_rate(kwargs, expected):
         expected, 
     ), "calculated reward rate should match expected reward rate :("
 
-def test_trial_data_from_log():
+def test_trial_data_from_log_0():
     test_trial_0 = {
         'index': 3,
         'cumulative_rewards': 1,
@@ -136,6 +136,7 @@ def test_trial_data_from_log():
 
     assert trials_processing.trial_data_from_log(test_trial_0) == expected_result_0
 
+def test_trial_data_from_log_1():
     test_trial_1 = {
         'index': 4,
         'cumulative_rewards': 1,
@@ -176,6 +177,7 @@ def test_trial_data_from_log():
 
     assert trials_processing.trial_data_from_log(test_trial_1) == expected_result_1
 
+def test_trial_data_from_log_2():
     test_trial_2 = {
         'index': 51,
         'cumulative_rewards': 11,

--- a/allensdk/test/brain_observatory/behavior/test_trials_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_trials_processing.py
@@ -78,7 +78,7 @@ def test_calculate_reward_rate(kwargs, expected):
     assert np.allclose(
         trials_processing.calculate_reward_rate(**kwargs),
         expected, 
-    ), "calculared reward rate should match expected reward rate :("
+    ), "calculated reward rate should match expected reward rate :("
 
 def test_trial_data_from_log():
     test_trial_0 = {

--- a/allensdk/test/brain_observatory/behavior/test_trials_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_trials_processing.py
@@ -80,3 +80,157 @@ def test_calculate_reward_rate(kwargs, expected):
         expected, 
     ), "calculared reward rate should match expected reward rate :("
 
+def test_trial_data_from_log():
+    test_trial_0 = {
+        'index': 3,
+        'cumulative_rewards': 1,
+        'licks': [(318.2737866026219, 18736),
+        (318.4235244484611, 18745),
+        (318.55351991075554, 18753),
+        (318.6735239364698, 18760),
+        (318.8235420609609, 18769),
+        (318.9733899117824, 18778),
+        (319.153503175955, 18789),
+        (319.35351008052305, 18801),
+        (321.24372627834714, 18914),
+        (321.3438153063156, 18920),
+        (321.49348118080985, 18929),
+        (321.6237259097134, 18937)],
+        'stimulus_changes': [(('im065', 'im065'),
+        ('im062', 'im062'),
+        317.76644976765834,
+        18706)],
+        'success': False,
+        'cumulative_volume': 0.005,
+        'trial_params': {'catch': False, 'auto_reward': True, 'change_time': 5},
+        'rewards': [(0.005, 317.92325660388286, 18715)],
+        'events': [['trial_start', '', 314.0120642698258, 18481],
+        ['initial_blank', 'enter', 314.01216666808074, 18481],
+        ['initial_blank', 'exit', 314.0122573636779, 18481],
+        ['pre_change', 'enter', 314.01233489378524, 18481],
+        ['pre_change', 'exit', 314.0124103759274, 18481],
+        ['stimulus_window', 'enter', 314.01248819860115, 18481],
+        ['stimulus_changed', '', 317.7666744586863, 18706],
+        ['auto_reward', '', 317.76681547571155, 18706],
+        ['response_window', 'enter', 317.9231027139341, 18715],
+        ['response_window', 'exit', 318.532233361527, 18752],
+        ['miss', '', 318.5324346472395, 18752],
+        ['stimulus_window', 'exit', 322.0351179203675, 18962],
+        ['no_lick', 'exit', 322.0352864386384, 18962],
+        ['trial_end', '', 322.0353750862705, 18962]]
+    }
+    
+    expected_result_0 = {
+        'reward_volume': 0.005,
+        'hit': False,
+        'false_alarm': False,
+        'miss': False,
+        'sham_change': False,
+        'stimulus_change': True,
+        'aborted': False,
+        'go': False,
+        'catch': False,
+        'auto_rewarded': True,
+        'correct_reject': False
+    }
+
+    assert trials_processing.trial_data_from_log(test_trial_0) == expected_result_0
+
+    test_trial_1 = {
+        'index': 4,
+        'cumulative_rewards': 1,
+        'licks': [(324.1935569847751, 19091),
+        (324.34329131981696, 19100),
+        (324.49368158882305, 19109)],
+        'stimulus_changes': [],
+        'success': False,
+        'cumulative_volume': 0.005,
+        'trial_params': {'catch': False, 'auto_reward': True, 'change_time': 6},
+        'rewards': [],
+        'events': [['trial_start', '', 322.2688823113451, 18976],
+        ['initial_blank', 'enter', 322.2689858798658, 18976],
+        ['initial_blank', 'exit', 322.26907599033007, 18976],
+        ['pre_change', 'enter', 322.2691523501716, 18976],
+        ['pre_change', 'exit', 322.26922900257955, 18976],
+        ['stimulus_window', 'enter', 322.26930536242105, 18976],
+        ['early_response', '', 324.1937059010944, 19091],
+        ['abort', '', 324.1937848940339, 19091],
+        ['timeout', 'enter', 324.19388963282034, 19091],
+        ['timeout', 'exit', 324.8042502297378, 19128],
+        ['trial_end', '', 324.80448691598986, 19128]]
+    }
+
+    expected_result_1 = {
+        'reward_volume': 0,
+        'hit': False,
+        'false_alarm': False,
+        'miss': False,
+        'sham_change': False,
+        'stimulus_change': False,
+        'aborted': True,
+        'go': False,
+        'catch': False,
+        'auto_rewarded': False,
+        'correct_reject': False
+    }
+
+    assert trials_processing.trial_data_from_log(test_trial_1) == expected_result_1
+
+    test_trial_2 = {
+        'index': 51,
+        'cumulative_rewards': 11,
+        'licks': [(542.6200214334176, 32186),
+        (542.7097825733969, 32191),
+        (542.8597161461861, 32200),
+        (542.9599280520605, 32206),
+        (543.059708422432, 32212),
+        (543.15998088956, 32218),
+        (543.2899491431752, 32226),
+        (543.4098750536493, 32233),
+        (543.5197477960238, 32240),
+        (543.6596846660369, 32248),
+        (543.7699336488565, 32255),
+        (543.8897463361172, 32262),
+        (544.0196821148575, 32270),
+        (544.13974055793, 32277),
+        (544.2596729048659, 32284),
+        (544.3896745110557, 32292),
+        (544.5397306691843, 32301)],
+        'stimulus_changes': [(('im069', 'im069'),
+        ('im085', 'im085'),
+        542.2007438794369,
+        32161)],
+        'success': True,
+        'cumulative_volume': 0.067,
+        'trial_params': {'catch': False, 'auto_reward': False, 'change_time': 4},
+        'rewards': [(0.007, 542.620156599114, 32186)],
+        'events': [['trial_start', '', 539.1971251251088, 31981],
+        ['initial_blank', 'enter', 539.197228401063, 31981],
+        ['initial_blank', 'exit', 539.1973220223246, 31981],
+        ['pre_change', 'enter', 539.1974007226976, 31981],
+        ['pre_change', 'exit', 539.197477667672, 31981],
+        ['stimulus_window', 'enter', 539.1975575383109, 31981],
+        ['stimulus_changed', '', 542.2009428246179, 32161],
+        ['response_window', 'enter', 542.3661398812824, 32171],
+        ['hit', '', 542.6201402153932, 32186],
+        ['response_window', 'exit', 542.9666720011281, 32207],
+        ['stimulus_window', 'exit', 546.4695340323526, 32417],
+        ['no_lick', 'exit', 546.4696966992947, 32417],
+        ['trial_end', '', 546.4697827138287, 32417]]
+    }
+
+    expected_result_2 = {
+        'reward_volume': 0.007,
+        'hit': True,
+        'false_alarm': False,
+        'miss': False,
+        'sham_change': False,
+        'stimulus_change': True,
+        'aborted': False,
+        'go': True,
+        'catch': False,
+        'auto_rewarded': False,
+        'correct_reject': False
+    }
+
+    assert trials_processing.trial_data_from_log(test_trial_2) == expected_result_2

--- a/allensdk/test/brain_observatory/behavior/test_trials_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_trials_processing.py
@@ -80,8 +80,8 @@ def test_calculate_reward_rate(kwargs, expected):
         expected, 
     ), "calculated reward rate should match expected reward rate :("
 
-def test_trial_data_from_log_0():
-    test_trial_0 = {
+def trial_data_and_expectation_0():
+    test_trial = {
         'index': 3,
         'cumulative_rewards': 1,
         'licks': [(318.2737866026219, 18736),
@@ -120,7 +120,7 @@ def test_trial_data_from_log_0():
         ['trial_end', '', 322.0353750862705, 18962]]
     }
     
-    expected_result_0 = {
+    expected_result = {
         'reward_volume': 0.005,
         'hit': False,
         'false_alarm': False,
@@ -134,10 +134,10 @@ def test_trial_data_from_log_0():
         'correct_reject': False
     }
 
-    assert trials_processing.trial_data_from_log(test_trial_0) == expected_result_0
+    return test_trial, expected_result
 
-def test_trial_data_from_log_1():
-    test_trial_1 = {
+def trial_data_and_expectation_1():
+    test_trial = {
         'index': 4,
         'cumulative_rewards': 1,
         'licks': [(324.1935569847751, 19091),
@@ -161,7 +161,7 @@ def test_trial_data_from_log_1():
         ['trial_end', '', 324.80448691598986, 19128]]
     }
 
-    expected_result_1 = {
+    expected_result = {
         'reward_volume': 0,
         'hit': False,
         'false_alarm': False,
@@ -175,10 +175,10 @@ def test_trial_data_from_log_1():
         'correct_reject': False
     }
 
-    assert trials_processing.trial_data_from_log(test_trial_1) == expected_result_1
+    return test_trial, expected_result
 
-def test_trial_data_from_log_2():
-    test_trial_2 = {
+def trial_data_and_expectation_2():
+    test_trial = {
         'index': 51,
         'cumulative_rewards': 11,
         'licks': [(542.6200214334176, 32186),
@@ -221,7 +221,7 @@ def test_trial_data_from_log_2():
         ['trial_end', '', 546.4697827138287, 32417]]
     }
 
-    expected_result_2 = {
+    expected_result = {
         'reward_volume': 0.007,
         'hit': True,
         'false_alarm': False,
@@ -235,4 +235,14 @@ def test_trial_data_from_log_2():
         'correct_reject': False
     }
 
-    assert trials_processing.trial_data_from_log(test_trial_2) == expected_result_2
+    return test_trial, expected_result
+
+
+@pytest.mark.parametrize("data_exp_getter", [
+    trial_data_and_expectation_0, 
+    trial_data_and_expectation_1,
+    trial_data_and_expectation_2
+])
+def test_trial_data_from_log(data_exp_getter):
+    data, expectation = data_exp_getter()
+    assert trials_processing.trial_data_from_log(data) == expectation


### PR DESCRIPTION
Currenty, foraging2 labels 'autorewarded' trials as 'go' trials. When reading trials into the SDK, the trial category is applied and autorewarded trials are therefore counted as a hit or miss (depending on whether or not the animal licked in the response window) and end up (erroneously) being used in the hit_rate calculation. 

This PR does the following:
* ensures that the hit/miss/false_alarm/correct_reject colums is False for any trials in with the auto_rewarded column is True
* ensures that the auto_rewarded column is False for any trials where the aborted column is True

Thus, of the six one-hot-encoded columns (hit, miss, false_alarm, correct_reject, aborted, auto_rewarded), only one can be True on a given trial.