### PR TITLE
Make BehaviorOphysNwbApi return arrays for timestamp attributes

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -126,10 +126,10 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         return {key: val.data[:] for key, val in self.nwbfile.stimulus_template.items()}
 
     def get_ophys_timestamps(self) -> np.ndarray:
-        return self.nwbfile.modules['two_photon_imaging'].get_data_interface('dff').roi_response_series['traces'].timestamps
+        return self.nwbfile.modules['two_photon_imaging'].get_data_interface('dff').roi_response_series['traces'].timestamps[:]
 
     def get_stimulus_timestamps(self) -> np.ndarray:
-        return self.nwbfile.modules['stimulus'].get_data_interface('timestamps').timestamps
+        return self.nwbfile.modules['stimulus'].get_data_interface('timestamps').timestamps[:]
 
     def get_trials(self) -> pd.DataFrame:
         trials = self.nwbfile.trials.to_dataframe()


### PR DESCRIPTION
Addresses #882 by making the BehaviorOphysNwbApi return the array of timestamp values instead of the timestamps object for the `ophys_timestamps` and `stimulus_timestamps`. 

This makes BehaviorOphysSession objects behave as they should:
```
In [7]: session.ophys_timestamps
Out[7]: 
array([2.97348000e+00, 3.00580000e+00, 3.03811000e+00, ...,
       4.52874295e+03, 4.52877528e+03, 4.52880760e+03])

In [8]: session.stimulus_timestamps
Out[8]: 
array([   7.46033,    7.47933,    7.49908, ..., 4510.0245 , 4510.03426,
       4510.05519])
```