### PR TITLE
1100 fix behavior ophys session nightly tests

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -235,38 +235,7 @@ def equals(A, B, reraise=False):
         for field in sorted(field_set):
             x1, x2 = getattr(A, field), getattr(B, field)
             err_msg = f"{field} on {A} did not equal {field} on {B} (\n{x1} vs\n{x2}\n)"
-
-            if isinstance(x1, pd.DataFrame):
-                try:
-                    assert_frame_equal(x1, x2, check_like=True)
-                except:
-                    print(err_msg)
-                    raise
-            elif isinstance(x1, np.ndarray):
-                np.testing.assert_array_almost_equal(x1, x2, err_msg=err_msg)
-            elif isinstance(x1, xr.DataArray):
-                xr.testing.assert_allclose(x1, x2)
-            elif isinstance(x1, (list,)):
-                assert x1 == x2, err_msg
-            elif isinstance(x1, (sitk.Image,)):
-                assert x1.GetSize() == x2.GetSize(), err_msg
-                assert x1 == x2, err_msg
-            elif isinstance(x1, (dict,)):
-                for key in set(x1.keys()).union(set(x2.keys())):
-                    key_err_msg = f"{key} on {field} on {A} did not equal {key} on {field} on {B}"
-
-                    if isinstance(x1[key], (np.ndarray,)):
-                        np.testing.assert_array_almost_equal(x1[key], x2[key], err_msg=key_err_msg)
-                    elif isinstance(x1[key], (float,)):
-                        if math.isnan(x1[key]) or math.isnan(x2[key]):
-                            assert math.isnan(x1[key]) and math.isnan(x2[key]), key_err_msg
-                        else:
-                            assert x1[key] == x2[key], key_err_msg
-                    else:
-                        assert x1[key] == x2[key], key_err_msg
-
-            else:
-                assert x1 == x2, err_msg
+            compare_fields(x1, x2, err_msg)
 
     except NotImplementedError as e:
         A_implements_get_field = hasattr(A.api, getattr(type(A), field).getter_name)
@@ -279,3 +248,38 @@ def equals(A, B, reraise=False):
         return False
 
     return True
+
+
+
+def compare_fields(x1, x2, err_msg=""):
+    if isinstance(x1, pd.DataFrame):
+        try:
+            assert_frame_equal(x1, x2, check_like=True)
+        except:
+            print(err_msg)
+            raise
+    elif isinstance(x1, np.ndarray):
+        np.testing.assert_array_almost_equal(x1, x2, err_msg=err_msg)
+    elif isinstance(x1, xr.DataArray):
+        xr.testing.assert_allclose(x1, x2)
+    elif isinstance(x1, (list,)):
+        assert x1 == x2, err_msg
+    elif isinstance(x1, (sitk.Image,)):
+        assert x1.GetSize() == x2.GetSize(), err_msg
+        assert x1 == x2, err_msg
+    elif isinstance(x1, (dict,)):
+        for key in set(x1.keys()).union(set(x2.keys())):
+            key_err_msg = f"mismatch when checking key {key}. {err_msg}"
+
+            if isinstance(x1[key], (np.ndarray,)):
+                np.testing.assert_array_almost_equal(x1[key], x2[key], err_msg=key_err_msg)
+            elif isinstance(x1[key], (float,)):
+                if math.isnan(x1[key]) or math.isnan(x2[key]):
+                    assert math.isnan(x1[key]) and math.isnan(x2[key]), key_err_msg
+                else:
+                    assert x1[key] == x2[key], key_err_msg
+            else:
+                assert x1[key] == x2[key], key_err_msg
+
+    else:
+        assert x1 == x2, err_msg

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -31,6 +31,7 @@ def test_equal(oeid1, oeid2, expected):
 
     assert equals(d1, d2) == expected
 
+@pytest.mark.requires_bamboo
 @pytest.mark.parametrize("get_expected,get_from_session", [
     [
         lambda ssn_data: ssn_data["ophys_experiment_id"], 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -30,14 +30,17 @@ def test_equal(oeid1, oeid2, expected):
 
     assert equals(d1, d2) == expected
 
-@pytest.mark.nightly
-def test_session_from_json(tmpdir_factory, session_data):
-    oeid = 789359614
+@pytest.mark.parametrize("session_data_key,getter", [
+    ["ophys_experiment_id", lambda ssn: ssn.ophys_experiment_id],
+    ["targeted_structure", lambda ssn: ssn.metadata["targeted_structure"]]
+])
+def test_session_from_json(tmpdir_factory, session_data, session_data_key, getter):
+    session = BehaviorOphysSession(api=BehaviorOphysJsonApi(session_data))
 
-    d1 = BehaviorOphysSession(api=BehaviorOphysJsonApi(session_data))
-    d2 = BehaviorOphysSession.from_lims(oeid)
+    expected = session_data[session_data_key]
+    obtained = getter(session)
 
-    assert equals(d1, d2)
+    assert expected == obtained
 
 
 @pytest.mark.requires_bamboo

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -81,7 +81,7 @@ def test_visbeh_ophys_data_set():
     assert data_set.metadata == {'stimulus_frame_rate': 60.0,
                                  'full_genotype': 'Slc17a7-IRES2-Cre/wt;Camk2a-tTA/wt;Ai93(TITL-GCaMP6f)/wt',
                                  'ophys_experiment_id': 789359614,
-                                 'session_type': 'Unknown',
+                                 'session_type': 'OPHYS_6_images_B',
                                  'driver_line': ['Camk2a-tTA', 'Slc17a7-IRES2-Cre'],
                                  'behavior_session_uuid': uuid.UUID('69cdbe09-e62b-4b42-aab1-54b5773dfe78'),
                                  'experiment_datetime': pytz.utc.localize(datetime.datetime(2018, 11, 30, 23, 28, 37)),


### PR DESCRIPTION
1. replaces the json api integration test, which compared cached data vs. the results of a lims query with a parametrized test of the actual behavior ophys json api.
2. updates expectation in `test_visbeh_ophys_data_set`