### PR TITLE
apply unit default filters to project cache

### DIFF
--- a/allensdk/brain_observatory/ecephys/__init__.py
+++ b/allensdk/brain_observatory/ecephys/__init__.py
@@ -13,7 +13,7 @@ UNIT_FILTER_DEFAULTS = {
     },
     "isi_violations_maximum": {
         "value": 0.5,
-        "misssing": np.inf
+        "missing": np.inf
     }
 }
 

--- a/allensdk/brain_observatory/ecephys/__init__.py
+++ b/allensdk/brain_observatory/ecephys/__init__.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+
+UNIT_FILTER_DEFAULTS = {
+    "amplitude_cutoff_maximum": {
+        "value": 0.1,
+        "missing": np.inf
+    },
+    "presence_ratio_minimum": {
+        "value": 0.95,
+        "missing": -np.inf
+    },
+    "isi_violations_maximum": {
+        "value": 0.5,
+        "misssing": np.inf
+    }
+}
+
+
+def get_unit_filter_value(key, pop=True, **source):
+    if pop:
+        value = source.pop(key, UNIT_FILTER_DEFAULTS[key]["value"])
+    else:
+        value = source.get(key, UNIT_FILTER_DEFAULTS[key]["value"])
+    
+    if value is None:
+        value = UNIT_FILTER_DEFAULTS[key]["default"]
+
+    return value

--- a/allensdk/brain_observatory/ecephys/__init__.py
+++ b/allensdk/brain_observatory/ecephys/__init__.py
@@ -18,13 +18,13 @@ UNIT_FILTER_DEFAULTS = {
 }
 
 
-def get_unit_filter_value(key, pop=True, **source):
+def get_unit_filter_value(key, pop=True, replace_none=True, **source):
     if pop:
         value = source.pop(key, UNIT_FILTER_DEFAULTS[key]["value"])
     else:
         value = source.get(key, UNIT_FILTER_DEFAULTS[key]["value"])
     
-    if value is None:
+    if value is None and replace_none:
         value = UNIT_FILTER_DEFAULTS[key]["default"]
 
     return value

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -9,6 +9,7 @@ from .http_engine import HttpEngine
 from .utilities import postgres_macros, build_and_execute
 
 from allensdk.internal.api import PostgresQueryMixin
+from allensdk.brain_observatory.ecephys import get_unit_filter_value
 
 
 class EcephysProjectLimsApi(EcephysProjectApi):
@@ -96,9 +97,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                 {{pm.optional_contains('ec.id', channel_ids) -}}
                 {{pm.optional_contains('ep.id', probe_ids) -}}
                 {{pm.optional_contains('es.id', session_ids) -}}
-                {{pm.optional_le('eun.amplitude_cutoff', amplitude_cutoff_maximum) -}}
-                {{pm.optional_ge('eun.presence_ratio', presence_ratio_minimum) -}}
-                {{pm.optional_le('eun.isi_violations', isi_violations_maximum) -}}
+                {{pm.optional_le('eu.amplitude_cutoff', amplitude_cutoff_maximum) -}}
+                {{pm.optional_ge('eu.presence_ratio', presence_ratio_minimum) -}}
+                {{pm.optional_le('eu.isi_violations', isi_violations_maximum) -}}
             """,
             base=postgres_macros(),
             engine=self.postgres_engine.select,

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -74,7 +74,12 @@ class EcephysProjectLimsApi(EcephysProjectApi):
         )
 
     def get_units(
-        self, unit_ids=None, channel_ids=None, probe_ids=None, session_ids=None, quality="good"
+        self, unit_ids=None, 
+        channel_ids=None, 
+        probe_ids=None, 
+        session_ids=None, 
+        quality="good",
+        **kwargs
     ):
         response = build_and_execute(
             """
@@ -91,6 +96,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                 {{pm.optional_contains('ec.id', channel_ids) -}}
                 {{pm.optional_contains('ep.id', probe_ids) -}}
                 {{pm.optional_contains('es.id', session_ids) -}}
+                {{pm.optional_le('eun.amplitude_cutoff', amplitude_cutoff_maximum) -}}
+                {{pm.optional_ge('eun.presence_ratio', presence_ratio_minimum) -}}
+                {{pm.optional_le('eun.isi_violations', isi_violations_maximum) -}}
             """,
             base=postgres_macros(),
             engine=self.postgres_engine.select,
@@ -98,7 +106,10 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             channel_ids=channel_ids,
             probe_ids=probe_ids,
             session_ids=session_ids,
-            quality=f"'{quality}'" if quality is not None else quality
+            quality=f"'{quality}'" if quality is not None else quality,
+            amplitude_cutoff_maximum=get_unit_filter_value("amplitude_cutoff_maximum", replace_none=False, **kwargs),
+            presence_ratio_minimum=get_unit_filter_value("presence_ratio_minimum", replace_none=False, **kwargs),
+            isi_violations_maximum=get_unit_filter_value("isi_violations_maximum", replace_none=False, **kwargs)
         )
 
         response.set_index("id", inplace=True)
@@ -106,7 +117,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
         return response
 
-    def get_channels(self, channel_ids=None, probe_ids=None, session_ids=None):
+    def get_channels(self, channel_ids=None, probe_ids=None, session_ids=None, **kwargs):
         response = build_and_execute(
             """
                 {%- import 'postgres_macros' as pm -%}
@@ -130,6 +141,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                     join ecephys_units eun on (
                         eun.ecephys_channel_id = ech.id
                         and eun.quality = 'good'
+                        {{pm.optional_le('eun.amplitude_cutoff', amplitude_cutoff_maximum) -}}
+                        {{pm.optional_ge('eun.presence_ratio', presence_ratio_minimum) -}}
+                        {{pm.optional_le('eun.isi_violations', isi_violations_maximum) -}}
                     )
                     group by ech.id
                 ) pc on ec.id = pc.ecephys_channel_id
@@ -143,10 +157,13 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             channel_ids=channel_ids,
             probe_ids=probe_ids,
             session_ids=session_ids,
+            amplitude_cutoff_maximum=get_unit_filter_value("amplitude_cutoff_maximum", replace_none=False, **kwargs),
+            presence_ratio_minimum=get_unit_filter_value("presence_ratio_minimum", replace_none=False, **kwargs),
+            isi_violations_maximum=get_unit_filter_value("isi_violations_maximum", replace_none=False, **kwargs)
         )
         return response.set_index("id")
 
-    def get_probes(self, probe_ids=None, session_ids=None):
+    def get_probes(self, probe_ids=None, session_ids=None, **kwargs):
         response = build_and_execute(
             """
                 {%- import 'postgres_macros' as pm -%}
@@ -177,6 +194,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                     join ecephys_units eun on (
                         eun.ecephys_channel_id = ech.id
                         and eun.quality = 'good'
+                        {{pm.optional_le('eun.amplitude_cutoff', amplitude_cutoff_maximum) -}}
+                        {{pm.optional_ge('eun.presence_ratio', presence_ratio_minimum) -}}
+                        {{pm.optional_le('eun.isi_violations', isi_violations_maximum) -}}
                     )
                     group by epr.id
                 ) chc on ep.id = chc.ecephys_probe_id
@@ -220,6 +240,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             engine=self.postgres_engine.select,
             probe_ids=probe_ids,
             session_ids=session_ids,
+            amplitude_cutoff_maximum=get_unit_filter_value("amplitude_cutoff_maximum", replace_none=False, **kwargs),
+            presence_ratio_minimum=get_unit_filter_value("presence_ratio_minimum", replace_none=False, **kwargs),
+            isi_violations_maximum=get_unit_filter_value("isi_violations_maximum", replace_none=False, **kwargs)
         )
         return response.set_index("id")
 
@@ -233,7 +256,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             "BrainTV Neuropixels Visual Behavior",
             "BrainTV Neuropixels Visual Coding",
         ),
+        **kwargs
     ):
+
         response = build_and_execute(
             """
                 {%- import 'postgres_macros' as pm -%}
@@ -274,6 +299,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                     join ecephys_units eun on (
                         eun.ecephys_channel_id = ech.id
                         and eun.quality = 'good'
+                        {{pm.optional_le('eun.amplitude_cutoff', amplitude_cutoff_maximum) -}}
+                        {{pm.optional_ge('eun.presence_ratio', presence_ratio_minimum) -}}
+                        {{pm.optional_le('eun.isi_violations', isi_violations_maximum) -}}
                     )
                     group by es.id
                 ) pc on es.id = pc.ecephys_session_id
@@ -319,6 +347,9 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             published=published,
             habituation=f"{habituation}".lower() if habituation is not None else habituation,
             project_names=project_names,
+            amplitude_cutoff_maximum=get_unit_filter_value("amplitude_cutoff_maximum", replace_none=False, **kwargs),
+            presence_ratio_minimum=get_unit_filter_value("presence_ratio_minimum", replace_none=False, **kwargs),
+            isi_violations_maximum=get_unit_filter_value("isi_violations_maximum", replace_none=False, **kwargs)
         )
         
         response.set_index("id", inplace=True) 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/utilities.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/utilities.py
@@ -40,6 +40,16 @@ def postgres_macros():
                     and {{key}} is {{- ' not ' if value -}} null
                 {% endif %}
             {% endmacro %}
+            {% macro optional_le(key, value) %}
+                {% if value is not none -%}
+                    and {{key}} <= {{value}}
+                {% endif %}
+            {% endmacro %}
+            {% macro optional_ge(key, value) %}
+                {% if value is not none -%}
+                    and {{key}} >= {{value}}
+                {% endif %}
+            {% endmacro %}
         """,
         "macros": macros()["macros"]
     }

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -47,8 +47,6 @@ class EcephysProjectCache(Cache):
 
         super(EcephysProjectCache, self).__init__(**kwargs)
         self.fetch_api = fetch_api
-        
-        self.unit_filter_defaults = unit_filter_defaults()
 
 
     def get_sessions(self):

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -82,6 +82,11 @@ class EcephysProjectCache(Cache):
         """
 
         path = self.get_cache_path(None, self.UNITS_KEY)
+        get_units = self.fetch_api.get_units(
+            amplitude_cutoff_maximum=None, # pull down all the units to csv and filter on the way out
+            presence_ratio_minimum=None, 
+            isi_violations_maximum=None
+        )
         units = call_caching(self.fetch_api.get_units, path, strategy='lazy', **csv_io)
 
         if annotate:

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -95,9 +95,11 @@ class EcephysProjectCache(Cache):
             units = pd.merge(units, probes, left_on='ecephys_probe_id', right_index=True, suffixes=['_unit', '_probe'])
             units = pd.merge(units, sessions, left_on='ecephys_session_id', right_index=True, suffixes=['_unit', '_session'])
 
-        units = units[units["amplitude_cutoff"] <= get_unit_filter_value("amplitude_cutoff_maximum", **kwargs)]
-        units = units[units["presence_ratio"] >= get_unit_filter_value("presence_ratio_minimum", **kwargs)]
-        units = units[units["isi_violations"] <= get_unit_filter_value("isi_violations_maximum", **kwargs)]
+        units =units[
+            (units["amplitude_cutoff"] <= get_unit_filter_value("amplitude_cutoff_maximum", **kwargs))
+            & (units["presence_ratio"] >= get_unit_filter_value("presence_ratio_minimum", **kwargs))
+            & (units["isi_violations"] <= get_unit_filter_value("isi_violations_maximum", **kwargs))
+        ]
         
         return units
 

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -11,6 +11,7 @@ from .ecephys_session_api import EcephysSessionApi
 from allensdk.brain_observatory.ecephys.file_promise import FilePromise
 from allensdk.brain_observatory.nwb.nwb_api import NwbApi
 import allensdk.brain_observatory.ecephys.nwb
+from allensdk.brain_observatory.ecephys import get_unit_filter_value
 
 
 class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
@@ -18,9 +19,9 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
     def __init__(self, path, probe_lfp_paths: Optional[Dict[int, FilePromise]] = None, **kwargs):
 
         self.filter_by_validity = kwargs.pop("filter_by_validity", True)
-        self.amplitude_cutoff_maximum = kwargs.pop("amplitude_cutoff_maximum", 0.1)
-        self.presence_ratio_minimum = kwargs.pop("presence_ratio_minimum", 0.95)
-        self.isi_violations_maximum = kwargs.pop("isi_violations_maximum", 0.5)
+        self.amplitude_cutoff_maximum = get_unit_filter_value("amplitude_cutoff_maximum", **kwargs)
+        self.presence_ratio_minimum = get_unit_filter_value("presence_ratio_minimum", **kwargs)
+        self.isi_violations_maximum = get_unit_filter_value("isi_violations_maximum", **kwargs)
 
         super(EcephysNwbSessionApi, self).__init__(path, **kwargs)
         self.probe_lfp_paths = probe_lfp_paths
@@ -167,13 +168,8 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
             ]
             units.drop(columns=["quality"], inplace=True)
 
-        if self.amplitude_cutoff_maximum is not None:
-            units = units[units["amplitude_cutoff"] <= self.amplitude_cutoff_maximum]
-
-        if self.presence_ratio_minimum is not None:
-            units = units[units["presence_ratio"] >= self.presence_ratio_minimum]
-        
-        if self.isi_violations_maximum is not None:
-            units = units[units["isi_violations"] <= self.isi_violations_maximum]
+        units = units[units["amplitude_cutoff"] <= self.amplitude_cutoff_maximum]
+        units = units[units["presence_ratio"] >= self.presence_ratio_minimum]
+        units = units[units["isi_violations"] <= self.isi_violations_maximum]
 
         return units

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
@@ -23,7 +23,10 @@ def sessions():
 def units():
     return pd.DataFrame({
         'peak_channel_id': [2, 1],
-        'snr': [1.5, 4.9]
+        'snr': [1.5, 4.9],
+        "amplitude_cutoff": [0.05, 0.2],
+        "presence_ratio": [10, 20],
+        "isi_violations": [0.3, 0.4]
     }, index=pd.Series(name='id', data=[1, 2]))
 
 
@@ -107,11 +110,12 @@ def test_get_sessions(tmpdir_cache, sessions):
 
 
 def test_get_units(tmpdir_cache, units):
+    units = units[units["amplitude_cutoff"] <= 0.1]
     lazy_cache_test(tmpdir_cache, 'get_units', "get_units", units)
 
 
 def test_get_units_annotated(tmpdir_cache, units, channels, probes, sessions):
-    units = tmpdir_cache.get_units(annotate=True)
+    units = tmpdir_cache.get_units(annotate=True, amplitude_cutoff_maximum=10)
     assert units.loc[2, "stimulus_name"] == "stimulus_set_two"
 
 

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
@@ -63,16 +63,16 @@ def mock_api(shared_tmpdir, sessions, units, channels, probes):
         def __getattr__(self, name):
             self.accesses[name] += 1
 
-        def get_sessions(self):
+        def get_sessions(self, **kwargs):
             return sessions
 
-        def get_units(self):
+        def get_units(self, **kwargs):
             return units
 
-        def get_channels(self):
+        def get_channels(self, **kwargs):
             return channels
 
-        def get_probes(self):
+        def get_probes(self, **kwargs):
             return probes
 
         def get_session_data(self, session_id):

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
@@ -26,12 +26,12 @@ from allensdk.brain_observatory.ecephys.ecephys_project_api import (
         [
             "get_units",
             {"session_ids": [1, 2, 3]},
-            re.compile(r"select eu\.\*.*and es\.id in \(1,2,3\)$"),
+            re.compile(r"select eu\.\*.*and es\.id in \(1,2,3\) and eu.amplitude_cutoff <= 0.1 and eu.presence_ratio >= 0.95 and eu.isi_violations <= 0.5$"),
         ],
         [
             "get_units",
             {"session_ids": [1, 2, 3], "unit_ids": (4, 5, 6)},
-            re.compile(r"select eu\.\*.*and eu\.id in \(4,5,6\) and es\.id in \(1,2,3\)$")
+            re.compile(r"select eu\.\*.*and eu\.id in \(4,5,6\) and es\.id in \(1,2,3\) and eu.amplitude_cutoff <= 0.1 and eu.presence_ratio >= 0.95 and eu.isi_violations <= 0.5$")
         ],
         [
             "get_channels",
@@ -56,7 +56,9 @@ def test_query(method, conditions, expected):
 
     results = getattr(api, method)(**conditions)
     
-    match = expected.match(pg_engine.query.strip())
+    obtained = pg_engine.query.strip()
+    print(obtained)
+    match = expected.match(obtained)
     assert match is not None
 
 


### PR DESCRIPTION
- unit quality filter defaults are stored in a single location
- project level access applies quality filters by default