### PR TITLE
Make behavior-only sessions work with gratings sessions

### DIFF
--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -28,8 +28,7 @@ def load_pickle(pstream):
 
 def get_stimulus_presentations(data, stimulus_timestamps):
 
-    visual_stimuli = get_visual_stimuli_df(data, stimulus_timestamps)
-    stimulus_table = visual_stimuli[:-10]  # ignore last 10 flashes
+    stimulus_table = get_visual_stimuli_df(data, stimulus_timestamps)
     # workaround to rename columns to harmonize with visual coding and rebase timestamps to sync time
     stimulus_table.insert(loc=0, column='flash_number', value=np.arange(0, len(stimulus_table)))
     stimulus_table = stimulus_table.rename(columns={'frame': 'start_frame', 'time': 'start_time', 'flash_number':'stimulus_presentations_id'})
@@ -199,30 +198,32 @@ def get_visual_stimuli_df(data, time):
     visual_stimuli_df = pd.DataFrame(data=visual_stimuli_data)
 
     # Add omitted flash info:
-    omitted_flash_list = []
-    omitted_flash_frame_log = data['items']['behavior']['omitted_flash_frame_log']
-    for stimuli_group_name, omitted_flash_frames in omitted_flash_frame_log.items():
+    if 'omitted_flash_frame_log' in data['items']['behavior']:
+        omitted_flash_list = []
+        omitted_flash_frame_log = data['items']['behavior']['omitted_flash_frame_log']
+        for stimuli_group_name, omitted_flash_frames in omitted_flash_frame_log.items():
 
-        stim_frames = visual_stimuli_df['frame'].values
-        omitted_flash_frames = np.array(omitted_flash_frames)
+            stim_frames = visual_stimuli_df['frame'].values
+            omitted_flash_frames = np.array(omitted_flash_frames)
 
-        #  Test offsets of omitted flash frames to see if they are in the stim log
-        offsets = np.arange(-3, 4)
-        offset_arr = np.add(np.repeat(omitted_flash_frames[:, np.newaxis], offsets.shape[0], axis=1), offsets)
-        matched_any_offset = np.any(np.isin(offset_arr, stim_frames), axis=1)
+            #  Test offsets of omitted flash frames to see if they are in the stim log
+            offsets = np.arange(-3, 4)
+            offset_arr = np.add(np.repeat(omitted_flash_frames[:, np.newaxis], offsets.shape[0], axis=1), offsets)
+            matched_any_offset = np.any(np.isin(offset_arr, stim_frames), axis=1)
 
-        #  Remove omitted flashes that also exist in the stimulus log
-        was_true_omitted = np.logical_not(matched_any_offset)  # bool
-        omitted_flash_frames_to_keep = omitted_flash_frames[was_true_omitted]
+            #  Remove omitted flashes that also exist in the stimulus log
+            was_true_omitted = np.logical_not(matched_any_offset)  # bool
+            omitted_flash_frames_to_keep = omitted_flash_frames[was_true_omitted]
 
-        # Have to remove frames that are double-counted in omitted log
-        omitted_flash_list += list(np.unique(omitted_flash_frames_to_keep))
+            # Have to remove frames that are double-counted in omitted log
+            omitted_flash_list += list(np.unique(omitted_flash_frames_to_keep))
 
-    omitted = np.ones_like(omitted_flash_list).astype(bool)
-    time = [time[fi] for fi in omitted_flash_list]
-    omitted_df = pd.DataFrame({'omitted': omitted, 'frame': omitted_flash_list, 'time': time,
-                               'image_name':'omitted'})
+        omitted = np.ones_like(omitted_flash_list).astype(bool)
+        time = [time[fi] for fi in omitted_flash_list]
+        omitted_df = pd.DataFrame({'omitted': omitted, 'frame': omitted_flash_list, 'time': time,
+                                   'image_name':'omitted'})
 
-    df = pd.concat((visual_stimuli_df, omitted_df), sort=False).sort_values('frame').reset_index()
+        df = pd.concat((visual_stimuli_df, omitted_df), sort=False).sort_values('frame').reset_index()
+    else:
+        df = visual_stimuli_df
     return df
-

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -90,18 +90,34 @@ def get_stimulus_templates(pkl):
 
 def get_stimulus_metadata(pkl):
 
-    images = get_images_dict(pkl)
-    stimulus_index_df = pd.DataFrame(images['image_attributes'])
-    image_set_filename = convert_filepath_caseinsensitive(images['metadata']['image_set'])
-    stimulus_index_df['image_set'] = IMAGE_SETS_REV[image_set_filename]
+    if 'images' in pkl["items"]["behavior"]["stimuli"]:
+        images = get_images_dict(pkl)
+        stimulus_index_df = pd.DataFrame(images['image_attributes'])
+        image_set_filename = convert_filepath_caseinsensitive(images['metadata']['image_set'])
+        stimulus_index_df['image_set'] = IMAGE_SETS_REV[image_set_filename]
 
-    # Add an entry for omitted stimuli
-    omitted_df = pd.DataFrame({'image_category':['omitted'],
-                               'image_name':['omitted'],
-                               'image_set':['omitted'],
-                               'image_index':[stimulus_index_df['image_index'].max()+1]})
-    stimulus_index_df = stimulus_index_df.append(omitted_df, ignore_index=True, sort=False)
-    stimulus_index_df.set_index(['image_index'], inplace=True, drop=True)
+        # Add an entry for omitted stimuli
+        omitted_df = pd.DataFrame({'image_category':['omitted'],
+                                   'image_name':['omitted'],
+                                   'image_set':['omitted'],
+                                   'image_index':[stimulus_index_df['image_index'].max()+1]})
+        stimulus_index_df = stimulus_index_df.append(omitted_df, ignore_index=True, sort=False)
+        stimulus_index_df.set_index(['image_index'], inplace=True, drop=True)
+    else:
+        stim_groups = pkl['items']['behavior']['stimuli']['grating']['stim_groups']
+        image_sets = []
+        image_names = []
+        for group in stim_groups.keys():
+            for ori in stim_groups[group][1]:
+                image_sets.append(group)
+                image_names.append('gratings_{}'.format(ori))
+        image_groups = image_names
+        stimulus_index_df = pd.DataFrame({
+            'image_name': image_names,
+            'image_group': image_groups,
+            'image_set': image_sets
+        })
+        stimulus_index_df.index.name = 'image_index'
     return stimulus_index_df
 
 

--- a/allensdk/internal/api/behavior_lims_api.py
+++ b/allensdk/internal/api/behavior_lims_api.py
@@ -122,7 +122,29 @@ class BehaviorLimsApi(PostgresQueryMixin):
         behavior_stimulus_file = self.get_behavior_stimulus_file()
         data = pd.read_pickle(behavior_stimulus_file)
         stimulus_presentations_df_pre = get_stimulus_presentations(data, stimulus_timestamps)
-        stimulus_metadata_df = get_stimulus_metadata(data)
+        if pd.isnull(stimulus_presentations_df_pre['image_name']).all():
+            if ~pd.isnull(stimulus_presentations_df_pre['orientation']).all():
+                stimulus_presentations_df_pre['image_name'] = stimulus_presentations_df_pre['image_name'].astype(str)
+                for ind_row in stimulus_presentations_df_pre.index:
+                    stimulus_presentations_df_pre.at[ind_row, 'image_name'] = 'gratings_{}'.format(
+                        stimulus_presentations_df_pre.at[ind_row, 'orientation']
+                    )
+            else:
+                raise ValueError('non_null orientation and image_name')
+                    
+        if 'images' in data["items"]["behavior"]["stimuli"]:
+            stimulus_metadata_df = get_stimulus_metadata(data) 
+        else:
+            image_names = stimulus_presentations_df_pre['image_name'].unique()
+            image_groups = image_names
+            image_sets = ['vertical' if x in ['gratings_0', 'gratings_180'] else 'horizontal' for x in image_names]
+            stimulus_metadata_df = pd.DataFrame({
+                'image_name': image_names,
+                'image_group': image_groups,
+                'image_set': image_sets
+            })
+            stimulus_metadata_df.index.name = 'image_index'
+
         idx_name = stimulus_presentations_df_pre.index.name
         stimulus_index_df = stimulus_presentations_df_pre.reset_index().merge(stimulus_metadata_df.reset_index(), on=['image_name']).set_index(idx_name)
         stimulus_index_df.sort_index(inplace=True)

--- a/allensdk/internal/api/behavior_lims_api.py
+++ b/allensdk/internal/api/behavior_lims_api.py
@@ -132,19 +132,7 @@ class BehaviorLimsApi(PostgresQueryMixin):
             else:
                 raise ValueError('non_null orientation and image_name')
                     
-        if 'images' in data["items"]["behavior"]["stimuli"]:
-            stimulus_metadata_df = get_stimulus_metadata(data) 
-        else:
-            image_names = stimulus_presentations_df_pre['image_name'].unique()
-            image_groups = image_names
-            image_sets = ['vertical' if x in ['gratings_0', 'gratings_180'] else 'horizontal' for x in image_names]
-            stimulus_metadata_df = pd.DataFrame({
-                'image_name': image_names,
-                'image_group': image_groups,
-                'image_set': image_sets
-            })
-            stimulus_metadata_df.index.name = 'image_index'
-
+        stimulus_metadata_df = get_stimulus_metadata(data) 
         idx_name = stimulus_presentations_df_pre.index.name
         stimulus_index_df = stimulus_presentations_df_pre.reset_index().merge(stimulus_metadata_df.reset_index(), on=['image_name']).set_index(idx_name)
         stimulus_index_df.sort_index(inplace=True)

--- a/allensdk/internal/api/behavior_lims_api.py
+++ b/allensdk/internal/api/behavior_lims_api.py
@@ -18,20 +18,20 @@ from allensdk.internal.core.lims_utilities import safe_system_path
 
 class BehaviorLimsApi(PostgresQueryMixin):
 
-    def __init__(self, behavior_experiment_id):
+    def __init__(self, behavior_session_id):
         """
         Notes
         -----
-        - behavior_experiment_id is the same as behavior_session_id which is in lims
-        - behavior_experiment_id is associated with foraging_id in lims
+        - behavior_session_id is the same as behavior_session_id which is in lims
+        - behavior_session_id is associated with foraging_id in lims
         - foraging_id in lims is the same as behavior_session_uuid in mtrain which is the same
         as session_uuid in the pickle returned by behavior_stimulus_file
         """
-        self.behavior_experiment_id = behavior_experiment_id
+        self.behavior_session_id = behavior_session_id
         PostgresQueryMixin.__init__(self)
 
-    def get_behavior_experiment_id(self):
-        return self.behavior_experiment_id
+    def get_behavior_session_id(self):
+        return self.behavior_session_id
 
     def get_behavior_session_uuid(self):
         behavior_stimulus_file = self.get_behavior_stimulus_file()
@@ -45,7 +45,7 @@ class BehaviorLimsApi(PostgresQueryMixin):
                 FROM behavior_sessions bs 
                 LEFT JOIN well_known_files stim ON stim.attachable_id=bs.id AND stim.attachable_type = 'BehaviorSession' AND stim.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'StimulusPickle') 
                 WHERE bs.id= {};
-                '''.format(self.get_behavior_experiment_id())
+                '''.format(self.get_behavior_session_id())
         return safe_system_path(self.fetchone(query, strict=True))
 
     def get_extended_trials(self):
@@ -72,7 +72,7 @@ class BehaviorLimsApi(PostgresQueryMixin):
     @classmethod
     def from_foraging_id(cls, foraging_id):
         return cls(
-            behavior_experiment_id=cls.foraging_id_to_behavior_session_id(foraging_id),
+            behavior_session_id=cls.foraging_id_to_behavior_session_id(foraging_id),
         )
 
     @memoize
@@ -168,7 +168,7 @@ class BehaviorLimsApi(PostgresQueryMixin):
     def get_metadata(self):
 
         metadata = {}
-        metadata['behavior_experiment_id'] = self.get_behavior_experiment_id()
+        metadata['behavior_session_id'] = self.get_behavior_session_id()
         # metadata['experiment_container_id'] = self.get_experiment_container_id()
         # metadata['ophys_frame_rate'] = self.get_ophys_frame_rate()
         metadata['stimulus_frame_rate'] = self.get_stimulus_frame_rate()


### PR DESCRIPTION
* Changes for processing gratings sessions
* Skipping omitted flash processing if we don't have an omitted flash frame log - this log is missing for a subset of the behavior training sessions for pipeline animals (sessions collected before the camstim change was pushed). However, training sessions never have omitted stimuli so this shouldn't be a problem. 
* Stop dropping the last 10 flashes during stimulus processing. This was a questionable workaround in VBA and looks like it was ported over directly (correct me if there is some good reason to do this).
* Fixed a typo