### PR TITLE
restore ecephys project cache validity filter

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -116,7 +116,7 @@ class EcephysProjectCache(Cache):
             & (units["isi_violations"] <= get_unit_filter_value("isi_violations_maximum", **kwargs))
         ]
 
-        if "quality" in units.columns:
+        if "quality" in units.columns and kwargs.get("filter_by_validity", True):
             units = units[units["quality"] == "good"]
             units.drop(columns="quality", inplace=True)
         


### PR DESCRIPTION
restore the capacity of ecephys project cache to provide noise units upon request