### PR TITLE
ecephys project lims api skips failed probes and sessions in return

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -92,6 +92,8 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                 join ecephys_probes ep on ep.id = ec.ecephys_probe_id
                 join ecephys_sessions es on es.id = ep.ecephys_session_id 
                 where ec.valid_data
+                and ep.workflow_state != 'failed'
+                and es.workflow_state != 'failed'
                 {{pm.optional_equals('eu.quality', quality) -}}
                 {{pm.optional_contains('eu.id', unit_ids) -}}
                 {{pm.optional_contains('ec.id', channel_ids) -}}
@@ -149,6 +151,8 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                     group by ech.id
                 ) pc on ec.id = pc.ecephys_channel_id
                 where valid_data
+                and ep.workflow_state != 'failed'
+                and es.workflow_state != 'failed'
                 {{pm.optional_contains('ec.id', channel_ids) -}}
                 {{pm.optional_contains('ep.id', probe_ids) -}}
                 {{pm.optional_contains('es.id', session_ids) -}}
@@ -234,6 +238,8 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                     group by epr.id
                 ) str on ep.id = str.ecephys_probe_id
                 where true
+                and ep.workflow_state != 'failed'
+                and es.workflow_state != 'failed'
                 {{pm.optional_contains('ep.id', probe_ids) -}}
                 {{pm.optional_contains('es.id', session_ids) -}}
             """,
@@ -320,7 +326,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
                     )
                     join well_known_file_types wkft on wkft.id = wkf.well_known_file_type_id
                     where wkft.name = 'EcephysNwb'
-                ) nwb on es.id = nwb.ecephys_session_id
+                ) nwb on es.id = nwb.ecephy {{pm.optional_contains('es.workflow_state', workflow_states, True) -}}s_session_id
                 left join (
                     select es.id as ecephys_session_id,
                     array_agg (st.id) as structure_ids,

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
@@ -36,12 +36,12 @@ from allensdk.brain_observatory.ecephys.ecephys_project_api import (
         [
             "get_channels",
             {},
-            re.compile(r"select ec\.id as id.*where valid_data$"),
+            re.compile(r"select ec\.id as id.*where valid_data and ep.workflow_state != 'failed' and es.workflow_state != 'failed'$"),
         ],
         [
             "get_probes",
             {},
-            re.compile(r"select ep\.id as id, ep.ecephys_session_id.*where true$"),
+            re.compile(r"select ep\.id as id, ep.ecephys_session_id.*where true and ep.workflow_state != 'failed' and es.workflow_state != 'failed'$"),
         ],
     ],
 )


### PR DESCRIPTION
I could see an argument for this being opt-in, but I'm not sure that anyone would ever use that functionality.