### PR TITLE
1101 update 2p session analysis nightly tests for recent scipy

### DIFF
--- a/allensdk/brain_observatory/stimulus_analysis.py
+++ b/allensdk/brain_observatory/stimulus_analysis.py
@@ -465,14 +465,14 @@ class StimulusAnalysis(object):
                     nc, start_max * binsize:(start_max + 1) * binsize]
                 other_values = np.delete(celltraces_sorted_sp[nc, :], range(
                     start_max * binsize, (start_max + 1) * binsize))
-                (_, peak_run.ptest_sp[nc]) = st.ks_2samp(
+                (_, peak_run.ptest_sp[nc]) = nonraising_ks_2samp(
                     test_values, other_values)
             else:
                 test_values = celltraces_sorted_sp[
                     nc, start_min * binsize:(start_min + 1) * binsize]
                 other_values = np.delete(celltraces_sorted_sp[nc, :], range(
                     start_min * binsize, (start_min + 1) * binsize))
-                (_, peak_run.ptest_sp[nc]) = st.ks_2samp(
+                (_, peak_run.ptest_sp[nc]) = nonraising_ks_2samp(
                     test_values, other_values)
             temp = binned_cells_vis[nc, :, 0]
             start_max = temp.argmax()
@@ -489,7 +489,7 @@ class StimulusAnalysis(object):
                     nc, start_min * binsize:(start_min + 1) * binsize]
                 other_values = np.delete(celltraces_sorted_vis[nc, :], range(
                     start_min * binsize, (start_min + 1) * binsize))
-            (_, peak_run.ptest_vis[nc]) = st.ks_2samp(
+            (_, peak_run.ptest_vis[nc]) = nonraising_ks_2samp(
                 test_values, other_values)
 
         return binned_dx_sp, binned_cells_sp, binned_dx_vis, binned_cells_vis, peak_run
@@ -581,3 +581,13 @@ class StimulusAnalysis(object):
         else:
             raise Exception("Could not find row for csid(%s) idx(%s)" % (str(csid), str(idx)))
     
+    
+def nonraising_ks_2samp(data1, data2, **kwargs):
+    """ scipy.stats.ks_2samp now raises a ValueError if one of the input arrays 
+    is of length 0. Previously it signaled this case by returning nans. This 
+    function restores the prior behavior.
+    """
+
+    if min(len(data1), len(data2)) == 0:
+        return (np.nan, np.nan)
+    return st.ks_2samp(data1, data2, **kwargs)

--- a/allensdk/test/brain_observatory/test_session_analysis.py
+++ b/allensdk/test/brain_observatory/test_session_analysis.py
@@ -47,13 +47,16 @@ def mock_stimulus_table(dset, name):
     t = _orig_get_stimulus_table(dset, name)
     t.set_value(0, 'end',
                 t.loc[0,'start'] + 10)
-    
+
     return t
 
 
 @pytest.fixture
 def session_a():
-    filename = '/data/informatics/module_test_data/observatory/test_nwb/out_510390912.nwb'
+    filename = os.path.abspath(os.path.join(
+            "/", "allen", "aibs", "informatics", "module_test_data",
+            "observatory", "test_nwb", "out_510390912.nwb"
+    ))
     save_path = 'xyza'
 
     sa = SessionAnalysis(filename, save_path)
@@ -63,7 +66,10 @@ def session_a():
 
 @pytest.fixture
 def session_b():
-    filename = '/data/informatics/module_test_data/observatory/test_nwb/506278598.nwb'
+    filename = os.path.abspath(os.path.join(
+            "/", "allen", "aibs", "informatics", "module_test_data", 
+            "observatory", "test_nwb", "506278598.nwb"
+    ))
     save_path = 'xyzb'
 
     sa = SessionAnalysis(filename, save_path)
@@ -73,7 +79,10 @@ def session_b():
 
 @pytest.fixture
 def session_c():
-    filename = '/data/informatics/module_test_data/observatory/test_nwb/out_510221121.nwb'
+    filename = os.path.abspath(os.path.join(
+            "/", "allen", "aibs", "informatics", "module_test_data",
+            "observatory", "test_nwb", "out_510221121.nwb"
+    ))
     save_path = 'xyzc'
 
     sa = SessionAnalysis(filename, save_path)


### PR DESCRIPTION
newer versions of scipy.stats two sample kolmogorov smirnoff test raise ValueError if one of the inputs is empty. This is pretty sensible, but it differs from the old behavior of returning nans and breaks our session analysis code.

I resolved this problem by using a wrapper that checks for empty arrays and returns nans if present, otherwise calling scipy.