### PR TITLE
Remove unused EcephysSessionApi abstract method

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_session_api.py
@@ -56,9 +56,6 @@ class EcephysSessionApi:
     def get_spike_amplitudes(self) -> Dict[int, np.ndarray]:
         raise NotImplementedError
 
-    def get_rig_metadata(self) -> Optional[dict]:
-        raise NotImplementedError
-
     def get_eye_tracking_data(self, suppress_eye_gaze_data: bool) -> Optional[pd.DataFrame]:
         raise NotImplementedError
 


### PR DESCRIPTION
Woops, forgot to remove this.

Rig data is accessed as properties of the `EcephysSession` and not as a 'getter method'.