### PR TITLE
#988 allow interpolated channel csds to be read

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -149,10 +149,12 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
         csd = xr.DataArray(
             name="CSD",
             data=csd_ts.data[:],
-            dims=["virtual channel location", "time"],
+            dims=["virtual_channel_index", "time"],
             coords={
-                "virtual channel location": csd_ts.control[:],
-                "time": csd_ts.timestamps[:]
+                "virtual_channel_index": np.arange(csd_ts.data.shape[0]),
+                "time": csd_ts.timestamps[:],
+                "vertical_position": (("virtual_channel_index",), csd_ts.control[:, 1]),
+                "horizontal_position": (("virtual_channel_index",), csd_ts.control[:, 0])
             }
         )
         return csd


### PR DESCRIPTION
this produces e.g.
```
<xarray.DataArray 'CSD' (virtual_channel_index: 384, time: 3250)>
array([[  94878.748614,   84961.811112,   75630.675519, ...,  137162.94287 ,
          87328.033653,   34959.984655],
       [ -41132.659207,  -44641.739002,  -47674.976389, ...,   35292.818528,
           9884.883134,  -16979.766797],
       [ -48662.111909,  -48171.07484 ,  -47165.570435, ...,   64325.344373,
          20393.155532,  -26189.966436],
       ...,
       [  17697.971448,     753.413238,  -15164.857293, ...,    1667.389667,
          -3522.385255,   -9217.433373],
       [ 357931.944249,  201442.001566,   57567.657443, ...,  128549.380412,
           -699.540276, -138876.387213],
       [-397977.69713 , -215171.137996,  -46047.194769, ..., -119643.162894,
          13364.319122,  155734.761669]])
Coordinates:
  * virtual_channel_index  (virtual_channel_index) int64 0 1 2 3 ... 381 382 383
  * time                   (time) float64 -0.3 -0.2996 -0.2992 ... 0.9992 0.9996
    vertical_position      (virtual_channel_index) uint64 0 10 20 ... 3820 3830
    horizontal_position    (virtual_channel_index) uint64 24 24 24 ... 24 24 24
```