### PR TITLE
pull change_time in trials table from stimulus_presentations

### DIFF
--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -217,7 +217,7 @@ def get_trial_reward_time(rebased_reward_times, start_time, stop_time):
     return float('nan') if len(reward_times) == 0 else one(reward_times)
         
 
-def get_trial_timing(event_dict, go, catch, auto_rewarded, hit, false_alarm):
+def get_trial_timing(event_dict, stimulus_presentations_df, go, catch, auto_rewarded, hit, false_alarm):
     '''
     extract trial timing data
     
@@ -235,22 +235,34 @@ def get_trial_timing(event_dict, go, catch, auto_rewarded, hit, false_alarm):
     assert not (go==True and catch==True), "both `go` and `catch` cannot be True, they are mutually exclusive categories"
     assert not (go==True and auto_rewarded==True), "both `go` and `auto_rewarded` cannot be True, they are mutually exclusive categories"
 
-    start_time = event_dict["trial_start", ""]
-    stop_time = event_dict["trial_end", ""]
+    start_time = event_dict["trial_start", ""]['rebased_time']
+    stop_time = event_dict["trial_end", ""]['rebased_time']
 
     if hit:
-        response_time = event_dict.get(("hit", ""))
+        response_time = event_dict.get(("hit", ""))['rebased_time']
     elif false_alarm:
-        response_time = event_dict.get(("false_alarm", ""))
+        response_time = event_dict.get(("false_alarm", ""))['rebased_time']
     else:
         response_time = float("nan")
 
+    def get_change_time(change_frame,stimulus_presentations_df):
+        # get the first stimulus in the log after the current change frame:
+        query = stimulus_presentations_df.query('start_frame >= @change_frame')
+        if len(query) > 0:
+            return query['start_time'].iloc[0]
+        else:
+            # return NaN if the query is empty
+            return np.nan
+
     if go or auto_rewarded:
-        change_time = event_dict.get(('stimulus_changed', ''))
+        change_frame = event_dict.get(('stimulus_changed', ''))['frame']
+        change_time = get_change_time(change_frame,stimulus_presentations_df)
     elif catch:
-        change_time = event_dict.get(('sham_change', ''))
+        change_frame = event_dict.get(('sham_change', ''))['frame']
+        change_time = get_change_time(change_frame,stimulus_presentations_df)
     else:
         change_time = float("nan")
+        change_frame = float("nan")
 
     if not (go or catch or auto_rewarded):
         response_latency = None
@@ -265,6 +277,7 @@ def get_trial_timing(event_dict, go, catch, auto_rewarded, hit, false_alarm):
         "stop_time": stop_time,
         "trial_length": stop_time - start_time,
         "response_time": response_time,
+        "change_frame": change_frame,
         "change_time": change_time,
         "response_latency": response_latency,
     }       
@@ -286,7 +299,7 @@ def get_trial_image_names(trial, stimuli):
     }
 
 
-def get_trials(data, licks_df, rewards_df, rebase):
+def get_trials(data, licks_df, rewards_df, stimulus_presentations_df, rebase):
     assert rewards_df.index.name == 'timestamps'
     stimuli = data["items"]["behavior"]["stimuli"]
     trial_log = data["items"]["behavior"]["trial_log"]
@@ -296,13 +309,15 @@ def get_trials(data, licks_df, rewards_df, rebase):
     rebased_reward_times = rewards_df.index.values
 
     for idx, trial in enumerate(trial_log):
-        event_dict = {(e[0], e[1]): rebase(e[2]) for e in trial['events']}
+        # extract rebased time and frame for each event in the trial log:
+        event_dict = {(e[0], e[1]): {'rebased_time':rebase(e[2]),'frame':e[3]} for e in trial['events']}
 
         tr_data = {"trial": trial["index"]}
 
         tr_data.update(trial_data_from_log(trial))
         tr_data.update(get_trial_timing(
             event_dict,
+            stimulus_presentations_df,
             tr_data['go'],
             tr_data['catch'],
             tr_data['auto_rewarded'],

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -180,8 +180,9 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
         behavior_stimulus_file = self.get_behavior_stimulus_file()
         data = pd.read_pickle(behavior_stimulus_file)
         rewards = self.get_rewards()
+        stimulus_presentations = self.get_stimulus_presentations()
         rebase_function = self.get_stimulus_rebase_function()
-        trial_df = get_trials(data, licks, rewards, rebase_function)
+        trial_df = get_trials(data, licks, rewards, stimulus_presentations, rebase_function)
 
         return trial_df
 

--- a/allensdk/test/brain_observatory/behavior/test_trials_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_trials_processing.py
@@ -246,3 +246,220 @@ def trial_data_and_expectation_2():
 def test_trial_data_from_log(data_exp_getter):
     data, expectation = data_exp_getter()
     assert trials_processing.trial_data_from_log(data) == expectation
+
+
+def test_get_trial_timing():
+    event_dict = {
+        ('trial_start', ''): {'rebased_time': 306.4785879253758, 'frame': 18075},
+        ('initial_blank', 'enter'): {'rebased_time': 306.47868008512637,
+        'frame': 18075},
+        ('initial_blank', 'exit'): {'rebased_time': 306.4787637603285,
+        'frame': 18075},
+        ('pre_change', 'enter'): {'rebased_time': 306.47883573270514, 'frame': 18075},
+        ('pre_change', 'exit'): {'rebased_time': 306.4789062422286, 'frame': 18075},
+        ('stimulus_window', 'enter'): {'rebased_time': 306.478977629464,
+        'frame': 18075},
+        ('stimulus_changed', ''): {'rebased_time': 310.9827406729944, 'frame': 18345},
+        ('auto_reward', ''): {'rebased_time': 310.98279450599154, 'frame': 18345},
+        ('response_window', 'enter'): {'rebased_time': 311.13223900212347,
+        'frame': 18354},
+        ('response_window', 'exit'): {'rebased_time': 311.73284526699706,
+        'frame': 18390},
+        ('miss', ''): {'rebased_time': 311.7330193465259, 'frame': 18390},
+        ('stimulus_window', 'exit'): {'rebased_time': 315.2356723770604,
+        'frame': 18600},
+        ('no_lick', 'exit'): {'rebased_time': 315.23582480636213, 'frame': 18600},
+        ('trial_end', ''): {'rebased_time': 315.23590438557534, 'frame': 18600}
+    }
+
+    nan = np.nan
+    stimulus_presentations_df = pd.DataFrame({
+        'duration': {
+            2: 0.2499599999999873,
+            3: nan,
+            4: 0.24966999999998052,
+            5: 0.24990999999999985,
+            6: 0.2499800000000505,
+            7: 0.2499300000000062,
+            8: 0.24996999999996206,
+            9: 0.24968999999998687,
+            10: 0.25983999999999696,
+            11: nan,
+            12: 0.24995000000001255,
+            13: 0.2500800000000254,
+            14: 0.2500800000000254
+        },
+        'end_frame': {
+            2: 18091.0,
+            3: nan,
+            4: 18181.0,
+            5: 18226.0,
+            6: 18271.0,
+            7: 18316.0,
+            8: 18361.0,
+            9: 18406.0,
+            10: 18451.0,
+            11: nan,
+            12: 18541.0,
+            13: 18586.0,
+            14: 18631.0
+        },
+        'image_index': {
+            2: 0,
+            3: 8,
+            4: 0,
+            5: 0,
+            6: 0,
+            7: 0,
+            8: 5,
+            9: 5,
+            10: 5,
+            11: 8,
+            12: 5,
+            13: 5,
+            14: 5
+        },
+        'image_name': {
+            2: 'im065',
+            3: 'omitted',
+            4: 'im065',
+            5: 'im065',
+            6: 'im065',
+            7: 'im065',
+            8: 'im062',
+            9: 'im062',
+            10: 'im062',
+            11: 'omitted',
+            12: 'im062',
+            13: 'im062',
+            14: 'im062'
+        },
+        'image_set': {
+            2: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            3: 'omitted',
+            4: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            5: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            6: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            7: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            8: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            9: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            10: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            11: 'omitted',
+            12: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            13: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2',
+            14: 'Natural_Images_Lum_Matched_set_training_2017.07.14_2'
+        },
+        'index': {
+            2: 2,
+            3: 0,
+            4: 3,
+            5: 4,
+            6: 5,
+            7: 6,
+            8: 7,
+            9: 8,
+            10: 9,
+            11: 1,
+            12: 10,
+            13: 11,
+            14: 12
+        },
+        'omitted': {
+            2: False,
+            3: True,
+            4: False,
+            5: False,
+            6: False,
+            7: False,
+            8: False,
+            9: False,
+            10: False,
+            11: True,
+            12: False,
+            13: False,
+            14: False
+        },
+        'orientation': {
+            2: nan,
+            3: nan,
+            4: nan,
+            5: nan,
+            6: nan,
+            7: nan,
+            8: nan,
+            9: nan,
+            10: nan,
+            11: nan,
+            12: nan,
+            13: nan,
+            14: nan
+        },
+        'start_frame': {
+            2: 18076,
+            3: 18120,
+            4: 18166,
+            5: 18211,
+            6: 18256,
+            7: 18301,
+            8: 18346,
+            9: 18391,
+            10: 18436,
+            11: 18480,
+            12: 18526,
+            13: 18571,
+            14: 18616
+        },
+        'start_time': {
+            2: 307.2712,
+            3: 308.00111,
+            4: 308.77121,
+            5: 309.52094,
+            6: 310.27088,
+            7: 311.02089,
+            8: 311.77086,
+            9: 312.52112,
+            10: 313.27098,
+            11: 314.01115,
+            12: 314.78083,
+            13: 315.53094,
+            14: 316.2808
+        },
+        'stop_time': {
+            2: 307.52116,
+            3: nan,
+            4: 309.02088,
+            5: 309.77085,
+            6: 310.52086,
+            7: 311.27082,
+            8: 312.02083,
+            9: 312.77081,
+            10: 313.53082,
+            11: nan,
+            12: 315.03078,
+            13: 315.78102,
+            14: 316.53088
+        }
+    })
+
+    result = trials_processing.get_trial_timing(
+        event_dict,
+        stimulus_presentations_df,
+        go=False,
+        catch=False,
+        auto_rewarded=True,
+        hit=False,
+        false_alarm=False,
+    )
+
+    expected_result = {
+        'start_time': 306.4785879253758,
+        'stop_time': 315.23590438557534,
+        'trial_length': 8.757316460199547,
+        'response_time': nan,
+        'change_frame': 18345,
+        'change_time': 311.77086,
+        'response_latency': np.inf
+        }
+
+    # use assert_frame_equal to take advantage of the nice way it deals with NaNs
+    pd.testing.assert_frame_equal(pd.DataFrame(result,index=[0]), pd.DataFrame(expected_result,index=[0]), check_names=False)


### PR DESCRIPTION
addresses issue #802. Pulls the values in the 'change_time' column from the 'stimulus_presentations' dataframe. Assuming that the 'stimulus_presentations' table represents the time that each stimulus is presented to the animal, this will make the 'change_time' column accurately represent the change time that the animal experienced during the experiment.