### PR TITLE
Make behavior ophys session stimulus templates return a dict for SWDB

### DIFF
--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -187,6 +187,33 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         task_parameters['stimulus_duration_sec'] = 0.25
         return task_parameters
 
+    def get_metadata(self):
+        metadata = super(ExtendedNwbApi, self).get_metadata()
+
+        # We want stage name in metadata for easy access by the students
+        task_parameters = self.get_task_parameters()
+        metadata['stage'] = task_parameters['stage']
+
+        # metadata should not include 'session_type' because it is 'Unknown'
+        metadata.pop('session_type')
+
+        # For SWDB only
+        # metadata should not include 'behavior_session_uuid' because it is not useful to students and confusing
+        metadata.pop('behavior_session_uuid')
+
+        # Rename LabTracks_ID to mouse_id to reduce student confusion
+        metadata['mouse_id'] = metadata.pop('LabTracks_ID')
+
+        return metadata
+
+    def get_running_speed(self):
+        # We want the running speed attribute to be a dataframe (like licks, rewards, etc.) instead of a 
+        # RunningSpeed object. This will improve consistency for students. For SWDB we have also opted to 
+        # have columns for both 'timestamps' and 'values' of things, since this is more intuitive for students
+        running_speed = super(ExtendedNwbApi, self).get_running_speed()
+        return pd.DataFrame({'speed': running_speed.values,
+                             'timestamps': running_speed.timestamps})
+
     def get_trials(self, filter_aborted_trials=True):
         trials = super(ExtendedNwbApi, self).get_trials()
         stimulus_presentations = super(ExtendedNwbApi, self).get_stimulus_presentations()

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import json
 
+from allensdk import one
 from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi
 from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession
 from allensdk.core.lazy_property import LazyProperty
@@ -397,10 +398,10 @@ class ExtendedBehaviorSession(BehaviorOphysSession):
 
         self.trial_response_df = LazyProperty(self.api.get_trial_response_df)
         self.flash_response_df = LazyProperty(self.api.get_flash_response_df)
-        self.image_index = LazyProperty(self.get_stimulus_index)
+        self.image_index = LazyProperty(self.get_image_index)
 
-    def get_stimulus_index(self):
-        return self.stimulus_presentations.groupby('image_index').apply(
-            lambda group: group['image_name'].unique()[0]
+    def get_image_index(self):
+        image_index_names = self.get_stimulus_presentations().groupby('image_index').apply(
+            lambda group: one(group['image_name'].unique())
         )
 

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -340,9 +340,7 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
 
         # What we really want is a dict with image_name as key
         template_dict = {}
-        image_index_names = self.get_stimulus_presentations().groupby('image_index').apply(
-            lambda group: one(group['image_name'].unique())
-        )
+        image_index_names = self.get_image_index_names()
         for image_index, image_name in image_index_names.iteritems():
             if image_name != 'omitted':
                 template_dict.update({image_name:stimulus_template_array[image_index, :, :]})
@@ -379,6 +377,12 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         dff_traces = super(ExtendedNwbApi, self).get_dff_traces()
         dff_traces = dff_traces.drop(columns=['cell_roi_id'])
         return dff_traces
+
+    def get_image_index_names(self):
+        image_index_names = self.get_stimulus_presentations().groupby('image_index').apply(
+            lambda group: one(group['image_name'].unique())
+        )
+        return image_index_names
 
 
 class ExtendedBehaviorSession(BehaviorOphysSession):
@@ -435,12 +439,7 @@ class ExtendedBehaviorSession(BehaviorOphysSession):
 
         self.trial_response_df = LazyProperty(self.api.get_trial_response_df)
         self.flash_response_df = LazyProperty(self.api.get_flash_response_df)
-        self.image_index = LazyProperty(self.get_image_index)
-
-    def get_image_index(self):
-        image_index_names = self.get_stimulus_presentations().groupby('image_index').apply(
-            lambda group: one(group['image_name'].unique())
-        )
+        self.image_index = LazyProperty(self.api.get_image_index_names)
 
 if __name__ == "__main__":
     cache = BehaviorProjectCache(cache_paths_example)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
@@ -51,8 +51,10 @@ def test_stimulus_presentations_image_set(session):
 
 @pytest.mark.requires_bamboo
 def test_stimulus_templates(session):
-    # Was a dict with only one key, so we popped it out 
-    assert isinstance(session.stimulus_templates, np.ndarray)
+    # Was a dict with only one key, where the value was a 3d array.
+    # We made it a dict with image names as keys and 2d arrs (the images) as values
+    for image_name, image_arr in session.stimulus_templates.items():
+        assert image_arr.ndim == 2
 
 # Test trial response df
 @pytest.mark.requires_bamboo
@@ -68,7 +70,7 @@ def test_session_trial_response(key, output, session):
 @pytest.mark.requires_bamboo
 @pytest.mark.parametrize('key, output', [
     ('time_from_last_lick', 7.3577),
-    ('running_speed', 22.143871),
+    ('mean_running_speed', 22.143871),
     ('duration', 0.25024),
 ])
 def test_session_flash_response(key, output, session):
@@ -114,7 +116,7 @@ def test_binarized_segmentation_mask_image(session):
 
 @pytest.mark.requires_bamboo
 def test_no_nan_flash_running_speed(session):
-    assert not pd.isnull(session.stimulus_presentations['running_speed']).any()
+    assert not pd.isnull(session.stimulus_presentations['mean_running_speed']).any()
 
 @pytest.mark.requires_bamboo
 def test_licks_correct_colname(session):


### PR DESCRIPTION
Has the image names as keys, which will be easier than finding the index for an image and indexing into a 3d array. 

Also contains a change to the metadata included with the session object, and changes the session.running_speed attr to return a dataframe instead of a named tuple. 