### PR TITLE
GH-1032: add mtrain criteria to allensdk with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ Jed Perkins @jfperkins
 Joe Knox @jknox13
 
 Justin Kiggins @neuromusic
+
+Kat Schelonka @kschelonka

--- a/allensdk/brain_observatory/behavior/criteria.py
+++ b/allensdk/brain_observatory/behavior/criteria.py
@@ -1,0 +1,216 @@
+"""
+Functions for calculating mtrain state transitions.
+If criteria are met, return true. Otherwise, return false.
+"""
+
+import logging
+from allensdk.core.exceptions import DataFrameKeyError, DataFrameIndexError
+
+
+logger = logging.getLogger(__name__)
+
+
+def two_out_of_three_aint_bad(session_summary):
+    """Returns true if 2 of the last 3 days showed a peak
+    d-prime above 2.
+
+    Args:
+        session_summary (pd.DataFrame): Pandas dataframe with daily values for 'dprime_peak',
+        ordered ascending by training day, for at least the past 3 days. If dataframe is not
+        properly ordered, criterion may not be correctly calculated. This function does not
+        sort the data to preserve prior behavior (sorting column was not required by mtrain function).
+        The mtrain implementation created the required columns if they didn't exist, so 
+        a more informative error is raised here to assist end-users in debugging.
+    Returns:
+        bool: True if criterion is met, False otherwise
+    """
+    if len(session_summary) < 3:
+        raise DataFrameIndexError("Not enough data in session_summary frame. "
+                                  "Expected >= 3 rows, got {}".format(len(session_summary)))
+    try:
+        last_three = session_summary["dprime_peak"][-3:]
+    except KeyError as e:
+        raise DataFrameKeyError("Failed accessing last three values in colum"
+                               "'dprime_peak'.\n df length={}, df columns={}\n"
+                               .format(len(session_summary), list(session_summary)), e)
+    logger.info('dprime_peak over last three days: {}'.format(list(last_three)))
+    criteria = bool(
+        ((last_three > 2).sum() > 1)  # at least two of the last three
+    )
+    logger.info("'Two out of three ain't bad' criteria met: '{}'".format(criteria))
+    return criteria
+
+def yesterday_was_good(session_summary):
+    """Returns true if the last day showed a peak d-prime above 2
+    Args:
+        session_summary (pd.DataFrame): Pandas dataframe with daily values for 'dprime_peak',
+        ordered ascending by training day, for at least 1 day. If dataframe is not
+        properly ordered, criterion may not be correctly calculated. This function does not
+        sort the data to preserve prior behavior (sorting column was not required by mtrain function).
+        The mtrain implementation created the required columns if they didn't exist, so 
+        a more informative error is raised here to assist end-users in debugging.
+    Returns:
+        bool: True if criterion is met, False otherwise
+    """
+    if len(session_summary) < 1:
+        raise DataFrameIndexError("Not enough data in session_summary frame. "
+                                  "Expected >= 1 row(s), got {}".format(len(session_summary)))
+    try:
+        last_day = session_summary['dprime_peak'].iloc[-1]
+    except KeyError as e:
+        raise DataFrameKeyError("Failed accessing last three values in colum"
+                               "'dprime_peak'.\n df length={}, df columns={}\n"
+                               .format(len(session_summary), list(session_summary)), e)
+    criteria = bool(last_day > 2)
+    logger.info("'Yesterday was good' criteria met: {}".format(criteria))
+    return criteria
+
+
+def no_response_bias(session_summary):
+    """the mouse meets this criterion if their last session exhibited a
+    response bias between 10% and 90%
+        Args:
+        session_summary (pd.DataFrame): Pandas dataframe with daily values for 'response_bias',
+        ordered ascending by training day, for at least 1 day. If dataframe is not
+        properly ordered, criterion may not be correctly calculated. This function does not
+        sort the data to preserve prior behavior (sorting column was not required by mtrain function).
+        The mtrain implementation created the required columns if they didn't exist, so 
+        a more informative error is raised here to assist end-users in debugging.
+    Returns:
+        bool: True if criterion is met, False otherwise
+    """
+    if len(session_summary) < 1:
+        raise DataFrameIndexError("Not enough data in session_summary frame. "
+                                  "Expected >= 1 row(s), got {}".format(len(session_summary)))
+    try:
+        response_bias = session_summary['response_bias'].iloc[-1]
+    except KeyError as e:
+        raise DataFrameKeyError("Failed accessing last values in colum"
+                               "'response_bias'.\n df length={}, df columns={}\n"
+                               .format(len(session_summary), list(session_summary)), e)
+    criteria = (response_bias < 0.9) & (response_bias > 0.1)
+    logger.info("'No response bias' criteria met: {} (response bias={})"
+                .format(criteria, response_bias))
+    return criteria
+
+
+def whole_lotta_trials(session_summary):
+    """
+    Mouse meets this criterion if the last session has more than 300 trials.
+    Args:
+        session_summary (pd.DataFrame): Pandas dataframe with daily values for 'num_contingent_trials',
+        ordered ascending by training day, for at least 1 day. If dataframe is not
+        properly ordered, criterion may not be correctly calculated. This function does not
+        sort the data to preserve prior behavior (sorting column was not required by mtrain function).
+        The mtrain implementation created the required columns if they didn't exist, so 
+        a more informative error is raised here to assist end-users in debugging.
+    Returns:
+        bool: True if criterion is met, False otherwise
+    """
+    if len(session_summary) < 1:
+        raise DataFrameIndexError("Not enough data in session_summary frame. "
+                                  "Expected >= 1 row(s), got {}".format(len(session_summary)))
+    try:
+        num_trials = session_summary['num_contingent_trials'].iloc[-1]
+    except KeyError as e:
+        raise DataFrameKeyError("Failed accessing last values in colum"
+                               "'num_contingent_trials'.\n df length={}, df columns={}\n"
+                               .format(len(session_summary), list(session_summary)), e)
+    criteria = num_trials > 300
+    logger.info("'Trials > 300' criteria met: {} (n trials={})".format(criteria, num_trials)) 
+    return criteria
+
+
+def mostly_useful(trials):
+    """
+    Returns True if fewer than half the trial time on the last day were
+    aborted trials.
+        Args:
+        trials (pd.DataFrame): Pandas dataframe with columns 'training_day', 'trial_type',
+        and 'trial_length'.
+    Returns:
+        bool: True if criterion is met, False otherwise
+    """
+    if len(trials) == 0:   # empty df would return true, but shouldn't
+        return False
+    last_day = trials['training_day'].max()
+    group = trials.groupby('training_day').get_group(last_day)
+    trial_fractions = group.groupby('trial_type')['trial_length'].sum() \
+        / group['trial_length'].sum()
+    aborted = trial_fractions['aborted']
+    criteria = aborted < 0.5
+    logger.info("Fewer than half the trials were aborted on the last training day: {} "
+                 "(% aborted trials={})".format(criteria, aborted))
+    return criteria
+
+
+def consistency_is_key(session_summary):
+    '''need some way to judge consistency of various parameters
+
+    - dprime
+    - num trials
+    - hit rate
+    - fa rate
+    - lick timing
+    '''
+    raise NotImplementedError
+
+
+def consistent_behavior_within_session(session_summary):
+    '''need some way to measure consistent performance within a session
+
+    - compare peak to overall dprime?
+    - variance in rolling window dprime?
+    '''
+    raise NotImplementedError
+
+
+def n_complete(threshold, count):
+    """
+    For compatibility with original API. If count >= threshold, return True.
+    Otherwise return False.
+    Args:
+        threshold (numeric): Threshold for the count to meet.
+        count (numeric): The count to compare to the threshold.
+    Returns:
+        True if count >= threshold, otherwise False.
+    """
+    return count >= threshold
+
+
+def meets_engagement_criteria(session_summary):
+    """
+    Returns true if engagement criteria were met for the past 3 days, else false.
+    Args:
+        session_summary (pd.DataFrame): Pandas dataframe with daily values for 'dprime_peak' and 'num_engaged_trials',
+        ordered ascending by training day, for at least 3 days. If dataframe is not
+        properly ordered, criterion may not be correctly calculated. This function does not
+        sort the data to preserve prior behavior (sorting column was not required by mtrain function)
+        The mtrain implementation created the required columns if they didn't exist, so 
+        a more informative error is raised here to assist end-users in debugging.
+    Returns:
+        bool: True if criterion is met, False otherwise
+    """
+    criteria = 3
+    if len(session_summary) < 3:
+        raise DataFrameIndexError("Not enough data in session_summary frame. "
+                                  "Expected >= 3 rows, got {}".format(len(session_summary)))
+    try:
+        session_summary['engagement_criteria'] = (
+            (session_summary['dprime_peak'] > 1.0)
+            & (session_summary['num_engaged_trials'] > 100)
+        )
+        engaged_days = session_summary['engagement_criteria'].iloc[-3:].sum()
+    except KeyError as e:
+        raise DataFrameKeyError("Failed accessing columns 'dprime_peak' and/or "
+                               "'num_engaged_trials' for 3 days.\n df length={}, df columns={}\n"
+                               .format(len(session_summary), list(session_summary)), e)
+    return engaged_days == criteria
+
+
+def summer_over(trials):
+    """
+    Returns true if the maximum value of 'training_day' in the trials dataframe is >= 40,
+    else false.
+    """
+    return trials['training_day'].max() >= 40

--- a/allensdk/brain_observatory/behavior/mtrain.py
+++ b/allensdk/brain_observatory/behavior/mtrain.py
@@ -1,5 +1,6 @@
 from marshmallow import Schema, fields
 from datetime import datetime, date
+import numpy as np
 
 
 def annotate_change_detect(trials):

--- a/allensdk/brain_observatory/behavior/session_metrics.py
+++ b/allensdk/brain_observatory/behavior/session_metrics.py
@@ -1,0 +1,37 @@
+import numpy as np
+from allensdk.brain_observatory.behavior import trial_masks as masks
+
+def response_bias(trials, detect_col, trial_types=("go", "catch")):
+    """
+    Calculate the response bias for a subset of trial types from a behavioral
+    training dataframe.
+    Args:
+        trials (pandas.DataFrame): Dataframe containing trial-level information
+            from a behavioral training session. Required columns:
+            "trial_type", `detect_col`.
+        detect_col (str): Name of column containing boolean 
+            or numeric codings (0/1) for whether or not the mouse had a 
+            response.
+        trial_types (iterable<str>): Iterable containing string trial types
+            to check for the response bias. Trials of types not included in this
+            iterable will be ignored. Default=("go", "catch")
+    Return:
+        The response bias (or average value of the `detect_col`)
+        for trials in `trial_types`.
+    """
+    mask = masks.trial_types(trials, trial_types)
+    return trials[mask][detect_col].mean()
+
+
+def num_contingent_trials(session_trials):
+    """
+    Returns the number of "go" and "catch" trials in a training session
+    dataframe.
+    Args:
+        session_trials (pandas.DataFrame): a pandas.DataFrame describing 
+        behavior training trials, with the string column "trial_type"
+        describing the type of trial.
+    Returns (int): Number of "go" and "catch" trials
+    """
+    return session_trials["trial_type"].isin(["go", "catch"]).sum()
+

--- a/allensdk/brain_observatory/behavior/trial_masks.py
+++ b/allensdk/brain_observatory/behavior/trial_masks.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+
+def trial_types(trials, trial_types):
+    """ only include trials of certain trial types
+
+    Parameters
+    ----------
+    trials : pandas DataFrame
+        dataframe of trials
+    trial_types : list or other iterator
+
+
+    Returns
+    -------
+    mask : pandas Series of booleans, indexed to trials DataFrame
+
+    """
+
+    if trial_types is not None and len(trial_types) > 0:
+        return trials['trial_type'].isin(trial_types)
+    else:
+        return pd.Series(np.ones((len(trials), ), dtype=bool), 
+                         name="trial_type", index=trials.index)
+
+
+def contingent_trials(trials):
+    """ GO & CATCH trials only
+
+    Parameters
+    ----------
+    trials : pandas DataFrame
+        dataframe of trials
+
+    Returns
+    -------
+    mask : pandas Series of booleans, indexed to trials DataFrame
+
+    """
+    return trial_types(trials, ('go', 'catch'))
+
+
+def reward_rate(trials, thresh=2.0):
+    """ masks trials where the reward rate (per minute) is below some threshold.
+
+    This de facto omits trials in which the animal was not licking for extended periods
+    or periods when they were licking indiscriminantly.
+
+    Parameters
+    ----------
+    trials : pandas DataFrame
+        dataframe of trials
+    thresh : float, optional
+        threshold under which trials will not be included, default: 2.0
+
+    Returns
+    -------
+    mask : pandas Series of booleans, indexed to trials DataFrame
+
+    """
+
+    mask = trials['reward_rate'] > thresh
+    return mask

--- a/allensdk/core/exceptions.py
+++ b/allensdk/core/exceptions.py
@@ -1,0 +1,22 @@
+class DataFrameKeyError(LookupError):
+    """More verbose method for accessing invalid rows or columns 
+    in a dataframe. Should be used when a keyerror is thrown on a dataframe.
+    """
+    def __init__(self, msg, caught_exception=None):
+        if caught_exception:
+            error_string = "{}\nCaught Exception: {}".format(msg, caught_exception)
+        else:
+            error_string = msg
+        super().__init__(error_string)
+
+class DataFrameIndexError(LookupError):
+    """More verbose method for accessing invalid rows or columns 
+    in a dataframe. Should be used when an index error is thrown on a dataframe.
+    """
+    def __init__(self, msg, caught_exception=None):
+        if caught_exception:
+            error_string = "{}\nCaught Exception: {}".format(msg, caught_exception)
+        else:
+            error_string = msg
+        super().__init__(error_string)
+

--- a/allensdk/test/brain_observatory/behavior/test_criteria.py
+++ b/allensdk/test/brain_observatory/behavior/test_criteria.py
@@ -1,0 +1,382 @@
+import pytest
+import pandas as pd
+from allensdk.brain_observatory.behavior import criteria
+from allensdk.core.exceptions import DataFrameKeyError, DataFrameIndexError
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 0, 1: 0, 2: 0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 2.0, 1: 2.0, 2: 2.0, },
+            }),
+            False,
+        ),  # should need to be greater than 2.0
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 0, 1: 0, 2: 2.1, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 0, 1: 2.1, 2: 2.1, },
+            }),
+            True,
+        ),
+    ],
+)
+def test_two_out_of_three_aint_bad(session_summary, expected):
+    assert criteria.two_out_of_three_aint_bad(session_summary) == expected
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, },
+                "dprime_peak": {0: 0, 1: 2.1, }
+            }),
+            pytest.raises(DataFrameIndexError),
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "other_col": {0: 0, 1: 2.1, 2: 2.1, }
+            }),
+            pytest.raises(DataFrameKeyError),
+        ),
+    ],
+)
+def test_two_out_of_three_aint_bad_exception(session_summary, expected):
+    with expected:
+        criteria.two_out_of_three_aint_bad(session_summary)
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 0, 1: 0, 2: 0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 2.0, 1: 2.0, 2: 2.0, },
+            }),
+            False,
+        ),  # should need to be greater than 2.0
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 0, 1: 2.1, 2: 0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "dprime_peak": {0: 0, 1: 0, 2: 2.1, },
+            }),
+            True,
+        ),
+
+    ],
+)
+def test_yesterday_was_good(session_summary, expected):
+    assert criteria.yesterday_was_good(session_summary) == expected
+
+
+@pytest.mark.parametrize(
+    "session_summary,expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {},
+                "dprime_peak": {},
+            }),
+            pytest.raises(DataFrameIndexError),
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "other_col": {0: 0, 1: 0, 2: 2.1, },
+            }),
+            pytest.raises(DataFrameKeyError),
+        ),
+    ],
+)
+def test_yesterday_was_good_exception(session_summary, expected):
+    with expected:
+        criteria.yesterday_was_good(session_summary)
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.1, },
+            }),
+            False,
+        ),  # non-inclusive
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.9, },
+            }),
+            False,
+        ),  # non-inclusive
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.11, },
+            }),
+            True,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.89, },
+            }),
+            True,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.1011, },
+            }),
+            True,
+        ),  # doesn't round
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "response_bias": {0: 0.0, 1: 0.0, 2: 0.8999, },
+            }),
+            True,
+        ),  # doesn't round
+    ],
+)
+def test_no_response_bias(session_summary, expected):
+    assert criteria.no_response_bias(session_summary) == expected
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {},
+                "response_bias": {},
+            }),
+            pytest.raises(DataFrameIndexError),
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "other_col": {0: 0.0, 1: 0.0, 2: 0.11, },
+            }),
+            pytest.raises(DataFrameKeyError),
+        ),
+    ],
+)
+def test_no_response_bias_exception(session_summary, expected):
+    with expected:
+        criteria.no_response_bias(session_summary)
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "num_contingent_trials": {0: 0.0, 1: 0.0, 2: 0.0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "num_contingent_trials": {0: 0.0, 1: 0.0, 2: 100.0, },
+            }),
+            False,
+        ),  # non-inclusive
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "num_contingent_trials": {0: 0.0, 1: 0.0, 2: 300.0, },
+            }),
+            False,
+        ),  # non-inclusive
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "num_contingent_trials": {0: 0.0, 1: 0.0, 2: 301.0, },
+            }),
+            True,
+        ),
+    ],
+)
+def test_whole_lotta_trials(session_summary, expected):
+    assert criteria.whole_lotta_trials(session_summary) == expected
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {},
+                "num_contingent_trials": {},
+            }),
+            pytest.raises(DataFrameIndexError),
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0, 1: 1, 2: 3, },
+                "other_col": {0: 0.0, 1: 0.0, 2: 301.0, },
+            }),
+            pytest.raises(DataFrameKeyError),
+        ),
+    ]
+)
+def test_whole_lotta_trials_exception(session_summary, expected):
+    with expected:
+        criteria.whole_lotta_trials(session_summary)
+
+
+@pytest.mark.parametrize(
+    "trials, expected",
+    [
+        (
+            pd.DataFrame({
+                "training_day": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, },  # associate all with same training day
+                "trial_type": {0: "aborted", 1: "go", 2: "catch", 3: "go", },
+                "trial_length": {0: 1.0, 1: 1.0, 2: 1.0, 3: 1.0, },
+            }),
+            True,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, },  # associate all with same training day
+                "trial_type": {0: "aborted", 1: "go", 2: "catch", 3: "aborted", },
+                "trial_length": {0: 1.0, 1: 1.0, 2: 1.0, 3: 1.0, },
+            }),
+            False,
+        ),  # non-inclusive
+        (
+            pd.DataFrame({
+                "training_day": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, },  # associate all with same training day
+                "trial_type": {0: "aborted", 1: "go", 2: "aborted", 3: "aborted", },
+                "trial_length": {0: 1.0, 1: 1.0, 2: 1.0, 3: 1.0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "training_day": {},  # associate all with same training day
+                "trial_type": {},
+                "trial_length": {},
+            }),
+            False,
+        ),
+    ],
+)
+def test_mostly_useful(trials, expected):
+    assert criteria.mostly_useful(trials) == expected
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "task": {0: "Images", 1: "", 2: "", 3: "Images", },
+                "dprime_peak": {0: 1.0, 1: 0.0, 2: 0.0, 3: 0.0, },
+                "num_engaged_trials": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "task": {0: "", 1: "", 2: "", 3: "Images", 4: "Images", 5: "Images"},
+                "dprime_peak": {0: 1.2, 1: 2.0, 2: 1.1, 3: 1.1, 4: 2.0, 5: 1.2, },
+                "num_engaged_trials": {0: 101, 1: 102, 2: 200, 3: 101, 4: 102, 5: 99, },
+            }),
+            False,
+        ),
+        (
+            pd.DataFrame({
+                "task": {0: "Images", 1: "Images", 2: "Images", 3: "Images", 4: "Images", 5: "Images"},
+                "dprime_peak": {0: 1.2, 1: 2.0, 2: 1.1, 3: 1.1, 4: 2.0, 5: 1.2, },
+                "num_engaged_trials": {0: 101, 1: 102, 2: 200, 3: 101, 4: 102, 5: 200, },
+            }),
+            True,
+        ),
+    ],
+)
+def test_meets_engagement_criteria(session_summary, expected):
+    assert criteria.meets_engagement_criteria(session_summary) == expected
+
+
+@pytest.mark.parametrize(
+    "session_summary, expected",
+    [
+        (
+            pd.DataFrame({
+                "task": {0: "Images", 1: "Images", 2: "Images", 3: "Images", 4: "Images", 5: "Images"},
+                "other_metric": {0: 1.2, 1: 2.0, 2: 1.1, 3: 1.1, 4: 2.0, 5: 1.2, },
+                "num_engaged_trials": {0: 101, 1: 102, 2: 200, 3: 101, 4: 102, 5: 200, },
+            }),
+            pytest.raises(DataFrameKeyError),
+        ),
+        (
+            pd.DataFrame({
+                "task": {0: "Images", 1: "Images", },
+                "dprime_peak": {0: 1.2, 1: 2.0,},
+                "num_engaged_trials": {0: 101, 1: 102},
+            }),
+            pytest.raises(DataFrameIndexError),
+        ),
+    ],
+)
+def test_meets_engagement_criteria_exception(session_summary, expected):
+    with expected:
+        criteria.meets_engagement_criteria(session_summary)
+
+
+@pytest.mark.parametrize(
+    "trials, expected",
+    [
+        (pd.DataFrame({'training_day': {0: 0, 1: 1, 2: 3, }, }), False, ),
+        (pd.DataFrame({'training_day': {0: 0, 1: 1, 2: 40, }, }), True, ),  # inclusive
+        (pd.DataFrame({'training_day': {0: 0, 1: 1, 2: 41, }, }), True, ),
+    ],
+)
+def test_summer_over(trials, expected):
+    assert criteria.summer_over(trials) == expected

--- a/allensdk/test/brain_observatory/behavior/test_session_metrics.py
+++ b/allensdk/test/brain_observatory/behavior/test_session_metrics.py
@@ -1,0 +1,71 @@
+import pytest
+from allensdk.brain_observatory.behavior import session_metrics as metrics
+import pandas as pd
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "trials, detect_col, trial_types, expected",
+    [
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True]}),
+            "detect",
+            ["go", "catch"],
+            0.75,
+        ),
+        (
+            pd.DataFrame({"trial_type":[ "go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True]}),
+            "detect",
+            ["go"],
+            0.5,
+        ),
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True]}),
+            "detect",
+            [],
+            0.8,
+        ),
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True]}),
+            "detect",
+            ["early"],
+            np.nan,
+        ),
+    ],
+)
+def test_response_bias(trials, detect_col, trial_types, expected):
+    assert metrics.response_bias(trials, detect_col, trial_types) == \
+        pytest.approx(expected, nan_ok=True)
+
+
+@pytest.mark.parametrize(
+    "trials, expected",
+    [
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],}),
+            4,
+        ),
+        (
+            pd.DataFrame({"trial_type":[ "go", "go", "go"],}),
+            3,
+        ),
+        (
+            pd.DataFrame({"trial_type": ["catch"],}),
+            1,
+        ),
+        (
+            pd.DataFrame({"trial_type": [],}),
+            0,
+        ),
+        (
+            pd.DataFrame({"trial_type": ["aborted", "nogo"]}),
+            0,
+        )
+    ],
+)
+def test_num_contingent_trials(trials, expected):
+    assert metrics.num_contingent_trials(trials) == expected

--- a/allensdk/test/brain_observatory/behavior/test_trial_masks.py
+++ b/allensdk/test/brain_observatory/behavior/test_trial_masks.py
@@ -1,0 +1,107 @@
+import pytest
+from allensdk.brain_observatory.behavior import trial_masks as masks
+import pandas as pd
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "trials, trial_types, expected",
+    [
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True],}),
+            ["go", "catch"],
+            pd.Series([True, True, True, True, False], name="trial_type"),
+        ),
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True],}),
+            ["aborted"],
+            pd.Series([False, False, False, False, True], name="trial_type")
+        ),
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True],}),
+            [],
+            pd.Series([True, True, True, True, True], name="trial_type"),
+        ),
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True],}),
+            ["early"],
+            pd.Series([False, False, False, False, False], name="trial_type"),
+        ),
+        (
+            pd.DataFrame({"trial_type": [],
+                          "detect": [],}),
+            ["go", "catch"],
+            pd.Series([], name="trial_type"),
+        ),
+    ],
+)
+def test_trial_types(trials, trial_types, expected):
+    pd.testing.assert_series_equal(
+        masks.trial_types(trials, trial_types), expected, check_dtype=False)
+
+
+
+@pytest.mark.parametrize(
+    "trials, trial_types, expected",
+    [
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "include": [True, False, True, True, True],}),
+            ["go", "catch"],
+            pd.Series([True, True, True, False], name="trial_type",
+            index=[0, 2, 3, 4]),
+        ),
+    ],
+)
+def test_trial_types_works_with_subselection(trials, trial_types, expected):
+    pd.testing.assert_series_equal(
+        masks.trial_types(trials[trials["include"]], trial_types), expected, 
+        check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    "trials, expected",
+    [
+        (
+            pd.DataFrame({"trial_type": ["go", "go", "catch", "catch", "aborted"],
+                          "detect": [True, False, True, True, True],}),
+            pd.Series([True, True, True, True, False], name="trial_type"),
+        ),
+        (
+            pd.DataFrame({"trial_type": [],
+                          "detect": [],}),
+            pd.Series([], name="trial_type"),
+        ),
+    ]
+)
+def test_contingent_trials(trials, expected):
+    pd.testing.assert_series_equal(
+        masks.contingent_trials(trials), expected, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    "trials, thresh, expected",
+    [
+        (
+            pd.DataFrame({"reward_rate": [0.0, 1.0, 2.0, 3.0]}),
+            -1.0,
+            pd.Series([True, True, True, True], name="reward_rate"),
+        ),
+        (
+            pd.DataFrame({"reward_rate": [0.0, 1.0, 2.0, 3.0]}),
+            1.0,
+            pd.Series([False, False, True, True], name="reward_rate"),
+        ),
+        (
+            pd.DataFrame({"reward_rate": [0.0, 1.0, 2.0, 3.0]}),
+            3.0,
+            pd.Series([False, False, False, False], name="reward_rate"),
+        ),
+    ]
+)
+def test_reward_rate(trials, thresh, expected):
+    pd.testing.assert_series_equal(masks.reward_rate(trials, thresh), expected)


### PR DESCRIPTION
Response to #1041, part of epic issue #1032 

Moves mtrain.criteria methods into allensdk, and updates the methods to take either a dataframe of trials or a dataframe session summary, rather than the mtrain Mouse object. Add some additional dependencies required by the Mouse object in mtrain_api to get the data into proper format for using the criteria methods. Also added unit testing where was previously missing in VBA (session_metrics and masks).