### PR TITLE
Filter aborted trials from trials table by default for sessions loaded from SWDB cache

### DIFF
--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -297,7 +297,8 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
 
         # Rename some columns to make more sense to students
         stimulus_presentations = stimulus_presentations.rename(
-            columns={'index':'absolute_flash_number'})
+            columns={'index':'absolute_flash_number',
+                     'running_speed':'mean_running_speed'})
         # Replace image set with A/B
         stimulus_presentations['image_set'] = self.get_task_parameters()['stage'][15]
         # Change index name for easier merge with flash_response_df

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -343,7 +343,48 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
 
 
 class ExtendedBehaviorSession(BehaviorOphysSession):
-
+    """Represents data from a single Visual Behavior Ophys imaging session.  LazyProperty attributes access the data only on the first demand, and then memoize the result for reuse.
+    
+    Attributes:
+        ophys_experiment_id : int (LazyProperty)
+            Unique identifier for this experimental session
+        max_projection : allensdk.brain_observatory.behavior.image_api.Image (LazyProperty)
+            2D max projection image
+        stimulus_timestamps : numpy.ndarray (LazyProperty)
+            Timestamps associated the stimulus presentations on the monitor 
+        ophys_timestamps : numpy.ndarray (LazyProperty)
+            Timestamps associated with frames captured by the microscope
+        metadata : dict (LazyProperty)
+            A dictionary of session-specific metadata
+        dff_traces : pandas.DataFrame (LazyProperty)
+            The traces of dff organized into a dataframe; index is the cell roi ids
+        cell_specimen_table : pandas.DataFrame (LazyProperty)
+            Cell roi information organized into a dataframe; index is the cell roi ids
+        running_speed : allensdk.brain_observatory.running_speed.RunningSpeed (LazyProperty)
+            NamedTuple with two fields
+                timestamps : numpy.ndarray
+                    Timestamps of running speed data samples
+                values : np.ndarray
+                    Running speed of the experimental subject (in cm / s).
+        stimulus_presentations : pandas.DataFrame (LazyProperty)
+            Table whose rows are stimulus presentations (i.e. a given image, for a given duration, typically 250 ms) and whose columns are presentation characteristics.
+        stimulus_templates : dict (LazyProperty)
+            A dictionary containing the stimulus images presented during the session keys are data set names, and values are 3D numpy arrays.
+        licks : pandas.DataFrame (LazyProperty)
+            A dataframe containing lick timestamps
+        rewards : pandas.DataFrame (LazyProperty)
+            A dataframe containing timestamps of delivered rewards
+        task_parameters : dict (LazyProperty)
+            A dictionary containing parameters used to define the task runtime behavior
+        trials : pandas.DataFrame (LazyProperty)
+            A dataframe containing behavioral trial start/stop times, and trial data
+        corrected_fluorescence_traces : pandas.DataFrame (LazyProperty)
+            The motion-corrected fluorescence traces organized into a dataframe; index is the cell roi ids
+        average_projection : allensdk.brain_observatory.behavior.image_api.Image (LazyProperty)
+            2D image of the microscope field of view, averaged across the experiment
+        motion_correction : pandas.DataFrame LazyProperty
+            A dataframe containing trace data used during motion correction computation
+    """
     def __init__(self, api):
 
         super(ExtendedBehaviorSession, self).__init__(api)

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -25,7 +25,7 @@ class BehaviorProjectCache(object):
     def __init__(self, cache_paths):
         '''
         A cache-level object for the behavior/ophys data. Provides access to the manifest of 
-        complete ophys/behavior containers, as well as pre-computed analysis files for each 
+        ophys/behavior containers, as well as pre-computed analysis files for each 
         experiment.
 
         Args:
@@ -39,7 +39,7 @@ class BehaviorProjectCache(object):
         
         Attributes: 
             manifest: (pd.DataFrame)
-                Table containing information about all ophys sessions from complete containers.
+                Table containing information about all ophys sessions.
             analysis_files_metadata (dict):
                 Metadata relating to the creation of the analysis files.
             

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -186,7 +186,7 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         task_parameters['stimulus_duration_sec'] = 0.25
         return task_parameters
 
-    def get_trials(self):
+    def get_trials(self, filter_aborted_trials=True):
         trials = super(ExtendedNwbApi, self).get_trials()
         stimulus_presentations = super(ExtendedNwbApi, self).get_stimulus_presentations()
 
@@ -224,6 +224,10 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         # asserts that every change time exists in the stimulus_presentations table
         for change_time in trials[trials['change_time'].notna()]['change_time']:
             assert change_time in stimulus_presentations['start_time'].values
+
+        # Return only non-aborted trials from this API by default
+        if filter_aborted_trials:
+            trials = trials.query('not aborted')
 
         # Reorder / drop some columns to make more sense to students
         trials = trials[[

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -384,6 +384,10 @@ class ExtendedBehaviorSession(BehaviorOphysSession):
             2D image of the microscope field of view, averaged across the experiment
         motion_correction : pandas.DataFrame LazyProperty
             A dataframe containing trace data used during motion correction computation
+
+    Attributes for internal / advanced users
+        running_data_df : pandas.DataFrame (LazyProperty)
+            Dataframe containing various signals used to compute running speed
     """
     def __init__(self, api):
 


### PR DESCRIPTION
This PR adds a flag on the get_trials method of the ExtendedBehaviorOphysNwbApi class used by the SWDB cache, which is true by default, and which removes aborted trials from the trials table that is returned. 

A few additional small changes:
*  Updates a docstring that used to say 'complete containers' to not say this, since some of the containers in the manifest are not complete (only have 5 sessions). 
* Updates docstring for Session objects returned by the SWDB cache to move running_data_df to a section called "For internal/advanced users" since this df gives info for debugging how the running speed was calculated, but users should just use the 'running_speed' attribute to get the final calculated values.
* Renames the extended stimulus column 'running_speed' to 'mean_running_speed' to be more explicit about what the column is (it is the average running speed during the stimulus presentation).