### PR TITLE
removing reference to neuron_morphology swc

### DIFF
--- a/allensdk/internal/pipeline_modules/cell_types/morphology/upright_transform.py
+++ b/allensdk/internal/pipeline_modules/cell_types/morphology/upright_transform.py
@@ -5,10 +5,8 @@ import argparse
 import sys
 import numpy as np
 from scipy.spatial.distance import euclidean
-import neuron_morphology.swc as swc
 import skimage.draw
 
-#import allensdk.core.json_utilities as json
 
 
 def calculate_centroid(x, y):


### PR DESCRIPTION
 it was being over-imported later in the script from allensdk.internal.core before being used

Relates to: #1128 