### PR TITLE
Add time since stimulus presentation to spike times

### DIFF
--- a/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_stimulus_analysis.py
+++ b/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_stimulus_analysis.py
@@ -190,7 +190,7 @@ def test_presentationwise_spike_times(ecephys_api):
     stim_analysis = StimulusAnalysis(ecephys_session=session, stimulus_key='s0')
     assert(len(stim_analysis.presentationwise_spike_times) == 12)
     assert(list(stim_analysis.presentationwise_spike_times.index.names) == ['spike_time'])
-    assert(set(stim_analysis.presentationwise_spike_times.columns) == {'stimulus_presentation_id', 'unit_id'})
+    assert(set(stim_analysis.presentationwise_spike_times.columns) == {'stimulus_presentation_id', 'unit_id', 'time_since_stimulus_presentation_onset'})
     assert(stim_analysis.presentationwise_spike_times.loc[1.01]['unit_id'] == 2)
     assert(stim_analysis.presentationwise_spike_times.loc[1.01]['stimulus_presentation_id'] == 2)
     assert(len(stim_analysis.presentationwise_spike_times.loc[3.0]) == 2)

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_session.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_session.py
@@ -316,7 +316,8 @@ def test_presentationwise_spike_times(spike_times_api):
 
     expected = pd.DataFrame({
         'unit_id': [2, 2, 2],
-        'stimulus_presentation_id': [2, 2, 2, ]
+        'stimulus_presentation_id': [2, 2, 2, ],
+        'time_since_stimulus_presentation_onset': [0.01, 0.02, 0.03]
     }, index=pd.Index(name='spike_time', data=[1.01, 1.02, 1.03]))
 
     pd.testing.assert_frame_equal(expected, obtained, check_like=True, check_dtype=False)    


### PR DESCRIPTION
Resolves the third point on #1063 (previous points are handled in other issues/PRs)

