### PR TITLE
904/ecephys fixed cache

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/__init__.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/__init__.py
@@ -1,3 +1,4 @@
 from .ecephys_project_api import EcephysProjectApi
 from .ecephys_project_lims_api import EcephysProjectLimsApi
 from .ecephys_project_warehouse_api import EcephysProjectWarehouseApi
+from .ecephys_project_fixed_api import EcephysProjectFixedApi

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/__init__.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/__init__.py
@@ -1,4 +1,4 @@
 from .ecephys_project_api import EcephysProjectApi
 from .ecephys_project_lims_api import EcephysProjectLimsApi
 from .ecephys_project_warehouse_api import EcephysProjectWarehouseApi
-from .ecephys_project_fixed_api import EcephysProjectFixedApi
+from .ecephys_project_fixed_api import EcephysProjectFixedApi, MissingDataError

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -2,7 +2,7 @@ class EcephysProjectApi:
     def get_sessions(self):
         raise NotImplementedError()
 
-    def get_session_data(self):
+    def get_session_data(self, session_id):
         raise NotImplementedError()
 
     def get_targeted_regions(self):
@@ -20,5 +20,5 @@ class EcephysProjectApi:
     def get_probes(self):
         raise NotImplementedError()
 
-    def get_probe_lfp_data(self):
+    def get_probe_lfp_data(self, probe_id):
         raise NotImplementedError()

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_fixed_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_fixed_api.py
@@ -1,0 +1,24 @@
+from allensdk.brain_observatory.ecephys.ecephys_project_api import EcephysProjectApi
+
+
+class MissngDataError(ValueError):
+    pass
+
+
+class EcephysProjectFixedApi(EcephysProjectApi):
+
+    SPECIALIZED = ("get_session_data", "get_probe_data")
+
+    def get_session_data(self, session_id):
+        raise MissngDataError(f"data for session {session_id} not found!")
+
+    def get_probe_lfp_data(self, probe_id):
+        raise MissngDataError(f"lfp data for probe {probe_id} not found!")
+
+    def __getattr__(self, key):
+        if key in self.SPECIALIZED:
+            return self.__dict__[key]
+
+        def cannot_get(*args, **kwargs):
+            raise MissingDataError(f"Data not found (you called {key} with args {args} and kwargs {kwargs})!")
+        return cannot_get

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_fixed_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_fixed_api.py
@@ -7,8 +7,6 @@ class MissingDataError(ValueError):
 
 class EcephysProjectFixedApi(EcephysProjectApi):
 
-    SPECIALIZED = ("get_session_data", "get_probe_data")
-
     def get_session_data(self, session_id):
         raise MissingDataError(f"data for session {session_id} not found!")
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_fixed_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_fixed_api.py
@@ -1,7 +1,7 @@
 from allensdk.brain_observatory.ecephys.ecephys_project_api import EcephysProjectApi
 
 
-class MissngDataError(ValueError):
+class MissingDataError(ValueError):
     pass
 
 
@@ -10,15 +10,25 @@ class EcephysProjectFixedApi(EcephysProjectApi):
     SPECIALIZED = ("get_session_data", "get_probe_data")
 
     def get_session_data(self, session_id):
-        raise MissngDataError(f"data for session {session_id} not found!")
+        raise MissingDataError(f"data for session {session_id} not found!")
 
     def get_probe_lfp_data(self, probe_id):
-        raise MissngDataError(f"lfp data for probe {probe_id} not found!")
+        raise MissingDataError(f"lfp data for probe {probe_id} not found!")
 
-    def __getattr__(self, key):
-        if key in self.SPECIALIZED:
-            return self.__dict__[key]
+    def get_sessions(self):
+        raise MissingDataError(f"Data not found!")
 
-        def cannot_get(*args, **kwargs):
-            raise MissingDataError(f"Data not found (you called {key} with args {args} and kwargs {kwargs})!")
-        return cannot_get
+    def get_targeted_regions(self):
+        raise MissingDataError(f"Data not found!")
+
+    def get_isi_experiments(self):
+        raise MissingDataError(f"Data not found!")
+
+    def get_units(self):
+        raise MissingDataError(f"Data not found!")
+
+    def get_channels(self):
+        raise MissingDataError(f"Data not found!")
+
+    def get_probes(self):
+        raise MissingDataError(f"Data not found!")

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from allensdk.api.cache import Cache
 
-from allensdk.brain_observatory.ecephys.ecephys_project_api import EcephysProjectLimsApi, EcephysProjectWarehouseApi
+from allensdk.brain_observatory.ecephys.ecephys_project_api import EcephysProjectLimsApi, EcephysProjectWarehouseApi, EcephysProjectFixedApi
 from allensdk.brain_observatory.ecephys.ecephys_session_api import EcephysNwbSessionApi
 from allensdk.brain_observatory.ecephys.ecephys_session import EcephysSession
 from allensdk.brain_observatory.ecephys.file_promise import FilePromise, read_nwb, write_from_stream
@@ -194,3 +194,7 @@ class EcephysProjectCache(Cache):
             fetch_api=EcephysProjectWarehouseApi.default(**warehouse_kwargs), 
             **kwargs
         )
+
+    @classmethod
+    def fixed(cls, **kwargs):
+        return cls(api=EcephysProjectFixedApi(), **kwargs)

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -197,4 +197,4 @@ class EcephysProjectCache(Cache):
 
     @classmethod
     def fixed(cls, **kwargs):
-        return cls(api=EcephysProjectFixedApi(), **kwargs)
+        return cls(fetch_api=EcephysProjectFixedApi(), **kwargs)

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_fixed_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_fixed_api.py
@@ -1,0 +1,16 @@
+import pytest
+
+from allensdk.brain_observatory.ecephys.ecephys_project_api import EcephysProjectFixedApi, MissingDataError
+
+
+def test_get_sessions():
+    api = EcephysProjectFixedApi()
+    with pytest.raises(MissingDataError) as err:
+        api.get_sessions()
+
+
+def test_get_session_data():
+    api = EcephysProjectFixedApi()
+    with pytest.raises(MissingDataError) as err:
+        api.get_session_data(12345)
+        assert re.compile("12345").search(err.message) is not None


### PR DESCRIPTION
adds an ecephys project api that raises nice errors when asked for data. This can be passed to a project cache in order to implement a fixed stable, cache for workshops or analysis.