### PR TITLE
Resolve GH-1022 cell_roi_id instead of cell_specimen_id in get_segmentation_mask_image

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -256,8 +256,8 @@ class BehaviorOphysSession(LazyPropertyMixin):
         allensdk.brain_observatory.behavior.image_api.Image:
             array-like interface to segmentation_mask image data and metadata
         """
-        masks = self.get_roi_masks()
-        mask_image_data = masks.any(dim='cell_specimen_id').astype(int)
+        masks = self._get_roi_masks_by_cell_roi_id()
+        mask_image_data = masks.any(dim='cell_roi_id').astype(int)
         mask_image = Image(
             data = mask_image_data.values,
             spacing = masks.attrs['spacing'],


### PR DESCRIPTION
This change is necessary to build NWB files that do not have cell_specimen_id 's assigned yet
Paire-programmed with @kschelonka 