### PR TITLE
Use get_roi_masks to construct segmentation_mask_image for behavior ophys sessions

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -241,14 +241,16 @@ class BehaviorOphysSession(LazyPropertyMixin):
         return self.deserialize_image(self.api.get_average_projection())
 
     def get_segmentation_mask_image(self):
-        """ Returns an image with a pixel value of zero if the pixel is not included in any ROI, and nonzero if included in a segmented ROI.
+        """ Returns an image with value 1 if the pixel was included in an ROI, and 0 otherwise
 
         Returns
         ----------
-        allensdk.brain_observatory.behavior.image_api.Image:
-            array-like interface to max projection image data and metadata
+        mask_image (xarray.DataArray):
+            Image with 1 if the pixel was included in any ROI, and 0 otherwise
         """
-        return self.deserialize_image(self.api.get_segmentation_mask_image())
+        masks = self.get_roi_masks()
+        mask_image = masks.any(dim='cell_specimen_id')
+        return mask_image
 
     def get_reward_rate(self):
         response_latency_list = []

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -253,8 +253,8 @@ class BehaviorOphysSession(LazyPropertyMixin):
 
         Returns
         ----------
-        mask_image (xarray.DataArray):
-            Image with 1 if the pixel was included in any ROI, and 0 otherwise
+        allensdk.brain_observatory.behavior.image_api.Image:
+            array-like interface to segmentation_mask image data and metadata
         """
         masks = self.get_roi_masks()
         mask_image_data = masks.any(dim='cell_specimen_id').astype(int)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -16,6 +16,7 @@ from allensdk.brain_observatory.behavior.write_nwb.__main__ import BehaviorOphys
 from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi, equals
 from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
 from allensdk.brain_observatory.behavior.behavior_ophys_api import BehaviorOphysApiBase
+from allensdk.brain_observatory.behavior.image_api import ImageApi
 
 
 @pytest.mark.nightly
@@ -192,6 +193,11 @@ def cell_specimen_table_api():
                 "image_mask": [roi_1, roi_2]
             }, index=pd.Index(data=[10, 11], name="cell_specimen_id")
         )
+        def get_segmentation_mask_image(self):
+            data = roi_1 #useless image data here
+            spacing = (1, 1)
+            unit = 'index'
+            return ImageApi.serialize(data, spacing, unit)
     return CellSpecimenTableApi()
 
 @pytest.mark.parametrize("roi_ids,expected", [


### PR DESCRIPTION
Makes behavior ophys sessions use the new function `get_roi_masks` to build the segmentation mask image, rather than loading a saved output image. This allows only the ROIs included in the `cell_specimens` table to be included in this image, which can be filtered on load to only include valid ROIs. 