### PR TITLE
Rename eye tracking df accessors to get_pupil_data

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -366,12 +366,12 @@ class EcephysSession(LazyPropertyMixin):
 
         return self.invalid_times
 
-    def get_eye_tracking_data(self, suppress_eye_gaze_data: bool = True) -> pd.DataFrame:
+    def get_pupil_data(self, suppress_pupil_data: bool = True) -> pd.DataFrame:
         """Return a dataframe with eye tracking data
 
         Parameters
         ----------
-        suppress_eye_gaze_data : bool, optional
+        suppress_pupil_data : bool, optional
             Whether or not to suppress eye gaze mapping data in output
             dataframe, by default True.
 
@@ -385,7 +385,7 @@ class EcephysSession(LazyPropertyMixin):
                 *_width
                 *_phi
             May also contain raw/filtered columns for gaze mapping if
-            suppress_eye_gaze_data is set to False:
+            suppress_pupil_data is set to False:
                 *_eye_area
                 *_pupil_area
                 *_screen_coordinates_x_cm
@@ -393,7 +393,7 @@ class EcephysSession(LazyPropertyMixin):
                 *_screen_coordinates_spherical_x_deg
                 *_screen_coorindates_spherical_y_deg
         """
-        return self.api.get_eye_tracking_data(suppress_eye_gaze_data=suppress_eye_gaze_data)
+        return self.api.get_pupil_data(suppress_pupil_data=suppress_pupil_data)
 
     def presentationwise_spike_counts(
         self, 

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -162,7 +162,7 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
 
         return rig_metadata
 
-    def get_eye_tracking_data(self, suppress_eye_gaze_data: bool = True) -> Optional[pd.DataFrame]:
+    def get_pupil_data(self, suppress_pupil_data: bool = True) -> Optional[pd.DataFrame]:
         try:
             et_mod = self.nwbfile.get_processing_module("eye_tracking")
             rgm_mod = self.nwbfile.get_processing_module("raw_gaze_mapping")
@@ -205,7 +205,7 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
             "eye_phi": eye_ellipse_fits["phi"].values
         }
 
-        if not suppress_eye_gaze_data:
+        if not suppress_pupil_data:
             eye_tracking_data.update(
                 {
                     "raw_eye_area": raw_eye_area_ts.data[:],

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_session_api.py
@@ -59,7 +59,7 @@ class EcephysSessionApi:
     def get_rig_metadata(self) -> Optional[dict]:
         raise NotImplementedError
 
-    def get_eye_tracking_data(self, suppress_eye_gaze_data: bool) -> Optional[pd.DataFrame]:
+    def get_pupil_data(self, suppress_pupil_data: bool) -> Optional[pd.DataFrame]:
         raise NotImplementedError
 
     def get_metadata(self):

--- a/allensdk/core/brain_observatory_cache.py
+++ b/allensdk/core/brain_observatory_cache.py
@@ -551,10 +551,10 @@ class BrainObservatoryCache(Cache):
 
         return np.load(file_name, allow_pickle=False)["ev"]
 
-    def get_ophys_eye_gaze_data(self,
-                                ophys_experiment_id: int,
-                                file_name: str = None,
-                                suppress_eye_gaze_data: bool = True) -> pd.DataFrame:
+    def get_ophys_pupil_data(self,
+                             ophys_experiment_id: int,
+                             file_name: str = None,
+                             suppress_pupil_data: bool = True) -> pd.DataFrame:
         """Download the h5 eye gaze mapping file for an ophys_experiment if
         it hasn't already been downloaded and return it as a pandas.DataFrame.
 
@@ -566,10 +566,10 @@ class BrainObservatoryCache(Cache):
             is disabled, no file will be saved. Default is None.
 
         ophys_experiment_id: int
-            id of the ophys_experiment to retrieve eye_gaze_mapping data for.
+            id of the ophys_experiment to retrieve pupil data for.
 
-        suppress_eye_gaze_data: bool
-            Whether or not to suppress eye gaze mapping data from dataset.
+        suppress_pupil_data: bool
+            Whether or not to suppress pupil data from dataset.
             Default is True.
 
         Returns
@@ -587,11 +587,11 @@ class BrainObservatoryCache(Cache):
                 An empty pandas DataFrame
         """
 
-        if suppress_eye_gaze_data:
-            print("This eye gaze mapping data is obtained using a new eye "
+        if suppress_pupil_data:
+            print("This pupil data is obtained using a new eye "
                   "tracking algorithm and is in the process of being validated. "
                   "If you would like to view the data anyways, "
-                  "please set the 'suppress_eye_gaze_data' parameter to 'False'.")
+                  "please set the 'suppress_pupil_data' parameter to 'False'.")
             return pd.DataFrame()
 
         # NOTE: This is a really ugly hack to get around the fact that warehouse does
@@ -600,13 +600,18 @@ class BrainObservatoryCache(Cache):
         # ----- Start of ugly hack -----
         try:
             ophys_session_id = ophys_experiment_session_id_map[ophys_experiment_id]
-        except KeyError as e:
+        except KeyError:
             raise RuntimeError(f"Experiment id '{ophys_experiment_id}' has no associated session!")
         # ----- End of ugly hack -----
 
         file_name = self.get_cache_path(file_name,
                                         self.EYE_GAZE_DATA_KEY,
                                         ophys_session_id)
+
+        if not file_name:
+            raise RuntimeError("Could not obtain a file_name for pupil data "
+                               f"with experiment id: {ophys_experiment_id} "
+                               f"(session id: {ophys_session_id})")
 
         # NOTE: `save_ophys_experiment_eye_gaze_data` will also need to be
         # updated to remove ophy_session_id param when ugly hack is removed.

--- a/allensdk/test/core/test_brain_observatory_cache.py
+++ b/allensdk/test/core/test_brain_observatory_cache.py
@@ -294,13 +294,13 @@ def test_get_cell_specimens(mock_json_msg_query,
 # NOTE: This test should be updated when ugly hack for associating
 # ophys experiment id with ophys session id is resolved.
 @patch.object(BrainObservatoryApi, "json_msg_query")
-def test_get_ophys_eye_gaze_data(mock_json_msg_query,
-                                 brain_observatory_cache):
+def test_get_ophys_pupil_data(mock_json_msg_query,
+                              brain_observatory_cache):
 
     with patch.dict('allensdk.core.ophys_experiment_session_id_mapping.ophys_experiment_session_id_map', {111: 777}, clear=True):
         # We are only testing that rma query is correct
         try:
-            tls = brain_observatory_cache.get_ophys_eye_gaze_data(111, suppress_eye_gaze_data=False)
+            tls = brain_observatory_cache.get_ophys_pupil_data(111, suppress_pupil_data=False)
         except Exception:
             pass
 


### PR DESCRIPTION
`ecephys session api` eye tracking accessor method name has been changed to `get_pupil_data`

`brain observatory cache` eye tracking accessor method name have been changed to `get_ophys_pupil_data` (to stay consistent with all the other accessor method names e.g. `get_ophys_experiment_events`, `get_ophys_experiment_data`, `get_ophys_experiment_stimuli`, etc...)