### PR TITLE
Return valid_cell_matching column from the manifest CSV

### DIFF
--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -71,7 +71,8 @@ class BehaviorProjectCache(object):
             'animal_name',
             'sex',
             'date_of_acquisition',
-            'retake_number'
+            'retake_number',
+            'valid_cell_matching'
         ]]
 
         self.nwb_base_dir = self.cache_paths['nwb_base_dir']


### PR DESCRIPTION
We added a column to the manifest CSV noting which experiments have trustworthy cell matching. However, during the re-ordering step we weren't including that column in the attribute owned by the cache object. 