### PR TITLE
Use falling edge of vsync line for stimulus vsync

### DIFF
--- a/allensdk/brain_observatory/behavior/sync/__init__.py
+++ b/allensdk/brain_observatory/behavior/sync/__init__.py
@@ -15,14 +15,14 @@ def get_sync_data(sync_path):
     meta_data = sync_dataset.meta_data
     sample_freq = meta_data['ni_daq']['counter_output_freq']
     
+    # use rising edge for Scientifica, falling edge for Nikon http://confluence.corp.alleninstitute.org/display/IT/Ophys+Time+Sync
     # 2P vsyncs
     vs2p_r = sync_dataset.get_rising_edges('2p_vsync')
     vs2p_f = sync_dataset.get_falling_edges('2p_vsync')  # new sync may be able to do units = 'sec', so conversion can be skipped
     frames_2p = vs2p_r / sample_freq
     vs2p_fsec = vs2p_f / sample_freq
 
-    # use rising edge for Scientifica, falling edge for Nikon http://confluence.corp.alleninstitute.org/display/IT/Ophys+Time+Sync
-    stimulus_times_no_monitor_delay = sync_dataset.get_rising_edges('stim_vsync') / sample_freq
+    stimulus_times_no_monitor_delay = sync_dataset.get_falling_edges('stim_vsync') / sample_freq
 
     if 'lick_times' in meta_data['line_labels']:
         lick_times = sync_dataset.get_rising_edges('lick_1') / sample_freq

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -72,7 +72,7 @@ def test_visbeh_ophys_data_set():
     assert len(data_set.corrected_fluorescence_traces) == 269 and sorted(data_set.corrected_fluorescence_traces.columns) == ['cell_roi_id', 'corrected_fluorescence']
     np.testing.assert_array_almost_equal(data_set.running_speed.timestamps, data_set.stimulus_timestamps)
     assert len(data_set.cell_specimen_table) == len(data_set.dff_traces)
-    assert data_set.average_projection.GetSize() == data_set.max_projection.GetSize()
+    assert data_set.average_projection.data.shape == data_set.max_projection.data.shape
     assert list(data_set.motion_correction.columns) == ['x', 'y']
     assert len(data_set.trials) == 602
 


### PR DESCRIPTION
The rising edges of the stimulus vsync line are currently being used as the stimulus_timestamps_no_monitor_delay, which is not correct. The interval between the rising edges fluctuates between 10ms and 20ms. The falling edge is the best estimate of when the frame has been sent off by camstim, and the difference between these edges is the expected 16.6ms. 