### PR TITLE
swapped ecephys metrics

### DIFF
--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
@@ -144,8 +144,9 @@ class ReceptiveFieldMapping(StimulusAnalysis):
                                    'width_rf',
                                    'height_rf',
                                    'area_rf',
+                                   'p_value_rf',
                                    'on_screen_rf',
-                                   'p_value_rf']] = [self._get_rf_stats(unit) for unit in unit_ids]
+                                   ]] = [self._get_rf_stats(unit) for unit in unit_ids]
                 metrics_df['firing_rate_rf'] = [self._get_overall_firing_rate(unit) for unit in unit_ids]
                 metrics_df['fano_rf'] = [self._get_fano_factor(unit, self._get_preferred_condition(unit))
                                          for unit in unit_ids]


### PR DESCRIPTION
p_value_rf and on_screen_rf were erroneously swapped in the analysis metrics module. This PR:
1. fixes the module
2. adds a hack into the EcephysWarehouseApi so that end users get the right metrics.
3. improves documentation