### PR TITLE
Removing unnecessary test.

### DIFF
--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -20,17 +20,6 @@ from allensdk.brain_observatory.behavior.behavior_ophys_api import BehaviorOphys
 from allensdk.brain_observatory.behavior.image_api import ImageApi
 
 
-@pytest.mark.nightly
-@pytest.mark.parametrize('oeid1, oeid2, expected', [
-    pytest.param(789359614, 789359614, True),
-    pytest.param(789359614, 739216204, False)
-])
-def test_equal(oeid1, oeid2, expected):
-    d1 = BehaviorOphysSession.from_lims(oeid1)
-    d2 = BehaviorOphysSession.from_lims(oeid2)
-
-    assert equals(d1, d2) == expected
-
 @pytest.mark.requires_bamboo
 @pytest.mark.parametrize("get_expected,get_from_session", [
     [


### PR DESCRIPTION
This test started failing because the custom equality operator (`equals`) is only looking for LazyProperty instance attributes, which are no longer on the Session object (since it was resulting in double caches). Since there are no more LazyProperty attributes, two Session objects are now considered equal by this function regardless of how they were instantiated.

The apparent purpose of this test is to see if two class instances that were instantiated with the same argument are equivalent. I think it is unnecessary, so I am removing it.

I am also adding an issue to clean up some of the comparator code that was put in the behavior_ophys_nwb_api module (`equals`, `compare_fields`). If we care about equality between objects then this should be defined using the `__eq__` property in the class. 
