### PR TITLE
Load eye tracking files via swdb cache

### DIFF
--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -130,6 +130,12 @@ class BehaviorProjectCache(object):
         except KeyError: # Experiment not in json file
             print("No eye tracking for this experiment")
 
+    def get_eye_tracking_sync_file(self, experiment_id):
+        return os.path.join(
+            self.eye_tracking_base_dir,
+             'eye_tracking_sync_ophys_experiment_{}.h5'.format(experiment_id)
+        )
+
     def get_session(self, experiment_id):
         '''
         Return a BehaviorOphysSession object given an ophys_experiment_id.
@@ -139,12 +145,14 @@ class BehaviorProjectCache(object):
         flash_response_df_path = self.get_flash_response_df_path(experiment_id)
         extended_stim_df_path = self.get_extended_stimulus_presentations_df(experiment_id)
         eye_tracking_path = self.get_eye_tracking_file(experiment_id)
+        eye_tracking_sync_file = self.get_eye_tracking_sync_file(experiment_id)
         api = ExtendedNwbApi(
             nwb_path=nwb_path,
             trial_response_df_path=trial_response_df_path,
             flash_response_df_path=flash_response_df_path,
             extended_stimulus_presentations_df_path=extended_stim_df_path,
-            eye_tracking_path = eye_tracking_path
+            eye_tracking_path = eye_tracking_path,
+            eye_tracking_sync_file = eye_tracking_sync_file
         )
         session = ExtendedBehaviorSession(api)
         return session
@@ -198,6 +206,7 @@ def parse_image_set(behavior_stage):
 class ExtendedNwbApi(BehaviorOphysNwbApi):
     def __init__(self, nwb_path, trial_response_df_path, flash_response_df_path,
                  extended_stimulus_presentations_df_path,
+                 eye_tracking_sync_file,
                  eye_tracking_path=None):
         '''
         Api to read data from an NWB file and associated analysis HDF5 files.
@@ -207,6 +216,7 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         self.flash_response_df_path = flash_response_df_path
         self.extended_stimulus_presentations_df_path = extended_stimulus_presentations_df_path
         self.eye_tracking_path=eye_tracking_path
+        self.eye_tracking_sync_file=eye_tracking_sync_file
 
     def get_trial_response_df(self):
         tdf = pd.read_hdf(self.trial_response_df_path, key='df')
@@ -227,9 +237,10 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
     def get_eye_tracking_data(self):
         if self.eye_tracking_path:
             output = {
-            'cr':pd.read_hdf(self.eye_tracking_path, key='cr'),
-            'eye':pd.read_hdf(self.eye_tracking_path, key='eye'),
-            "pupil":pd.read_hdf(self.eye_tracking_path, key='pupil')
+                'cr':pd.read_hdf(self.eye_tracking_path, key='cr'),
+                'eye':pd.read_hdf(self.eye_tracking_path, key='eye'),
+                'pupil':pd.read_hdf(self.eye_tracking_path, key='pupil'),
+                'sync': pd.read_hdf(self.eye_tracking_sync_file, key='df')
             }
             return output
         else:
@@ -509,6 +520,11 @@ if __name__ == "__main__":
     cache = BehaviorProjectCache(cache_path_example)
     #  session = cache.get_session(cache.experiment_table.iloc[0]['ophys_experiment_id'])
     oeid_with_eye_tracking = 879331157
+    oeid_without_eye_tracking = 795953296
     session = cache.get_session(oeid_with_eye_tracking)
 
-
+    #  cache_base_without_eye_tracking_data = os.path.join(
+    #      cache_path_example,
+    #      'cache_20190813'
+    #  )
+    #  cache_no_eye_tracking = BehaviorProjectCache(cache_base_without_eye_tracking_data)

--- a/allensdk/brain_observatory/behavior/swdb/stage_swdb_eye_tracking_files.py
+++ b/allensdk/brain_observatory/behavior/swdb/stage_swdb_eye_tracking_files.py
@@ -1,0 +1,73 @@
+import os
+import shutil
+import json
+import pandas as pd
+from allensdk import one
+from allensdk.internal.api import PostgresQueryMixin
+import allensdk.brain_observatory.behavior.swdb.behavior_project_cache as bpc
+from allensdk.internal.api import behavior_ophys_api as boa
+cache_path = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/SWDB_2019/cache_20190813'
+
+def get_eyetracking_file_path(ophys_experiment_id):
+    api = PostgresQueryMixin()
+    query = '''
+    SELECT wkf.storage_directory || wkf.filename as full_path,
+    wkf.filename
+    FROM well_known_files wkf
+    JOIN ophys_sessions os ON os.id=wkf.attachable_id
+    JOIN ophys_experiments oe ON oe.ophys_session_id=os.id
+    JOIN welL_known_file_types wkft ON wkft.id=wkf.well_known_file_type_id
+    WHERE wkft.name = 'EyeTracking Ellipses'
+    AND oe.id = {};
+    '''.format(ophys_experiment_id)
+    #  return api.fetchone(query, strict=True)
+    return pd.read_sql(query, api.get_connection())
+
+
+def get_eyetracking_sync_times(ophys_experiment_id):
+    '''
+    I hate everything about this.
+    '''
+    eyetracking_file = get_eyetracking_file_path(ophys_experiment_id).iloc[0]
+    pupil_data = pd.read_hdf(eyetracking_file['full_path'], key='pupil')
+    api = boa.BehaviorOphysLimsApi(ophys_experiment_id)
+    
+    eyetracking_sync_times = api.get_sync_data()['eye_tracking']
+    behaviormon_sync_times = api.get_sync_data()['behavior_monitoring']
+
+    if pupil_data.shape[0] == eyetracking_sync_times.shape[0]:
+        return pd.DataFrame({"timestamps":eyetracking_sync_times})
+    elif pupil_data.shape[0] == behaviormon_sync_times.shape[0]:
+        return pd.DataFrame({"timestamps":behaviormon_sync_times})
+    else:
+        raise ValueError("Eyetracking data did not match length of any sync time vectors")
+
+if __name__=="__main__":
+    output_dir = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/SWDB_2019/eye_tracking_files'
+    errors=0
+    oeid_fn_mapping = {}
+    cache = bpc.BehaviorProjectCache(cache_path)
+    oeids = cache.experiment_table['ophys_experiment_id'].values
+    for oeid in oeids:
+        try:
+            result = get_eyetracking_file_path(oeid).iloc[0]
+            oeid_fn_mapping.update({int(oeid):result['filename']})
+            print(result['full_path'])
+            src = result['full_path']
+            dest = os.path.join(output_dir, result['filename'])
+            shutil.copyfile(src, dest)
+
+            # Get the sync times and save them for this oeid
+            # NOTE: Using experiment ID here, which we want to get away from, but it's what we use for this cache
+            eye_tracking_sync_times = get_eyetracking_sync_times(oeid)
+            et_sync_path = os.path.join(output_dir, 'eye_tracking_sync_ophys_experiment_{}.h5'.format(oeid))
+            eye_tracking_sync_times.to_hdf(et_sync_path, key='df')
+        except:
+            errors+=1
+            print("ERROR")
+
+    output_json_path = os.path.join(output_dir, 'oeid_to_eye_tracking_file.json')
+    with open(output_json_path, 'w') as json_file:
+        json.dump(oeid_fn_mapping, json_file)
+
+


### PR DESCRIPTION
Many of the behavior/ophys sessions available in the SWDB cache have eye tracking data available as well. This PR modifies the sessions returned by the cache to be able to load this data if it exists. 

To be able to get the eye tracking data, a folder of eye tracking files must be available in `<cache_base_dir>/eye_tracking_files`