### PR TITLE
updating way create_stim_table handles negative durations

### DIFF
--- a/allensdk/brain_observatory/ecephys/stimulus_table/__main__.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/__main__.py
@@ -31,6 +31,7 @@ def build_stimulus_table(
     column_name_map,
     output_stimulus_table_path,
     output_frame_times_path,
+    fail_on_negative_duration,
     **kwargs
 ):
 
@@ -65,7 +66,7 @@ def build_stimulus_table(
         stim_table_full, frame_times, stim_file.frames_per_second, True
     )
 
-    output_validation.validate_epoch_durations(stim_table_full)
+    output_validation.validate_epoch_durations(stim_table_full, fail_on_negative_durations=fail_on_negative_duration)
     output_validation.validate_max_spontaneous_epoch_duration(
         stim_table_full, maximum_expected_spontanous_activity_duration
     )

--- a/allensdk/brain_observatory/ecephys/stimulus_table/_schemas.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/_schemas.py
@@ -92,6 +92,11 @@ class InputParameters(ArgSchema):
         default=["name", "maskParams", "win", "autoLog", "autoDraw"],
     )
 
+    fail_on_negative_duration = Bool(
+        default=False,
+        help="Determine if the module should fail if a stimulus epoch has a negative duration."
+    )
+
 
 class OutputSchema(DefaultSchema):
     input_parameters = Nested(

--- a/allensdk/brain_observatory/ecephys/stimulus_table/output_validation.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/output_validation.py
@@ -13,8 +13,8 @@ def validate_epoch_durations(table, start_key="Start", end_key="End"):
             UserWarning,
         )
     if min_duration < 0:
-        print(table.loc[min_duration_index - 5 : min_duration_index + 5, :])
-        raise ValueError(f"there is an epoch with negative duration (index: {min_duration_index}")
+        # print(table.loc[min_duration_index - 5 : min_duration_index + 5, :])
+        warnings.warn(f"there is an epoch with negative duration (index: {min_duration_index}")
 
 
 def validate_epoch_order(table, time_keys=("Start", "End")):

--- a/allensdk/brain_observatory/ecephys/stimulus_table/output_validation.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/output_validation.py
@@ -2,7 +2,7 @@ import numpy as np
 import warnings
 
 
-def validate_epoch_durations(table, start_key="Start", end_key="End"):
+def validate_epoch_durations(table, start_key="Start", end_key="End", fail_on_negative_durations=False):
     durations = table[end_key] - table[start_key]
     min_duration_index = durations.idxmin()
     min_duration = durations[min_duration_index]
@@ -13,8 +13,10 @@ def validate_epoch_durations(table, start_key="Start", end_key="End"):
             UserWarning,
         )
     if min_duration < 0:
-        # print(table.loc[min_duration_index - 5 : min_duration_index + 5, :])
-        warnings.warn(f"there is an epoch with negative duration (index: {min_duration_index}")
+        msg = f"there is an epoch with negative duration (index: {min_duration_index})"
+        if fail_on_negative_durations:
+            raise ValueError(msg)
+        warnings.warn(msg)
 
 
 def validate_epoch_order(table, time_keys=("Start", "End")):

--- a/allensdk/test/brain_observatory/ecephys/stimulus_table/test_stimulus_table_module.py
+++ b/allensdk/test/brain_observatory/ecephys/stimulus_table/test_stimulus_table_module.py
@@ -306,6 +306,7 @@ def test_build_stimulus_table(tmpdir_factory, expected_table):
         column_name_map={},
         output_stimulus_table_path=table_path,
         output_frame_times_path=frame_times_path,
+        fail_on_negative_duration=True
     )
 
     obtained_table = pd.read_csv(table_path)


### PR DESCRIPTION
For failed CreateStimulusTableStrategy for session 754312389 where two of the natural_movies_1 presentation duration was negative. Agreed to let it pass this module.