### PR TITLE
Correct behaviormon and eye tracking camera sync line labels

### DIFF
--- a/allensdk/brain_observatory/behavior/sync/__init__.py
+++ b/allensdk/brain_observatory/behavior/sync/__init__.py
@@ -42,12 +42,12 @@ def get_sync_data(sync_path):
         a = sync_dataset.get_rising_edges('photodiode') / sample_freq
         b = sync_dataset.get_falling_edges('photodiode') / sample_freq
         stim_photodiode = sorted(list(a)+list(b))
-    if 'cam1_exposure' in meta_data['line_labels']:
-        eye_tracking = sync_dataset.get_rising_edges('cam1_exposure') / sample_freq
+    if 'cam2_exposure' in meta_data['line_labels']:
+        eye_tracking = sync_dataset.get_rising_edges('cam2_exposure') / sample_freq
     elif 'eye_tracking' in meta_data['line_labels']:
         eye_tracking = sync_dataset.get_rising_edges('eye_tracking') / sample_freq
-    if 'cam2_exposure' in meta_data['line_labels']:
-        behavior_monitoring = sync_dataset.get_rising_edges('cam2_exposure') / sample_freq
+    if 'cam1_exposure' in meta_data['line_labels']:
+        behavior_monitoring = sync_dataset.get_rising_edges('cam1_exposure') / sample_freq
     elif 'behavior_monitoring' in meta_data['line_labels']:
         behavior_monitoring = sync_dataset.get_rising_edges('behavior_monitoring') / sample_freq
 

--- a/allensdk/test/brain_observatory/behavior/test_sync_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_sync_processing.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+import cv2
+from allensdk.brain_observatory.behavior.sync import get_sync_data
+
+def number_of_video_frames(video_path):
+    video = cv2.VideoCapture(video_path)
+    return int(video.get(cv2.CAP_PROP_FRAME_COUNT))
+
+base_dir='/allen/programs/braintv/production/visualbehavior/prod0/specimen_789992909/ophys_session_819949602/'
+eye_tracking_video_path=os.path.join(base_dir, '819949602_video-1.avi')
+behaviormon_video_path=os.path.join(base_dir, '819949602_video-0.avi')
+sync_path=os.path.join(base_dir, '819949602_sync.h5')
+
+@pytest.mark.requires_bamboo
+@pytest.mark.parametrize('path_to_video, path_to_sync_file, sync_key', [
+    pytest.param(behaviormon_video_path, sync_path, 'behavior_monitoring'),
+    pytest.param(eye_tracking_video_path, sync_path, 'eye_tracking')
+])
+def test_video_exposure_time_sync(path_to_video, path_to_sync_file, sync_key):
+    n_video_frames = number_of_video_frames(path_to_video)
+    n_sync_timestamps = get_sync_data(path_to_sync_file)[sync_key].shape[0]
+    assert n_video_frames == n_sync_timestamps

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,4 +11,4 @@ flake8>=1.5.0
 pylint>=1.5.4
 numpydoc>=0.6.0
 jupyter>=1.0.0
-cv2==4.1.0
+opencv-python==4.1.0.25

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,3 +11,4 @@ flake8>=1.5.0
 pylint>=1.5.4
 numpydoc>=0.6.0
 jupyter>=1.0.0
+cv2==4.1.0


### PR DESCRIPTION
Addresses #967 by assigning sync line labels to behaviormon and eye tracking according to current MPE setup. 

Also adds a test to verify that the number of sync timestamps lines up with the number of frames in a set of behavior and eye tracking videos. The way I have written it depends on `cv2`, which I added to the test_requirements. @NileGraddis I can write the test in a different way if that dependency will cause something to break with the bamboo builds. 