### PR TITLE
Fix alignment between trial df and stimulus_presentation df

### DIFF
--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -197,6 +197,11 @@ def get_visual_stimuli_df(data, time):
 
     visual_stimuli_df = pd.DataFrame(data=visual_stimuli_data)
 
+    # ensure that every rising edge in the draw_log is accounted for in the visual_stimuli_df
+    draw_log_rising_edges = len(np.where(np.diff(stimuli['images']['draw_log'])==1)[0])
+    discrete_flashes = len(visual_stimuli_data)
+    assert draw_log_rising_edges == discrete_flashes, "the number of rising edges in the draw log is expected to match the number of flashes in the stimulus table"
+
     # Add omitted flash info:
     omitted_flash_list = []
     omitted_flash_frame_log = data['items']['behavior']['omitted_flash_frame_log']

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -28,8 +28,7 @@ def load_pickle(pstream):
 
 def get_stimulus_presentations(data, stimulus_timestamps):
 
-    visual_stimuli = get_visual_stimuli_df(data, stimulus_timestamps)
-    stimulus_table = visual_stimuli[:-10]  # ignore last 10 flashes
+    stimulus_table = get_visual_stimuli_df(data, stimulus_timestamps)
     # workaround to rename columns to harmonize with visual coding and rebase timestamps to sync time
     stimulus_table.insert(loc=0, column='flash_number', value=np.arange(0, len(stimulus_table)))
     stimulus_table = stimulus_table.rename(columns={'frame': 'start_frame', 'time': 'start_time', 'flash_number':'stimulus_presentations_id'})

--- a/allensdk/brain_observatory/behavior/validation.py
+++ b/allensdk/brain_observatory/behavior/validation.py
@@ -59,7 +59,7 @@ def validate_last_trial_ends_adjacent_to_flash(ophys_experiment_id, api=None, ve
         # count number of omitted flashes at the very end of the session
         N_final_omitted_flashes = session.stimulus_presentations.index.max() - session.stimulus_presentations.query('omitted == False').index.max()
         
-        # get the star/end time of the last valid (non-omitted) flash
+        # get the start/end time of the last valid (non-omitted) flash
         last_flash_start = session.stimulus_presentations.query('omitted == False')['start_time'].iloc[-1]
         last_flash_end = session.stimulus_presentations.query('omitted == False')['stop_time'].iloc[-1]
         

--- a/allensdk/brain_observatory/behavior/validation.py
+++ b/allensdk/brain_observatory/behavior/validation.py
@@ -3,6 +3,7 @@ import os
 
 from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
 from allensdk.internal.api.ophys_lims_api import OphysLimsApi
+from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession
 
 class ValidationError(AssertionError):
     pass
@@ -36,6 +37,45 @@ def validate_ophys_timestamps(ophys_experiment_id, api=None):
 
     if raw_data_shape[0] != ophys_timestamps_shape[0]:
         raise ValidationError('ophys_timestamp length does not match raw data length')
+
+def validate_last_trial_ends_adjacent_to_flash(ophys_experiment_id, api=None, verbose=False):
+        # ensure that the last trial ends sometime on the last flash/blank cycle
+        # i.e, if this is the last flash/blank iteration (high = stimulus present):
+        #           -------           -------           -------           -------
+        #          |       |         |       |         |       |         |       |
+        # ---------         ---------         ---------         ---------         -------------------------------------------
+        #                                                                ^                                                  ^
+        # The last trial has to have ended somewhere between the two carrots where:
+        #   the first carrot represents the time of the last recorded stimulus flash
+        #   the second carrot represents the time at which another flash should have started, after accounting for the possibility of the session ending on an omitted flash
+        
+        api = BehaviorOphysLimsApi() if api is None else api
+        session = BehaviorOphysSession(api)
+
+        # get the flash/blank parameters
+        max_flash_duration = session.stimulus_presentations['duration'].max()
+        max_blank_duration = session.task_parameters['blank_duration_sec'][1]
+        
+        # count number of omitted flashes at the very end of the session
+        N_final_omitted_flashes = session.stimulus_presentations.index.max() - session.stimulus_presentations.query('omitted == False').index.max()
+        
+        # get the star/end time of the last valid (non-omitted) flash
+        last_flash_start = session.stimulus_presentations.query('omitted == False')['start_time'].iloc[-1]
+        last_flash_end = session.stimulus_presentations.query('omitted == False')['stop_time'].iloc[-1]
+        
+        # calculate when the next stimulus should have flashed, after accounting for any omitted flashes at the end of the session
+        next_flash_would_have_started = last_flash_end + max_blank_duration + N_final_omitted_flashes*(max_flash_duration + max_blank_duration)
+        
+        # get the end time of the last trial
+        last_trial_end = session.trials.iloc[-1]['stop_time']
+        
+        if verbose:
+            print('last flash ended at {}'.format(last_flash_end))
+            print('another flash should have started by {}'.format(next_flash_would_have_started))
+            print('last trial ended at {}'.format(last_trial_end))
+        
+        if not last_flash_start <= last_trial_end <= next_flash_would_have_started:
+            raise ValidationError('The last trial does not end between the start of the last flash and the expected start time of the next flash')
 
 if __name__ == "__main__":
 

--- a/allensdk/brain_observatory/behavior/validation.py
+++ b/allensdk/brain_observatory/behavior/validation.py
@@ -94,7 +94,12 @@ if __name__ == "__main__":
                                 808619526, 808619543, 808621034, 808621015]
 
     for ophys_experiment_id in ophys_experiment_id_list:
-        for validation_function in [validate_ophys_timestamps, validate_ophys_dff_length]:
+        validation_functions_to_run = [
+            validate_ophys_timestamps, 
+            validate_ophys_dff_length,
+            validate_last_trial_ends_adjacent_to_flash,
+        ]
+        for validation_function in validation_functions_to_run:
 
             try:
                 validation_function(ophys_experiment_id, api=api)


### PR DESCRIPTION
This PR does the following:
* addresses issue #893, in which the last 10 trials of the stimulus_presentations table was being clipped (discussed verbally with @matchings, she verified that this fix could be applied)
* asserts that the number of flashes in the stimulus table matches the number of rising edges in the draw_log
* adds a validation function that ensures that the last trial in the trial dataframe ends at the correct time relative to the flashing cadence (i.e., no more than one flash/blank duration after the start of the last flash in the table)