### PR TITLE
Fix failing write permission test on Bamboo

### DIFF
--- a/allensdk/test/test_argschema_utilities.py
+++ b/allensdk/test/test_argschema_utilities.py
@@ -160,6 +160,12 @@ class TestOutputFile(object):
         # TODO: This is a stopgap for now
         if os.name == 'nt':
             pytest.skip()
+        # This test was failing on Bamboo because it was run in a container
+        # as root (which means pretty much anything is writable). If this test
+        # is run as root, skip it as it will always successfully create the
+        # output file.
+        if os.getuid() == 0:
+            pytest.skip()
 
         with pytest.raises(ValidationError, match="Can't build path to requested location"):
             self.parser.load(output_data)


### PR DESCRIPTION
A test which tries to check that writing an
invalid path results in a raised exception
was failing because the tests are run as
root for Bamboo.

Tests now pass on Bamboo:
http://bamboo.corp.alleninstitute.org/browse/IFR-AAG29-PYT-1