### PR TITLE
ignore case in stim param munging

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -618,7 +618,7 @@ class EcephysSession(LazyPropertyMixin):
         stimulus_presentations = naming_utilities.map_stimulus_names(
             stimulus_presentations, default_stimulus_renames
         )
-        stimulus_presentations.rename(columns=default_column_renames, inplace=True)
+        stimulus_presentations = naming_utilities.map_column_names(stimulus_presentations, default_column_renames)
 
         # pandas groupby ops ignore nans, so we need a new null value that pandas does not recognize as null ...
         stimulus_presentations[stimulus_presentations == ''] = np.nan

--- a/allensdk/brain_observatory/ecephys/stimulus_table/__main__.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/__main__.py
@@ -77,7 +77,7 @@ def build_stimulus_table(
     stim_table_full = naming_utilities.map_stimulus_names(
         stim_table_full, stimulus_name_map
     )
-    stim_table_full.rename(columns=column_name_map, inplace=True)
+    stim_table_full = naming_utilities.map_column_names(stim_table_full, column_name_map)
 
     stim_table_full.to_csv(output_stimulus_table_path, index=False)
     np.save(output_frame_times_path, frame_times, allow_pickle=False)

--- a/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
@@ -1,5 +1,6 @@
 import re
 import warnings
+import functools
 
 import pandas as pd
 import numpy as np
@@ -174,3 +175,14 @@ def map_stimulus_names(table, name_map=None, stim_colname="stimulus_name"):
         to_replace=name_map, inplace=False
     )
     return table
+
+
+def map_column_names(table, name_map=None, ignore_case=True):
+
+    if ignore_case and name_map is not None:
+        name_map = {key.lower(): value for key, value in name_map.items()}
+        mapper = lambda name: name if name.lower() not in name_map else name_map[name.lower()]
+    else:
+        mapper = name_map
+
+    return table.rename(columns=mapper)


### PR DESCRIPTION
some ecephys sessions have lowercase parameters e.g. "ori" in their stim tables. These ought to pass transparently through the name mapping utilities.