### PR TITLE
GH 1117: Tissuecyte unionization in python 3

### DIFF
--- a/allensdk/internal/mouse_connectivity/interval_unionize/run_tissuecyte_unionize_classic.py
+++ b/allensdk/internal/mouse_connectivity/interval_unionize/run_tissuecyte_unionize_classic.py
@@ -1,10 +1,9 @@
 import logging
-from six import iteritems
 
 from allensdk.core.simple_tree import SimpleTree
 
 from allensdk.internal.mouse_connectivity.interval_unionize.tissuecyte_unionizer import TissuecyteUnionizer
-import data_utilities as du
+import allensdk.internal.mouse_connectivity.interval_unionize.data_utilities as du
 
 
 def get_ancestor_id_map(structures):
@@ -15,7 +14,7 @@ def get_ancestor_id_map(structures):
                        lambda st: st['parent_structure_id'])
     ancestor_id_map = tree.value_map( lambda st: st['id'], 
                                       lambda st: tree.ancestor_ids([st['id']])[0] )
-    for k in ancestor_id_map.keys():
+    for k in list(ancestor_id_map):
         ancestor_id_map[-k] = map(lambda x: -x, ancestor_id_map[k])
       
     return ancestor_id_map
@@ -54,7 +53,7 @@ def run(input_data):
     signal_arrays.update(du.get_sum_pixel_intensities(input_data['grid_paths']['sum_pixel_intensities'], 
                                                       input_data['grid_paths']['injection_sum_pixel_intensities']))
 
-    for k, v in iteritems(signal_arrays):
+    for k, v in signal_arrays.items():
         logging.info('sorting {0} array'.format(k))
         signal_arrays[k] = v.flat[unionizer.sort]
     


### PR DESCRIPTION
Update methods and imports to be compatible with python 3.

Re-ran `/allen/programs/celltypes/production/ctyconn/prod100/image_series_961151940/TISSUECYTE_UNIONIZE_CLASSIC_QUEUE_961151940.pbs` with a cloned version of the production py_36 environment, using the allenSDK version installed from this branch.

Did a regression test to ensure values were the same. Results below:

![tissuecyte-nb](https://user-images.githubusercontent.com/34227334/67337727-6ff7bd00-f4dc-11e9-9f2a-cf58b9c18b27.png)

Note that the results were not in the same order. Not sure if that matters. Once the indices were set then the dataframes were equivalent.

Comparison files:
Original - `/allen/programs/celltypes/production/ctyconn/prod100/image_series_961151940/TISSUECYTE_UNIONIZE_CLASSIC_QUEUE_961151940_output.json`
New - `/allen/aibs/technology/nicholasc/tissuecyte/tissucyte_py3_961151940_test_output.json`

PBS file used to qsub for new result: `/allen/aibs/technology/nicholasc/tissuecyte/tissucyte_py3_test.pbs`
