### PR TITLE
1102/session analysis kstest

### DIFF
--- a/allensdk/brain_observatory/stimulus_analysis.py
+++ b/allensdk/brain_observatory/stimulus_analysis.py
@@ -33,6 +33,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+import warnings
 import scipy.stats as st
 import numpy as np
 import pandas as pd
@@ -85,6 +86,10 @@ class StimulusAnalysis(object):
         self._mean_sweep_response = StimulusAnalysis._PRELOAD
         self._pval = StimulusAnalysis._PRELOAD
         self._peak = StimulusAnalysis._PRELOAD
+
+        # get_speed_tuning emits a warning describing a scipy ks_2samp update. 
+        # we only want to see this warning once
+        self.__warned_speed_tuning = False
 
     @property
     def stim_table(self):
@@ -284,6 +289,13 @@ class StimulusAnalysis(object):
         -------
         tuple: binned_dx_sp, binned_cells_sp, binned_dx_vis, binned_cells_vis, peak_run
         """
+
+        if not self.__warned_speed_tuning:
+            self.__warned_speed_tuning = True
+            warnings.warn(
+                f"scipy 1.3 (your version: {scipy.__version__}) improved two-sample Kolmogorov-Smirnoff test p values for small and medium-sized samples. "
+                "Precalculated speed tuning p values may not agree with outputs obtained under recent scipy versions!"
+            )
 
         StimulusAnalysis._log.info(
             'Calculating speed tuning, spontaneous vs visually driven')

--- a/allensdk/brain_observatory/stimulus_analysis.py
+++ b/allensdk/brain_observatory/stimulus_analysis.py
@@ -35,6 +35,7 @@
 #
 import warnings
 import scipy.stats as st
+import scipy
 import numpy as np
 import pandas as pd
 import logging

--- a/allensdk/test/brain_observatory/test_session_analysis_regression.py
+++ b/allensdk/test/brain_observatory/test_session_analysis_regression.py
@@ -4,7 +4,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 import pytest
 import os
-import tempfile
 import json
 from pkg_resources import resource_filename  # @UnresolvedImport
 import numpy as np
@@ -102,9 +101,8 @@ def nm2(nwb_c, analysis_c):
     return NaturalMovie.from_analysis_file(BODS(nwb_c), analysis_c, si.NATURAL_MOVIE_TWO)
 
 @pytest.fixture(scope="module")
-def analysis_a_new(nwb_a):
-    with tempfile.NamedTemporaryFile(delete=True) as tf:
-        save_path = tf.name
+def analysis_a_new(nwb_a, tmpdir_factory):
+    save_path = str(tmpdir_factory.mktemp("session_a") / "session_a_new.h5")
 
     logging.debug("running analysis a")
     session_analysis = SessionAnalysis(nwb_a, save_path)
@@ -118,9 +116,8 @@ def analysis_a_new(nwb_a):
         os.remove(save_path)
 
 @pytest.fixture(scope="module")
-def analysis_b_new(nwb_b):
-    with tempfile.NamedTemporaryFile(delete=True) as tf:
-        save_path = tf.name
+def analysis_b_new(nwb_b, tmpdir_factory):
+    save_path = str(tmpdir_factory.mktemp("session_b") / "session_b_new.h5")
 
     logging.debug("running analysis b")
     session_analysis = SessionAnalysis(nwb_b, save_path)
@@ -134,9 +131,8 @@ def analysis_b_new(nwb_b):
         os.remove(save_path)
 
 @pytest.fixture(scope="module")
-def analysis_c_new(nwb_c):
-    with tempfile.NamedTemporaryFile(delete=True) as tf:
-        save_path = tf.name
+def analysis_c_new(nwb_c, tmpdir_factory):
+    save_path = str(tmpdir_factory.mktemp("session_c") / "session_c_new.h5")
 
     logging.debug("running analysis c")
     session_analysis = SessionAnalysis(nwb_c, save_path)

--- a/allensdk/test/brain_observatory/test_session_analysis_regression.py
+++ b/allensdk/test/brain_observatory/test_session_analysis_regression.py
@@ -112,8 +112,6 @@ def analysis_a_new(nwb_a, tmpdir_factory):
 
     yield save_path
 
-    if os.path.exists(save_path):
-        os.remove(save_path)
 
 @pytest.fixture(scope="module")
 def analysis_b_new(nwb_b, tmpdir_factory):
@@ -127,8 +125,6 @@ def analysis_b_new(nwb_b, tmpdir_factory):
 
     yield save_path
 
-    if os.path.exists(save_path):
-        os.remove(save_path)
 
 @pytest.fixture(scope="module")
 def analysis_c_new(nwb_c, tmpdir_factory):
@@ -147,9 +143,6 @@ def analysis_c_new(nwb_c, tmpdir_factory):
     logging.debug(save_path)
 
     yield save_path
-
-    if os.path.exists(save_path):
-        os.remove(save_path)
 
 
 def compare_peak(p1, p2):

--- a/allensdk/test/brain_observatory/test_session_analysis_regression_data.json
+++ b/allensdk/test/brain_observatory/test_session_analysis_regression_data.json
@@ -8,9 +8,9 @@
                "nwb_c": "/allen/aibs/informatics/module_test_data/observatory/py2_analysis/569494121.nwb"
         }, 
         "3": {
-               "analysis_a": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/510859641_three_session_A_analysis.h5",
-               "analysis_b": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/510698988_three_session_B_analysis.h5",
-               "analysis_c": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/510532780_three_session_C_analysis.h5",
+               "analysis_a": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp/510859641_three_session_A_analysis.h5",
+               "analysis_b": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp/510698988_three_session_B_analysis.h5",
+               "analysis_c": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp/510532780_three_session_C_analysis.h5",
                "nwb_a": "/allen/aibs/informatics/module_test_data/observatory//plots/510859641.nwb",
                "nwb_b": "/allen/aibs/informatics/module_test_data/observatory/plots/510698988.nwb",
                "nwb_c": "/allen/aibs/informatics/module_test_data/observatory/plots/510532780.nwb"

--- a/doc_template/brain_observatory.rst
+++ b/doc_template/brain_observatory.rst
@@ -12,6 +12,12 @@ an experiment container have different stimulus protocols, but cover the same im
 .. image:: /_static/container_session_layout.png
    :align: center
 
+**Note:** Version 1.3 of scipy fixed an error in its 2 sample Kolmogorov-Smirnoff test implementation. The new version produces more accurate p values for small and medium-sized samples.
+This change impacts speed tuning analysis p values (as returned by `StimulusAnalysis.get_speed_tuning`). 
+If you access precalculated analysis results via `BrainObservatoryCache.get_ophys_experiment_analysis`, you will see values calculated 
+using an older version of scipy's `ks_2samp`. To access values calculated from the new version, install scipy>=1.3.0 in your environment and construct a `StimulusAnalysis` object 
+from a `BrainObservatoryNwbDataSet` (as returned by `BrainObservatoryCache.get_ophys_experiment_data`).
+
 **Note:** Data collected after September 2016 uses a new session C stimulus designed to better-characterize spatial receptive fields in 
 higher visual areas.  The original locally sparse noise stimulus used 4.65 visual degree pixels.  Session C2 broke that stimulus
 into two separate stimulus blocks: one with 4.65 degree pixels and one with 9.3 degree pixels.  Note that the :py:mod:`~allensdk.brain_observatory.stimulus_info`


### PR DESCRIPTION
- Adds warning messages / announcement in docs
- updates session analysis regression test data to account for scipy's fixed ks_2samp implementation
- uses pytest for temp files in session analysis regression tests

- [x] create an issue for regenerating published values. EDIT: #1163 