### PR TITLE
1082/sync ecephys lims api

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -40,7 +40,12 @@ class EcephysProjectApi:
     ):
         raise NotImplementedError()
 
-    def get_probes(self, *args, **kwargs):
+    def get_probes(
+        self, 
+        probe_ids: Optional[ArrayLike] = None, 
+        session_ids: Optional[ArrayLike] = None, 
+        published_at: Optional[str] = None
+    ):
         raise NotImplementedError()
 
     def get_probe_lfp_data(self, probe_id, *args, **kwargs):

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, Generator
 
 import numpy as np
 import pandas as pd
@@ -55,10 +55,10 @@ class EcephysProjectApi:
     def get_probe_lfp_data(self, probe_id, *args, **kwargs):
         raise NotImplementedError()
 
-    def get_natural_movie_template(self, number, *args, **kwargs):
+    def get_natural_movie_template(self, number) -> Generator:
         raise NotImplementedError()
 
-    def get_natural_scene_template(self, number, *args, **kwargs):
+    def get_natural_scene_template(self, number) -> Generator:
         raise NotImplementedError()
 
     def get_unit_analysis_metrics(self, unit_ids=None, ecephys_session_ids=None, session_types=None, *args, **kwargs):

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -1,3 +1,13 @@
+from typing import Optional, TypeVar
+
+import numpy as np
+import pandas as pd
+
+
+ArrayLike = TypeVar("ArrayLike", list, np.ndarray, pd.Series, tuple)
+
+
+
 class EcephysProjectApi:
     def get_sessions(self, *args, **kwargs):
         raise NotImplementedError()
@@ -11,7 +21,14 @@ class EcephysProjectApi:
     def get_isi_experiments(self, *args, **kwargs):
         raise NotImplementedError()
 
-    def get_units(self, *args, **kwargs):
+    def get_units(
+        self, 
+        unit_ids: Optional[ArrayLike] = None, 
+        channel_ids: Optional[ArrayLike] = None, 
+        probe_ids: Optional[ArrayLike] = None, 
+        session_ids: Optional[ArrayLike] = None, 
+        published_at: Optional[str] = None
+    ):
         raise NotImplementedError()
 
     def get_channels(self, *args, **kwargs):

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -6,6 +6,9 @@ import pandas as pd
 
 # TODO: This should be a generic over the type of the values, but there is not 
 # good support currently for numpy and pandas type annotations 
+# we should investigate numpy and pandas typing support and migrate
+# https://github.com/numpy/numpy-stubs
+# https://github.com/pandas-dev/pandas/blob/master/pandas/_typing.py 
 ArrayLike = TypeVar("ArrayLike", list, np.ndarray, pd.Series, tuple)
 
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -9,7 +9,11 @@ ArrayLike = TypeVar("ArrayLike", list, np.ndarray, pd.Series, tuple)
 
 
 class EcephysProjectApi:
-    def get_sessions(self, *args, **kwargs):
+    def get_sessions(
+        self,
+        session_ids: Optional[ArrayLike] = None,
+        published_at: Optional[str] = None
+    ):
         raise NotImplementedError()
 
     def get_session_data(self, session_id, *args, **kwargs):

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -20,9 +20,6 @@ class EcephysProjectApi:
     def get_session_data(self, session_id: int) -> Generator:
         raise NotImplementedError()
 
-    def get_targeted_regions(self, *args, **kwargs):
-        raise NotImplementedError()
-
     def get_isi_experiments(self, *args, **kwargs):
         raise NotImplementedError()
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -4,8 +4,9 @@ import numpy as np
 import pandas as pd
 
 
+# TODO: This should be a generic over the type of the values, but there is not 
+# good support currently for numpy and pandas type annotations 
 ArrayLike = TypeVar("ArrayLike", list, np.ndarray, pd.Series, tuple)
-
 
 
 class EcephysProjectApi:
@@ -16,7 +17,7 @@ class EcephysProjectApi:
     ):
         raise NotImplementedError()
 
-    def get_session_data(self, session_id, *args, **kwargs):
+    def get_session_data(self, session_id: int) -> Generator:
         raise NotImplementedError()
 
     def get_targeted_regions(self, *args, **kwargs):
@@ -52,7 +53,7 @@ class EcephysProjectApi:
     ):
         raise NotImplementedError()
 
-    def get_probe_lfp_data(self, probe_id, *args, **kwargs):
+    def get_probe_lfp_data(self, probe_id: int) -> Generator:
         raise NotImplementedError()
 
     def get_natural_movie_template(self, number) -> Generator:
@@ -61,5 +62,10 @@ class EcephysProjectApi:
     def get_natural_scene_template(self, number) -> Generator:
         raise NotImplementedError()
 
-    def get_unit_analysis_metrics(self, unit_ids=None, ecephys_session_ids=None, session_types=None, *args, **kwargs):
+    def get_unit_analysis_metrics(
+        self, 
+        unit_ids: Optional[ArrayLike] = None, 
+        ecephys_session_ids: Optional[ArrayLike] = None, 
+        session_types: Optional[ArrayLike] = None
+    ) -> pd.DataFrame:
         raise NotImplementedError()

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypeVar, Generator
+from typing import Optional, TypeVar, Iterable
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,7 @@ class EcephysProjectApi:
     ):
         raise NotImplementedError()
 
-    def get_session_data(self, session_id: int) -> Generator:
+    def get_session_data(self, session_id: int) -> Iterable:
         raise NotImplementedError()
 
     def get_isi_experiments(self, *args, **kwargs):
@@ -53,13 +53,13 @@ class EcephysProjectApi:
     ):
         raise NotImplementedError()
 
-    def get_probe_lfp_data(self, probe_id: int) -> Generator:
+    def get_probe_lfp_data(self, probe_id: int) -> Iterable:
         raise NotImplementedError()
 
-    def get_natural_movie_template(self, number) -> Generator:
+    def get_natural_movie_template(self, number) -> Iterable:
         raise NotImplementedError()
 
-    def get_natural_scene_template(self, number) -> Generator:
+    def get_natural_scene_template(self, number) -> Iterable:
         raise NotImplementedError()
 
     def get_unit_analysis_metrics(

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_api.py
@@ -31,7 +31,13 @@ class EcephysProjectApi:
     ):
         raise NotImplementedError()
 
-    def get_channels(self, *args, **kwargs):
+    def get_channels(
+        self, 
+        channel_ids: Optional[ArrayLike] = None, 
+        probe_ids: Optional[ArrayLike] = None, 
+        session_ids: Optional[ArrayLike] = None, 
+        published_at: Optional[str] = None
+    ):
         raise NotImplementedError()
 
     def get_probes(self, *args, **kwargs):

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -1,4 +1,4 @@
-from typing import Optional, Generator, NamedTuple
+from typing import Optional, Iterable, NamedTuple
 
 import pandas as pd
 
@@ -32,7 +32,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
         app_engine : 
             used for making queries agains the lims web application. Must 
             implement:
-                stream : takes a url as a string. Returns a generator yielding 
+                stream : takes a url as a string. Returns an iterable yielding 
                 the response body as bytes.
 
         Notes
@@ -46,7 +46,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
         self.postgres_engine = postgres_engine
         self.app_engine = app_engine
 
-    def get_session_data(self, session_id: int) -> Generator[bytes, None, None]:
+    def get_session_data(self, session_id: int) -> Iterable[bytes]:
         """ Download an NWB file containing detailed data for an ecephys 
         session.
 
@@ -57,7 +57,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
         Returns
         -------
-        A generator yielding an NWB file as bytes.
+        An iterable yielding an NWB file as bytes.
 
         """
 
@@ -88,7 +88,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             f"well_known_files/download/{nwb_id}?wkf_id={nwb_id}"
         )
 
-    def get_probe_lfp_data(self, probe_id: int) -> Generator[bytes, None, None]:
+    def get_probe_lfp_data(self, probe_id: int) -> Iterable[bytes]:
         """ Download an NWB file containing detailed data for the local field 
         potential recorded from an ecephys probe.
 
@@ -99,7 +99,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
         Returns
         -------
-        A generator yielding an NWB file as bytes.
+        An iterable yielding an NWB file as bytes.
 
         """
 
@@ -160,7 +160,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             these sessions.
         published_at : 
             A date (rendered as "YYYY-MM-DD"). If provided, only units 
-            recorded during sessions published before this data will be 
+            recorded during sessions published before this date will be 
             returned.
 
         Returns
@@ -524,7 +524,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
         return self.app_engine.stream(download_link)
 
 
-    def get_natural_movie_template(self, number: int) -> Generator[bytes, None, None]:
+    def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
         """ Download a template for the natural movie stimulus. This is the 
         actual movie that was shown during the recording session.
 
@@ -536,7 +536,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
         Returns
         -------
-        A generator yielding an npy file as bytes
+        An iterable yielding an npy file as bytes
 
         """
 
@@ -545,7 +545,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
         )
 
 
-    def get_natural_scene_template(self, number: int) -> Generator[bytes, None, None]:
+    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
         """ Download a template for the natural scene stimulus. This is the 
         actual image that was shown during the recording session.
 
@@ -556,7 +556,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
         Returns
         -------
-        A generator yielding a tiff file as bytes.
+        An iterable yielding a tiff file as bytes.
 
         """
         return self._get_template(

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -157,7 +157,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             published_at_not_null=published_at_not_null,
             published_at=published_at
         )
-        return response.set_index("id", inplace=True)
+        return response.set_index("id", inplace=False)
 
     def get_channels(
         self, 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -1,4 +1,4 @@
-from typing import Optional, Generator, Dict, Union
+from typing import Optional, Generator, NamedTuple
 
 import pandas as pd
 
@@ -223,7 +223,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             channel_ids=channel_ids,
             probe_ids=probe_ids,
             session_ids=session_ids,
-            **_split_published_at(published_at)
+            **_split_published_at(published_at)._asdict()
         )
         return response.set_index("id", inplace=False)
 
@@ -293,7 +293,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             channel_ids=channel_ids,
             probe_ids=probe_ids,
             session_ids=session_ids,
-            **_split_published_at(published_at)
+            **_split_published_at(published_at)._asdict()
         )
         return response.set_index("id")
 
@@ -354,7 +354,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             engine=self.postgres_engine.select,
             probe_ids=probe_ids,
             session_ids=session_ids,
-            **_split_published_at(published_at)
+            **_split_published_at(published_at)._asdict()
         )
         return response.set_index("id")
 
@@ -429,7 +429,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
             base=postgres_macros(),
             engine=self.postgres_engine.select,
             session_ids=session_ids,
-            **_split_published_at(published_at)
+            **_split_published_at(published_at)._asdict()
         )
         
         response.set_index("id", inplace=True) 
@@ -580,13 +580,17 @@ class EcephysProjectLimsApi(EcephysProjectApi):
         return cls(pg_engine, app_engine)
 
 
-# TODO: in 3.8, use a typed dict here
-def _split_published_at(published_at: Optional[str]) -> Dict[str, Optional[Union[bool, str]]]:
+class SplitPublishedAt(NamedTuple):
+    published_at: Optional[str]
+    published_at_not_null: Optional[bool]
+
+
+def _split_published_at(published_at: Optional[str]) -> SplitPublishedAt:
     """ LIMS queries that filter on published_at need a couple of 
     reformattings of the argued date string.
     """
 
-    return {
-        "published_at": f"'{published_at}'" if published_at is not None else None,
-        "published_at_not_null": None if published_at is None else True
-    }
+    return SplitPublishedAt(
+        published_at=f"'{published_at}'" if published_at is not None else None,
+        published_at_not_null=None if published_at is None else True
+    )

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_warehouse_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_warehouse_api.py
@@ -70,7 +70,8 @@ class EcephysProjectWarehouseApi(EcephysProjectApi):
                 "[attachable_type$eq'Product']"
                 r"[attachable_id$eq{{ecephys_product_id}}]"
             ),
-             engine=self.rma_engine.get_rma_tabular, ecephys_product_id=ecephys_product_id
+            engine=self.rma_engine.get_rma_tabular, 
+            ecephys_product_id=ecephys_product_id
         )
 
         scene_number = []

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -132,14 +132,8 @@ class EcephysProjectCache(Cache):
 
     def _get_units(self, filter_by_validity: bool = True, **unit_filter_kwargs) -> pd.DataFrame:
         path = self.get_cache_path(None, self.UNITS_KEY)
-        get_units = partial(
-            self.fetch_api.get_units,
-            amplitude_cutoff_maximum=None,  # pull down all the units to csv and filter on the way out
-            presence_ratio_minimum=None,
-            isi_violations_maximum=None,
-            filter_by_validity=filter_by_validity
-        )
-        units: pd.DataFrame = one_file_call_caching(path, get_units, write_csv, read_csv, num_tries=self.fetch_tries)
+
+        units = call_caching(self.fetch_api.get_units, path, strategy='lazy', **csv_io)
         units = units.rename(columns={
             'PT_ratio': 'waveform_PT_ratio',
             'amplitude': 'waveform_amplitude',

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -133,7 +133,7 @@ class EcephysProjectCache(Cache):
     def _get_units(self, filter_by_validity: bool = True, **unit_filter_kwargs) -> pd.DataFrame:
         path = self.get_cache_path(None, self.UNITS_KEY)
 
-        units = call_caching(self.fetch_api.get_units, path, strategy='lazy', **csv_io)
+        units = one_file_call_caching(path, self.fetch_api.get_units, write_csv, read_csv, num_tries=self.fetch_tries)
         units = units.rename(columns={
             'PT_ratio': 'waveform_PT_ratio',
             'amplitude': 'waveform_amplitude',

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
@@ -1,5 +1,6 @@
 import os
 import re
+from unittest import mock
 
 import pytest
 import pandas as pd
@@ -10,103 +11,99 @@ from allensdk.brain_observatory.ecephys.ecephys_project_api import (
 )
 
 
-@pytest.mark.parametrize(
-    "method,conditions,expected",
+class MockSelector:
+
+    def __init__(self, checks, response):
+        self.checks = checks
+        self.response = response
+
+    def __call__(self, query, *args, **kwargs):
+        self.passed  = {}
+        self.query = query
+        for name, check in self.checks.items():
+            self.passed[name] = check(query)
+        return self.response
+
+
+@pytest.mark.parametrize("method_name,kwargs,response,checks,expected", [
     [
-        [
-            "get_sessions",
-            {"published": True},
-            re.compile(r".*where true and es\.workflow_state in \('uploaded'\) and es\.habituation = false and es\.published_at is not null and pr\.name in \('BrainTV Neuropixels Visual Behavior','BrainTV Neuropixels Visual Coding'\)$"),
-        ],
-        [
-            "get_sessions",
-            {"session_ids": [1, 2, 3]},
-            re.compile(r".*and es\.id in \(1,2,3\).*"),
-        ],
-        [
-            "get_units",
-            {"session_ids": [1, 2, 3]},
-            re.compile(r"select eu\.\*.*and es\.id in \(1,2,3\) and eu.amplitude_cutoff <= 0.1 and eu.presence_ratio >= 0.95 and eu.isi_violations <= 0.5$"),
-        ],
-        [
-            "get_units",
-            {"session_ids": [1, 2, 3], "unit_ids": (4, 5, 6)},
-            re.compile(r"select eu\.\*.*and eu\.id in \(4,5,6\) and es\.id in \(1,2,3\) and eu.amplitude_cutoff <= 0.1 and eu.presence_ratio >= 0.95 and eu.isi_violations <= 0.5$")
-        ],
-        [
-            "get_channels",
-            {},
-            re.compile(r"select ec\.id as id.*where valid_data and ep.workflow_state != 'failed' and es.workflow_state != 'failed'$"),
-        ],
-        [
-            "get_probes",
-            {},
-            re.compile(r"select ep\.id as id, ep.ecephys_session_id.*where true and ep.workflow_state != 'failed' and es.workflow_state != 'failed'$"),
-        ],
+        "get_units",
+        {},
+        pd.DataFrame({"id": [5, 6], "something": [12, 14]}),
+        {
+            "no_pa_check": lambda st: "published_at" not in st
+        },
+        pd.DataFrame(
+            {"something": [12, 14]}, 
+            index=pd.Index(name="id", data=[5, 6])
+        )
     ],
-)
-def test_query(method, conditions, expected):
-    class MockPgEngine:
-        def select(self, rendered):
-            self.query = " ".join([item.strip() for item in str(rendered).split()])
-            return pd.DataFrame({"id": [1, 2, 3], "ecephys_channel_id": [1, 2, 3], "genotype": [np.nan, "a", "b"]})
+    [
+        "get_units",
+        {"session_ids": [1, 2, 3]},
+        pd.DataFrame({"id": [5, 6], "something": [12, 14]}),
+        {
+            "filters_sessions": lambda st: re.compile(r".+and es.id in \(1,2,3\).*", re.DOTALL).match(st) is not None
+        },
+        pd.DataFrame(
+            {"something": [12, 14]}, 
+            index=pd.Index(name="id", data=[5, 6])
+        )
+    ],
+    [
+        "get_units",
+        {"unit_ids": [1, 2, 3]},
+        pd.DataFrame({"id": [5, 6], "something": [12, 14]}),
+        {
+            "filters_units": lambda st: re.compile(r".+and eu.id in \(1,2,3\).*", re.DOTALL).match(st) is not None
+        },
+        pd.DataFrame(
+            {"something": [12, 14]}, 
+            index=pd.Index(name="id", data=[5, 6])
+        )
+    ],
+    [
+        "get_units",
+        {"channel_ids": [1, 2, 3], "probe_ids": [4, 5, 6]},
+        pd.DataFrame({"id": [5, 6], "something": [12, 14]}),
+        {
+            "filters_channels": lambda st: re.compile(r".+and ec.id in \(1,2,3\).*", re.DOTALL).match(st) is not None,
+            "filters_probes": lambda st: re.compile(r".+and ep.id in \(4,5,6\).*", re.DOTALL).match(st) is not None
+        },
+        pd.DataFrame(
+            {"something": [12, 14]}, 
+            index=pd.Index(name="id", data=[5, 6])
+        )
+    ],
+    [
+        "get_units",
+        {"published_at": "2019-10-22"},
+        pd.DataFrame({"id": [5, 6], "something": [12, 14]}),
+        {
+            "checks_pa_not_null": lambda st: re.compile(r".+and es.published_at is not null.*", re.DOTALL).match(st) is not None,
+            "checks_pa": lambda st: re.compile(r".+and es.published_at <= '2019-10-22'.*", re.DOTALL).match(st) is not None
+        },
+        pd.DataFrame(
+            {"something": [12, 14]}, 
+            index=pd.Index(name="id", data=[5, 6])
+        )
+    ]
+])
+def test_pg_query(method_name,kwargs, response, checks, expected):
 
-    pg_engine = MockPgEngine()
-    api = epla.EcephysProjectLimsApi(postgres_engine=pg_engine, app_engine=None)
+    selector = MockSelector(checks, response)
 
-    results = getattr(api, method)(**conditions)
-    
-    obtained = pg_engine.query.strip()
-    print(obtained)
-    match = expected.match(obtained)
-    assert match is not None
+    with mock.patch("allensdk.internal.api.psycopg2_select", new=selector) as ptc:
+        api = epla.EcephysProjectLimsApi.default()
+        obtained = getattr(api, method_name)(**kwargs)
+        pd.testing.assert_frame_equal(expected, obtained, check_like=True)
 
-
-def test_get_session_data():
-
-    session_id = 12345
-    wkf_id = 987
-
-    class MockPgEngine:
-        def select(self, rendered):
-            pattern = re.compile(
-                r".*and ear.ecephys_session_id = (?P<session_id>\d+).*", re.DOTALL
-            )
-            match = pattern.match(rendered)
-            sid_obt = int(match["session_id"])
-            assert session_id == sid_obt
-            return pd.DataFrame({"id": [wkf_id]})
-
-    class MockHttpEngine:
-        def stream(self, path):
-            assert path == f"well_known_files/download/{wkf_id}?wkf_id={wkf_id}"
-
-    api = epla.EcephysProjectLimsApi(
-        postgres_engine=MockPgEngine(), app_engine=MockHttpEngine()
-    )
-    api.get_session_data(session_id)
-
-
-def test_get_probe_data():
-
-    probe_id = 12345
-    wkf_id = 987
-
-    class MockPgEngine:
-        def select(self, rendered):
-            pattern = re.compile(
-                r".*and earp.ecephys_probe_id = (?P<probe_id>\d+).*", re.DOTALL
-            )
-            match = pattern.match(rendered)
-            pid_obt = int(match["probe_id"])
-            assert probe_id == pid_obt
-            return pd.DataFrame({"id": [wkf_id]})
-
-    class MockHttpEngine:
-        def stream(self, path):
-            assert path == f"well_known_files/download/{wkf_id}?wkf_id={wkf_id}"
-
-    api = epla.EcephysProjectLimsApi(
-        postgres_engine=MockPgEngine(), app_engine=MockHttpEngine()
-    )
-    api.get_probe_lfp_data(probe_id)
+        any_checks_failed = False
+        for name, result in ptc.passed.items():
+            if not result:
+                print(f"check {name} failed")
+                any_checks_failed = True
+        
+        if any_checks_failed:
+            print(ptc.query)
+        assert not any_checks_failed


### PR DESCRIPTION
- `EcephysProjectLimsApi` returns data formatted identically to `EcephysProjectWarehouseApi`
- typing for `EcephysProjectLimsApi`
- documentation for `EcephysProjectLimsApi`
- `EcephysProjectLimsApi` tests refactored and coverage improved.

out-of-scope (will create issues)
- [x] investigate use of [numpy](https://github.com/numpy/numpy-stubs) and [pandas](https://github.com/pandas-dev/pandas/blob/master/pandas/_typing.py) type stubs for meaningful typing
- [x] agree on a set of filters. The lims and warehouse classes support kwargs that filter the results. They do not support a single set of kwargs. Sometimes this makes sense: e.g. filtering on published_at is useless for warehouse. This task is to figure out which filters each version ought to support, then implement and document them. #1166
- [x] migrate the warehouse api tests to the new pattern and unskip them. EDIT: #1165
