### PR TITLE
Consolidate ecephys eye tracking data

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -152,29 +152,18 @@ class EcephysSession(LazyPropertyMixin):
 
 
     @property
-    def corneal_reflection_ellipse_fits(self):
-        return self._eye_tracking_ellipse_fit_data["cr_ellipse_fits"]
-
-
-    @property
-    def eye_ellipse_fits(self):
-        return self._eye_tracking_ellipse_fit_data["eye_ellipse_fits"]
-
-
-    @property
-    def pupil_ellipse_fits(self):
-        return self._eye_tracking_ellipse_fit_data["pupil_ellipse_fits"]
-    
-
-    @property
     def rig_geometry_data(self):
-        return self._eye_tracking_ellipse_fit_data["rig_geometry_data"]
-
+        if self._rig_metadata:
+            return self._rig_metadata["rig_geometry_data"]
+        else:
+            return None
 
     @property
     def rig_equipment_name(self):
-        return self._eye_tracking_ellipse_fit_data["rig_equipment"]
-
+        if self._rig_metadata:
+            return self._rig_metadata["rig_equipment"]
+        else:
+            return None
 
     @property
     def specimen_name(self):
@@ -220,9 +209,7 @@ class EcephysSession(LazyPropertyMixin):
         self.inter_presentation_intervals = self.LazyProperty(self._build_inter_presentation_intervals)
         self.invalid_times = self.LazyProperty(self.api.get_invalid_times)
 
-        self._eye_tracking_ellipse_fit_data = self.LazyProperty(self.api.get_eye_tracking_ellipse_fit_data)
-        self.raw_eye_gaze_mapping_data = self.LazyProperty(self.api.get_raw_eye_gaze_mapping_data)
-        self.filtered_eye_gaze_mapping_data = self.LazyProperty(self.api.get_filtered_eye_gaze_mapping_data)
+        self._rig_metadata = self.LazyProperty(self.api.get_rig_metadata)
 
         self._metadata = self.LazyProperty(self.api.get_metadata)
 
@@ -379,6 +366,34 @@ class EcephysSession(LazyPropertyMixin):
 
         return self.invalid_times
 
+    def get_eye_tracking_data(self, suppress_eye_gaze_data: bool = True) -> pd.DataFrame:
+        """Return a dataframe with eye tracking data
+
+        Parameters
+        ----------
+        suppress_eye_gaze_data : bool, optional
+            Whether or not to suppress eye gaze mapping data in output
+            dataframe, by default True.
+
+        Returns
+        -------
+        pd.DataFrame
+            Contains columns for eye, pupil and cr ellipse fits:
+                *_center_x
+                *_center_y
+                *_height
+                *_width
+                *_phi
+            May also contain raw/filtered columns for gaze mapping if
+            suppress_eye_gaze_data is set to False:
+                *_eye_area
+                *_pupil_area
+                *_screen_coordinates_x_cm
+                *_screen_coordinates_y_cm
+                *_screen_coordinates_spherical_x_deg
+                *_screen_coorindates_spherical_y_deg
+        """
+        return self.api.get_eye_tracking_data(suppress_eye_gaze_data=suppress_eye_gaze_data)
 
     def presentationwise_spike_counts(
         self, 

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_session_api.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 from datetime import datetime
 
 import numpy as np
@@ -56,13 +56,10 @@ class EcephysSessionApi:
     def get_spike_amplitudes(self) -> Dict[int, np.ndarray]:
         raise NotImplementedError
 
-    def get_eye_tracking_ellipse_fit_data(self):
+    def get_rig_metadata(self) -> Optional[dict]:
         raise NotImplementedError
 
-    def get_raw_eye_gaze_mapping_data(self):
-        raise NotImplementedError
-
-    def get_filtered_eye_gaze_mapping_data(self):
+    def get_eye_tracking_data(self, suppress_eye_gaze_data: bool) -> Optional[pd.DataFrame]:
         raise NotImplementedError
 
     def get_metadata(self):


### PR DESCRIPTION
Consolidates eye tracking data output.

Example usage:
```
import os
import numpy as np
from allensdk.brain_observatory.ecephys.ecephys_project_cache import EcephysProjectCache

manifest_path = os.path.join("cache_dir", "manifest.json")
cache = EcephysProjectCache.from_lims(manifest=manifest_path)

session = cache.get_session_data(742951821)

# Show rig metadata
session._rig_metadata

# Show just eye tracking ellipse fit df
session.get_eye_tracking_data()

# Show all eye tracking data
session.get_eye_tracking_data(suppress_eye_gaze_data=False)
```

@jsiegle Let me know if other changes are desired!

Relates to: #1019