### PR TITLE
GH 1103: gbm heatmap nightly failure

### DIFF
--- a/allensdk/test/internal/gbm/test_generate_gbm_heatmap.py
+++ b/allensdk/test/internal/gbm/test_generate_gbm_heatmap.py
@@ -109,4 +109,4 @@ def test_create_sample_metadata():
     expected_data = pd.DataFrame(data=d, columns=["rna_well_id", "block_id", "block_name", "polygon_id", "specimen_id",
                                                   "specimen_name", "structure_abbreviation", "structure_color",
                                                   "structure_id", "structure_name", "tumor_id", "tumor_name"])
-    assert(expected_data.equals(data))
+    pd.testing.assert_frame_equal(expected_data, data, check_like=True)


### PR DESCRIPTION
Small fix for a test. Switch to using the more configurable pandas.testing module. Test was failing only because columns were not in the same order.

Tests passed on local machine.

```  TEST_COMPLETE=true TEST_INTERNAL=true python -m pytest allensdk/test/internal/gbm/test_generate_gbm_heatmap.py
================================================================================= test session starts =================================================================================
platform linux -- Python 3.6.9, pytest-5.2.0, py-1.8.0, pluggy-0.13.0
rootdir: /home/kat/code/AllenSDK, inifile: setup.cfg
plugins: cov-2.8.0
collected 5 items                                                                                                                                                                     

allensdk/test/internal/gbm/test_generate_gbm_heatmap.py .....                                                                                                                   [100%]

---------------------------------------------------------- generated xml file: /home/kat/code/AllenSDK/test-reports/test.xml ----------------------------------------------------------
================================================================================== 5 passed in 0.27s ==================================================================================```