### PR TITLE
Gh 1147/behavior lims api

### DIFF
--- a/allensdk/brain_observatory/behavior/internal/behavior_base.py
+++ b/allensdk/brain_observatory/behavior/internal/behavior_base.py
@@ -4,10 +4,7 @@ from typing import Dict, NamedTuple
 
 import numpy as np
 import pandas as pd
-
-
-RunningSpeed = NamedTuple("RunningSpeed", [("timestamps", np.ndarray),
-                                           ("values", np.ndarray)])
+from allensdk.brain_observatory.running_speed import RunningSpeed
 
 
 class BehaviorBase(abc.ABC):

--- a/allensdk/core/cache_method_utilities.py
+++ b/allensdk/core/cache_method_utilities.py
@@ -4,11 +4,11 @@ import inspect
 class CachedInstanceMethodMixin(object):
     def cache_clear(self):
         """
-        Calls `clear_cache` method on all bound methods in this instance
+        Calls `cache_clear` method on all bound methods in this instance
         (where valid).
         Intended to clear calls cached with the `memoize` decorator.
         Note that this will also clear functions decorated with `lru_cache` and
-        `lfu_cache` in this class (or any other function with `clear_cache`
+        `lfu_cache` in this class (or any other function with `cache_clear`
         attribute).
         """
         for _, method in inspect.getmembers(self, inspect.ismethod):

--- a/allensdk/core/cache_method_utilities.py
+++ b/allensdk/core/cache_method_utilities.py
@@ -1,0 +1,18 @@
+import inspect
+
+
+class CachedInstanceMethodMixin(object):
+    def cache_clear(self):
+        """
+        Calls `clear_cache` method on all bound methods in this instance
+        (where valid).
+        Intended to clear calls cached with the `memoize` decorator.
+        Note that this will also clear functions decorated with `lru_cache` and
+        `lfu_cache` in this class (or any other function with `clear_cache`
+        attribute).
+        """
+        for _, method in inspect.getmembers(self, inspect.ismethod):
+            try:
+                method.cache_clear()
+            except (AttributeError, TypeError):
+                pass

--- a/allensdk/internal/api/behavior_data_lims_api.py
+++ b/allensdk/internal/api/behavior_data_lims_api.py
@@ -182,7 +182,7 @@ class BehaviorDataLimsApi(PostgresQueryMixin, CachedInstanceMethodMixin,
         return RunningSpeed(timestamps=running_data_df.index.values,
                             values=running_data_df.speed.values)
 
-    def get_stimulus_frame_rate(self):
+    def get_stimulus_frame_rate(self) -> float:
         stimulus_timestamps = self.get_stimulus_timestamps()
         return np.round(1 / np.mean(np.diff(stimulus_timestamps)), 0)
 
@@ -296,6 +296,19 @@ class BehaviorDataLimsApi(PostgresQueryMixin, CachedInstanceMethodMixin,
                               lambda x: x)
 
         return trial_df
+
+    @memoize
+    def get_birth_date(self) -> datetime.date:
+        """Returns the birth date of the animal.
+        :rtype: datetime.date
+        """
+        query = f"""
+        SELECT d.date_of_birth
+        FROM behavior_sessions bs
+        JOIN donors d on d.id = bs.donor_id
+        WHERE bs.id = {self.behavior_session_id}
+        """
+        return self.fetchone(query, strict=True).date()
 
     @memoize
     def get_sex(self) -> str:

--- a/allensdk/internal/api/behavior_data_lims_api.py
+++ b/allensdk/internal/api/behavior_data_lims_api.py
@@ -1,0 +1,465 @@
+import numpy as np
+import pandas as pd
+import uuid
+from datetime import datetime
+import pytz
+
+from typing import Dict, Optional, Union, List, Any
+
+from allensdk.core.exceptions import DataFrameIndexError
+from allensdk.brain_observatory.behavior.internal.behavior_base import (
+    BehaviorBase)
+from allensdk.brain_observatory.behavior.rewards_processing import get_rewards
+from allensdk.brain_observatory.behavior.running_processing import (
+    get_running_df)
+from allensdk.brain_observatory.behavior.stimulus_processing import (
+    get_stimulus_presentations, get_stimulus_templates, get_stimulus_metadata)
+from allensdk.brain_observatory.running_speed import RunningSpeed
+from allensdk.brain_observatory.behavior.metadata_processing import (
+    get_task_parameters)
+from allensdk.brain_observatory.behavior.trials_processing import get_trials
+from allensdk.internal.core.lims_utilities import safe_system_path
+from allensdk.internal.api import PostgresQueryMixin
+from allensdk.api.cache import memoize
+from allensdk.internal.api import (
+    OneResultExpectedError, OneOrMoreResultExpectedError)
+from allensdk.core.cache_method_utilities import CachedInstanceMethodMixin
+
+
+class BehaviorDataLimsApi(PostgresQueryMixin, CachedInstanceMethodMixin,
+                          BehaviorBase):
+    def __init__(self, behavior_session_id):
+        super().__init__()
+        # TODO: this password has been exposed in code but we really need
+        # to move towards using a secrets database
+        self.mtrain_db = PostgresQueryMixin(
+            dbname="mtrain", user="mtrainreader",
+            host="prodmtrain1", port=5432, password="mtrainro")
+        self.behavior_session_id = behavior_session_id
+        ids = self._get_ids()
+        self.ophys_experiment_ids = ids.get("ophys_experiment_ids")
+        self.ophys_session_id = ids.get("ophys_session_id")
+        self.behavior_training_id = ids.get("behavior_training_id")
+        self.foraging_id = ids.get("foraging_id")
+        self.ophys_container_id = ids.get("ophys_container_id")
+
+    def _get_ids(self) -> Dict[str, Optional[Union[int, List[int]]]]:
+        """Fetch ids associated with this behavior_session_id. If there is no
+        id, return None.
+        :returns: Dictionary of ids with the following keys:
+            behavior_training_id: int -- Only if was a training session
+            ophys_session_id: int -- None if have behavior_training_id
+            ophys_experiment_ids: List[int] -- only if have ophys_session_id
+            foraging_id: int
+        :rtype: dict
+        """
+        # Get all ids from the behavior_sessions table
+        query = f"""
+            SELECT
+                ophys_session_id, behavior_training_id, foraging_id
+            FROM
+                behavior_sessions
+            WHERE
+                behavior_sessions.id = {self.behavior_session_id};
+        """
+        ids_response = self.select(query)
+        if len(ids_response) > 1:
+            raise OneResultExpectedError
+        ids_dict = ids_response.iloc[0].to_dict()
+
+        #  Get additional ids if also an ophys session
+        #     (experiment_id, container_id)
+        if ids_dict.get("ophys_session_id"):
+            oed_query = f"""
+                SELECT id
+                FROM ophys_experiments
+                WHERE ophys_session_id = {ids_dict["ophys_session_id"]};
+                """
+            oed = self.fetchall(oed_query)
+
+            container_query = f"""
+            SELECT DISTINCT
+                visual_behavior_experiment_container_id id
+            FROM
+                ophys_experiments_visual_behavior_experiment_containers
+            WHERE
+                ophys_experiment_id IN ({",".join(set(map(str, oed)))});
+            """
+            container_id = self.fetchone(container_query, strict=True)
+
+            ids_dict.update({"ophys_experiment_ids": oed,
+                             "ophys_container_id": container_id})
+        else:
+            ids_dict.update({"ophys_experiment_ids": None,
+                             "ophys_container_id": None})
+        return ids_dict
+
+    def get_behavior_session_id(self) -> int:
+        """Getter to be consistent with BehaviorOphysLimsApi."""
+        return self.behavior_session_id
+
+    def get_behavior_session_uuid(self) -> Optional[int]:
+        data = self._behavior_stimulus_file()
+        return data.get("session_uuid")
+
+    def get_behavior_stimulus_file(self) -> str:
+        """Return the path to the StimulusPickle file for a session.
+        :rtype: str
+        """
+        query = f"""
+            SELECT
+                stim.storage_directory || stim.filename AS stim_file
+            FROM
+                well_known_files stim
+            WHERE
+                stim.attachable_id = {self.behavior_session_id}
+                AND stim.attachable_type = 'BehaviorSession'
+                AND stim.well_known_file_type_id IN (
+                    SELECT id
+                    FROM well_known_file_types
+                    WHERE name = 'StimulusPickle');
+        """
+        return safe_system_path(self.fetchone(query, strict=True))
+
+    @memoize
+    def _behavior_stimulus_file(self) -> pd.DataFrame:
+        """Helper method to cache stimulus file in memory since it takes about
+        a second to load (and is used in many methods).
+        """
+        return pd.read_pickle(self.get_behavior_stimulus_file())
+
+    def get_licks(self) -> pd.DataFrame:
+        """Get lick data from pkl file.
+        This function assumes that the first sensor in the list of
+        lick_sensors is the desired lick sensor. If this changes we need
+        to update to get the proper line.
+
+        :returns: pd.DataFrame -- A dataframe containing lick timestamps
+        """
+        # Get licks from pickle file instead of sync
+        data = self._behavior_stimulus_file()
+        stimulus_timestamps = self.get_stimulus_timestamps()
+        lick_frames = (data["items"]["behavior"]["lick_sensors"][0]
+                       ["lick_events"])
+        lick_times = [stimulus_timestamps[frame] for frame in lick_frames]
+        return pd.DataFrame({"time": lick_times})
+
+    def get_rewards(self) -> pd.DataFrame:
+        """Get reward data from pkl file, based on pkl file timestamps
+        (not sync file).
+
+        :returns: pd.DataFrame -- A dataframe containing timestamps of
+            delivered rewards.
+        """
+        data = self._behavior_stimulus_file()
+        # No sync timestamps to rebase on, so pass dummy rebase function
+        return get_rewards(data, lambda x: x)
+
+    def get_running_data_df(self) -> pd.DataFrame:
+        """Get running speed data.
+
+        :returns: pd.DataFrame -- dataframe containing various signals used
+            to compute running speed.
+        """
+        stimulus_timestamps = self.get_stimulus_timestamps()
+        data = self._behavior_stimulus_file()
+        return get_running_df(data, stimulus_timestamps)
+
+    def get_running_speed(self) -> RunningSpeed:
+        """Get running speed using timestamps from
+        self.get_stimulus_timestamps.
+
+        NOTE: Do not correct for monitor delay.
+
+        :returns: RunningSpeed -- a NamedTuple containing the subject's
+            timestamps and running speeds (in cm/s)
+        """
+        running_data_df = self.get_running_data_df()
+        if running_data_df.index.name != "timestamps":
+            raise DataFrameIndexError(
+                f"Expected index to be named 'timestamps' but got "
+                "'{running_data_df.index.name}'.")
+        return RunningSpeed(timestamps=running_data_df.index.values,
+                            values=running_data_df.speed.values)
+
+    def get_stimulus_frame_rate(self):
+        stimulus_timestamps = self.get_stimulus_timestamps()
+        return np.round(1 / np.mean(np.diff(stimulus_timestamps)), 0)
+
+    def get_stimulus_presentations(self) -> pd.DataFrame:
+        """Get stimulus presentation data.
+
+        NOTE: Uses timestamps that do not account for monitor delay.
+
+        :returns: pd.DataFrame --
+            Table whose rows are stimulus presentations
+            (i.e. a given image, for a given duration, typically 250 ms)
+            and whose columns are presentation characteristics.
+        """
+        stimulus_timestamps = self.get_stimulus_timestamps()
+        data = self._behavior_stimulus_file()
+        raw_stim_pres_df = get_stimulus_presentations(
+            data, stimulus_timestamps)
+
+        # Fill in nulls for image_name
+        # This makes two assumptions:
+        #   1. Nulls in `image_name` should be "gratings_<orientation>"
+        #   2. Gratings are only present (or need to be fixed) when all
+        #      values for `image_name` are null.
+        if pd.isnull(raw_stim_pres_df["image_name"]).all():
+            if ~pd.isnull(raw_stim_pres_df["orientation"]).all():
+                raw_stim_pres_df["image_name"] = (
+                    raw_stim_pres_df["orientation"]
+                    .apply(lambda x: f"gratings_{x}"))
+            else:
+                raise ValueError("All values for 'orentation' and 'image_name'"
+                                 " are null.")
+
+        stimulus_metadata_df = get_stimulus_metadata(data)
+        idx_name = raw_stim_pres_df.index.name
+        stimulus_index_df = (
+            raw_stim_pres_df
+            .reset_index()
+            .merge(stimulus_metadata_df.reset_index(), on=["image_name"])
+            .set_index(idx_name))
+        stimulus_index_df = (
+            stimulus_index_df[["image_set", "image_index", "start_time"]]
+            .rename(columns={"start_time": "timestamps"})
+            .sort_index()
+            .set_index("timestamps", drop=True))
+        stim_pres_df = raw_stim_pres_df.merge(
+            stimulus_index_df, left_on="start_time", right_index=True,
+            how="left")
+        if len(raw_stim_pres_df) != len(stim_pres_df):
+            raise ValueError("Length of `stim_pres_df` should not change after"
+                             f" merge; was {len(raw_stim_pres_df)}, now "
+                             f" {len(stim_pres_df)}.")
+        return stim_pres_df[sorted(stim_pres_df)]
+
+    @memoize
+    def get_stimulus_templates(self) -> Dict[str, np.ndarray]:
+        """Get stimulus templates (movies, scenes) for behavior session.
+
+        Returns
+        -------
+        Dict[str, np.ndarray]
+            A dictionary containing the stimulus images presented during the
+            session. Keys are data set names, and values are 3D numpy arrays.
+        """
+        data = self._behavior_stimulus_file()
+        return get_stimulus_templates(data)
+
+    @memoize
+    def get_stimulus_timestamps(self) -> np.ndarray:
+        """Get stimulus timestamps (vsyncs) from pkl file.
+
+        NOTE: Located with behavior_session_id. Does not use the sync_file
+        which requires ophys_session_id.
+
+        Returns
+        -------
+        np.ndarray
+            Timestamps associated with stimulus presentations on the monitor
+            that do no account for monitor delay.
+        """
+        data = self._behavior_stimulus_file()
+        vsyncs = data["items"]["behavior"]["intervalsms"]
+        return np.hstack((0, vsyncs)).cumsum() / 1000.0  # cumulative time
+
+    def get_task_parameters(self) -> dict:
+        """Get task parameters from pkl file.
+
+        Returns
+        -------
+        dict
+            A dictionary containing parameters used to define the task runtime
+            behavior.
+        """
+        data = self._behavior_stimulus_file()
+        return get_task_parameters(data)
+
+    def get_trials(self) -> pd.DataFrame:
+        """Get trials from pkl file
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe containing behavioral trial start/stop times,
+            and trial data
+        """
+        licks = self.get_licks()
+        data = self._behavior_stimulus_file()
+        rewards = self.get_rewards()
+        stimulus_presentations = self.get_stimulus_presentations()
+        # Pass a dummy rebase function since we don't have two time streams
+        trial_df = get_trials(data, licks, rewards, stimulus_presentations,
+                              lambda x: x)
+
+        return trial_df
+
+    @memoize
+    def get_sex(self) -> str:
+        """Returns sex of the animal (M/F)
+        :rtype: str
+        """
+        query = f"""
+            SELECT g.name AS sex
+            FROM behavior_sessions bs
+            JOIN donors d ON bs.donor_id = d.id
+            JOIN genders g ON g.id = d.gender_id
+            WHERE bs.id = {self.behavior_session_id};
+            """
+        return self.fetchone(query, strict=True)
+
+    @memoize
+    def get_age(self) -> str:
+        """Returns age code of the subject.
+        :rtype: str
+        """
+        query = f"""
+            SELECT a.name AS age
+            FROM behavior_sessions bs
+            JOIN donors d ON d.id = bs.donor_id
+            JOIN ages a ON a.id = d.age_id
+            WHERE bs.id = {self.behavior_session_id};
+        """
+        return self.fetchone(query, strict=True)
+
+    @memoize
+    def get_rig_name(self) -> str:
+        """Returns the name of the experimental rig.
+        :rtype: str
+        """
+        query = f"""
+            SELECT e.name AS device_name
+            FROM behavior_sessions bs
+            JOIN equipment e ON e.id = bs.equipment_id
+            WHERE bs.id = {self.behavior_session_id};
+        """
+        return self.fetchone(query, strict=True)
+
+    @memoize
+    def get_stimulus_name(self) -> str:
+        """Returns the name of the stimulus set used for the session.
+        :rtype: str
+        """
+        query = f"""
+            SELECT stages.name
+            FROM behavior_sessions bs
+            JOIN stages ON stages.id = bs.state_id
+            WHERE bs.id = '{self.foraging_id}'
+        """
+        return self.mtrain_db.fetchone(query, strict=True)
+
+    @memoize
+    def get_reporter_line(self) -> List[str]:
+        """Returns the genotype name(s) of the reporter line(s).
+        :rtype: list
+        """
+        query = f"""
+            SELECT g.name AS reporter_line
+            FROM behavior_sessions bs
+            JOIN donors d ON bs.donor_id=d.id
+            JOIN donors_genotypes dg ON dg.donor_id=d.id
+            JOIN genotypes g ON g.id=dg.genotype_id
+            JOIN genotype_types gt
+                ON gt.id=g.genotype_type_id AND gt.name = 'reporter'
+            WHERE bs.id={self.behavior_session_id};
+        """
+        result = self.fetchall(query)
+        if result is None or len(result) < 1:
+            raise OneOrMoreResultExpectedError(
+                f"Expected one or more, but received: '{result}' "
+                f"from query:\n'{query}'")
+        return result
+
+    @memoize
+    def get_driver_line(self) -> List[str]:
+        """Returns the genotype name(s) of the driver line(s).
+        :rtype: list
+        """
+        query = f"""
+            SELECT g.name AS driver_line
+            FROM behavior_sessions bs
+            JOIN donors d ON bs.donor_id=d.id
+            JOIN donors_genotypes dg ON dg.donor_id=d.id
+            JOIN genotypes g ON g.id=dg.genotype_id
+            JOIN genotype_types gt
+                ON gt.id=g.genotype_type_id AND gt.name = 'driver'
+            WHERE bs.id={self.behavior_session_id};
+        """
+        result = self.fetchall(query)
+        if result is None or len(result) < 1:
+            raise OneOrMoreResultExpectedError(
+                f"Expected one or more, but received: '{result}' "
+                f"from query:\n'{query}'")
+        return result
+
+    @memoize
+    def get_external_specimen_name(self) -> int:
+        """Returns the LabTracks ID
+        :rtype: int
+        """
+        # TODO: Should this even be included?
+        # Found sometimes there were entries with NONE which is
+        # why they are filtered out; also many entries in the table
+        # match the donor_id, which is why used DISTINCT
+        query = f"""
+            SELECT DISTINCT(sp.external_specimen_name)
+            FROM behavior_sessions bs
+            JOIN donors d ON bs.donor_id=d.id
+            JOIN specimens sp ON sp.donor_id=d.id
+            WHERE bs.id={self.behavior_session_id}
+            AND sp.external_specimen_name IS NOT NULL;
+            """
+        return int(self.fetchone(query, strict=True))
+
+    @memoize
+    def get_full_genotype(self) -> str:
+        """Return the name of the subject's genotype
+        :rtype: str
+        """
+        query = f"""
+                SELECT d.full_genotype
+                FROM behavior_sessions bs
+                JOIN donors d ON d.id=bs.donor_id
+                WHERE bs.id= {self.behavior_session_id};
+                """
+        return self.fetchone(query, strict=True)
+
+    def get_experiment_date(self) -> datetime:
+        """Return timestamp the behavior stimulus file began recording in UTC
+        :rtype: datetime
+        """
+        data = self._behavior_stimulus_file()
+        # Assuming file has local time of computer (Seattle)
+        tz = pytz.timezone("America/Los_Angeles")
+        return tz.localize(data["start_time"]).astimezone(pytz.utc)
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Return metadata about the session.
+        :rtype: dict
+        """
+        if self.get_behavior_session_uuid() is None:
+            bs_uuid = None
+        else:
+            bs_uuid = uuid.UUID(self.get_behavior_session_uuid())
+        metadata = {
+            "rig_name": self.get_rig_name(),
+            "sex": self.get_sex(),
+            "age": self.get_age(),
+            "ophys_experiment_id": self.ophys_experiment_ids,
+            "experiment_container_id": self.experiment_container_id,
+            "stimulus_frame_rate": self.get_stimulus_frame_rate(),
+            "session_type": self.get_stimulus_name(),
+            "experiment_datetime": self.get_experiment_date(),
+            "reporter_line": self.get_reporter_line(),
+            "driver_line": self.get_driver_line(),
+            "LabTracks_ID": self.get_external_specimen_name(),
+            "full_genotype": self.get_full_genotype(),
+            "behavior_session_uuid": bs_uuid,
+            "foraging_id": self.foraging_id,
+            "behavior_session_id": self.behavior_session_id,
+            "behavior_training_id": self.behavior_training_id,
+        }
+        return metadata

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -6,15 +6,16 @@ import h5py
 import pytz
 import pandas as pd
 
-from allensdk.internal.api import PostgresQueryMixin, OneOrMoreResultExpectedError
+from allensdk.internal.api import (
+    PostgresQueryMixin, OneOrMoreResultExpectedError)
 from allensdk.api.cache import memoize
 from allensdk.brain_observatory.behavior.image_api import ImageApi
 import allensdk.brain_observatory.roi_masks as roi
 from allensdk.internal.core.lims_utilities import safe_system_path
-import inspect
+from allensdk.core.cache_method_utilities import CachedInstanceMethodMixin
 
 
-class OphysLimsApi(PostgresQueryMixin):
+class OphysLimsApi(PostgresQueryMixin, CachedInstanceMethodMixin):
 
     def __init__(self, ophys_experiment_id):
         self.ophys_experiment_id = ophys_experiment_id
@@ -22,21 +23,6 @@ class OphysLimsApi(PostgresQueryMixin):
 
     def get_ophys_experiment_id(self):
         return self.ophys_experiment_id
-
-    def cache_clear(self):
-        """
-        Calls `clear_cache` method on all bound methods in this instance
-        (where valid).
-        Intended to clear calls cached with the `memoize` decorator.
-        Note that this will also clear functions decorated with `lru_cache` and
-        `lfu_cache` in this class (or any other function with `clear_cache`
-        attribute).
-        """
-        for _, method in inspect.getmembers(self, inspect.ismethod):
-            try:
-                method.cache_clear()
-            except (AttributeError, TypeError):
-                pass
 
     @memoize
     def get_ophys_experiment_dir(self):

--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_lims_api.py
@@ -1,0 +1,267 @@
+import pytest
+import numpy as np
+import pandas as pd
+from datetime import datetime
+import pytz
+import math
+
+from allensdk.internal.api.behavior_data_lims_api import BehaviorDataLimsApi
+from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
+from allensdk.brain_observatory.running_speed import RunningSpeed
+from allensdk.core.exceptions import DataFrameIndexError
+
+
+@pytest.fixture
+def MockBehaviorDataLimsApi():
+    class MockBehaviorDataLimsApi(BehaviorDataLimsApi):
+        """
+        Mock class that overrides some functions to provide test data and
+        initialize without calls to db.
+        """
+        def __init__(self):
+            super().__init__(behavior_session_id=8675309)
+
+        def _get_ids(self):
+            return {}
+
+        def _behavior_stimulus_file(self):
+            data = {
+                "items": {
+                    "behavior": {
+                        "lick_sensors": [{
+                            "lick_events": [2, 6, 9],
+                        }],
+                        "intervalsms": np.array([16.0]*10),
+                    },
+                },
+                "session_uuid": 123456,
+                "start_time": datetime(2019, 9, 26, 9),
+            }
+            return data
+
+        def get_running_data_df(self):
+            return pd.DataFrame(
+                {"timestamps": [0.0, 0.1, 0.2],
+                 "speed": [8.0, 15.0, 16.0]}).set_index("timestamps")
+
+    api = MockBehaviorDataLimsApi()
+    yield api
+    api.cache_clear()
+
+
+@pytest.fixture
+def MockApiRunSpeedExpectedError():
+    class MockApiRunSpeedExpectedError(BehaviorDataLimsApi):
+        """
+        Mock class that overrides some functions to provide test data and 
+        initialize without calls to db.
+        """
+        def __init__(self):
+            super().__init__(behavior_session_id=8675309)
+
+        def _get_ids(self):
+            return {}
+
+        def get_running_data_df(self):
+            return pd.DataFrame(
+                {"timestamps": [0.0, 0.1, 0.2],
+                 "speed": [8.0, 15.0, 16.0]})
+    return MockApiRunSpeedExpectedError()
+
+
+# Test the non-sql-query functions
+# Does not include tests for the following functions, as they are just calls to
+# static methods provided for convenience (and should be covered with their own
+# unit tests):
+#    get_rewards
+#    get_running_data_df
+#    get_stimulus_templates
+#    get_task_parameters
+#    get_trials
+# Does not include test for get_metadata since it just collects data from
+# methods covered in other unit tests, or data derived from sql queries.
+def test_get_stimulus_timestamps(MockBehaviorDataLimsApi):
+    api = MockBehaviorDataLimsApi
+    expected = np.array([0.016 * i for i in range(11)])
+    assert np.allclose(expected, api.get_stimulus_timestamps())
+
+
+def test_get_licks(MockBehaviorDataLimsApi):
+    api = MockBehaviorDataLimsApi
+    expected = pd.DataFrame({"time": [0.016 * i for i in [2., 6., 9.]]})
+    pd.testing.assert_frame_equal(expected, api.get_licks())
+
+
+def test_get_behavior_session_uuid(MockBehaviorDataLimsApi):
+    api = MockBehaviorDataLimsApi
+    assert 123456 == api.get_behavior_session_uuid()
+
+
+def test_get_stimulus_frame_rate(MockBehaviorDataLimsApi):
+    api = MockBehaviorDataLimsApi
+    assert 62.0 == api.get_stimulus_frame_rate()
+
+
+def test_get_experiment_date(MockBehaviorDataLimsApi):
+    api = MockBehaviorDataLimsApi
+    expected = datetime(2019, 9, 26, 16, tzinfo=pytz.UTC)
+    actual = api.get_experiment_date()
+    assert expected == actual
+
+
+def test_get_running_speed(MockBehaviorDataLimsApi):
+    expected = RunningSpeed(timestamps=[0.0, 0.1, 0.2],
+                            values=[8.0, 15.0, 16.0])
+    api = MockBehaviorDataLimsApi
+    actual = api.get_running_speed()
+    assert expected == actual
+
+
+def test_get_running_speed_raises_index_error(MockApiRunSpeedExpectedError):
+    with pytest.raises(DataFrameIndexError):
+        MockApiRunSpeedExpectedError.get_running_speed()
+
+
+# def test_get_stimulus_presentations(MockBehaviorDataLimsApi):
+#     api = MockBehaviorDataLimsApi
+#     #  TODO. This function is a monster with multiple dependencies,
+#     #  no tests, and no documentation (for any of its dependencies).
+#     #  Needs to be broken out into testable parts.
+
+@pytest.mark.requires_bamboo
+@pytest.mark.nightly
+class TestBehaviorRegression:
+    """
+    Test whether behavior sessions (that are also ophys) loaded with
+    BehaviorDataLimsApi return the same results as sessions loaded
+    with BehaviorOphysLimsApi, for relevant functions. Do not check for
+    timestamps, which are from different files so will not be the same.
+    Also not checking for experiment_date, since they're from two different
+    sources (and I'm not sure how it's uploaded in the database).
+
+    Do not test `get_licks` regression because the licks come from two
+    different sources and are recorded differently (behavior pickle file in 
+    BehaviorDataLimsApi; sync file in BehaviorOphysLimeApi)
+    """
+    @classmethod
+    def setup_class(cls):
+        cls.bd = BehaviorDataLimsApi(976012750)
+        cls.od = BehaviorOphysLimsApi(976255949)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.bd.cache_clear()
+        cls.od.cache_clear()
+
+    def test_stim_file_regression(self):
+        assert (self.bd.get_behavior_stimulus_file()
+                == self.od.get_behavior_stimulus_file())
+
+    def test_get_rewards_regression(self):
+        """Index is timestamps here, so remove it before comparing."""
+        bd_rewards = self.bd.get_rewards().reset_index(drop=True)
+        od_rewards = self.od.get_rewards().reset_index(drop=True)
+        pd.testing.assert_frame_equal(bd_rewards, od_rewards)
+
+    def test_ophys_experiment_id_regression(self):
+        assert self.bd.ophys_experiment_ids[0] == self.od.ophys_experiment_id
+
+    def test_behavior_uuid_regression(self):
+        assert (self.bd.get_behavior_session_uuid()
+                == self.od.get_behavior_session_uuid())
+
+    def test_container_id_regression(self):
+        assert (self.bd.ophys_container_id
+                == self.od.get_experiment_container_id())
+
+    def test_stimulus_frame_rate_regression(self):
+        assert (self.bd.get_stimulus_frame_rate()
+                == self.od.get_stimulus_frame_rate())
+
+    def test_get_running_speed_regression(self):
+        """Can't test values because they're intrinsically linked to timestamps
+        """
+        bd_speed = self.bd.get_running_speed()
+        od_speed = self.od.get_running_speed()
+        assert len(bd_speed.values) == len(od_speed.values)
+        assert len(bd_speed.timestamps) == len(od_speed.timestamps)
+
+    def test_get_running_df_regression(self):
+        """Can't test values because they're intrinsically linked to timestamps
+        """
+        bd_running = self.bd.get_running_data_df()
+        od_running = self.od.get_running_data_df()
+        assert len(bd_running) == len(od_running)
+        assert list(bd_running) == list(od_running)
+
+    def test_get_stimulus_presentations_regression(self):
+        drop_cols = ["start_time", "stop_time"]
+        bd_pres = self.bd.get_stimulus_presentations().drop(drop_cols, axis=1)
+        od_pres = self.od.get_stimulus_presentations().drop(drop_cols, axis=1)
+        # Duration needs less precision (timestamp-dependent)
+        pd.testing.assert_frame_equal(bd_pres, od_pres, check_less_precise=2)
+
+    def test_get_stimulus_template_regression(self):
+        bd_template = self.bd.get_stimulus_templates()
+        od_template = self.od.get_stimulus_templates()
+        assert bd_template.keys() == od_template.keys()
+        for k in bd_template.keys():
+            assert np.array_equal(bd_template[k], od_template[k])
+
+    def test_get_task_parameters_regression(self):
+        bd_params = self.bd.get_task_parameters()
+        od_params = self.od.get_task_parameters()
+        # Have to do special checking because of nan equality
+        assert bd_params.keys() == od_params.keys()
+        for k in bd_params.keys():
+            bd_v = bd_params[k]
+            od_v = od_params[k]
+            try:
+                if math.isnan(bd_v):
+                    assert math.isnan(od_v)
+                else:
+                    assert bd_v == od_v
+            except (AttributeError, TypeError):
+                assert bd_v == od_v
+
+    def test_get_trials_regression(self):
+        """ A lot of timestamp dependent values. Test what we can."""
+        cols_to_test = ["reward_volume", "hit", "false_alarm", "miss",
+                        "sham_change", "stimulus_change", "aborted", "go",
+                        "catch", "auto_rewarded", "correct_reject",
+                        "trial_length", "change_frame", "initial_image_name",
+                        "change_image_name"]
+        bd_trials = self.bd.get_trials()[cols_to_test]
+        od_trials = self.od.get_trials()[cols_to_test]
+        pd.testing.assert_frame_equal(bd_trials, od_trials,
+                                      check_less_precise=2)
+
+    def test_get_sex_regression(self):
+        assert self.bd.get_sex() == self.od.get_sex()
+
+    def test_get_rig_name_regression(self):
+        assert self.bd.get_rig_name() == self.od.get_rig_name()
+
+    def test_get_stimulus_name_regression(self):
+        assert self.bd.get_stimulus_name() == self.od.get_stimulus_name()
+
+    def test_get_reporter_line_regression(self):
+        assert self.bd.get_reporter_line() == self.od.get_reporter_line()
+
+    def test_get_driver_line_regression(self):
+        assert self.bd.get_driver_line() == self.od.get_driver_line()
+
+    def test_get_external_specimen_name_regression(self):
+        assert (self.bd.get_external_specimen_name()
+                == self.od.get_external_specimen_name())
+
+    def test_get_full_genotype_regression(self):
+        assert self.bd.get_full_genotype() == self.od.get_full_genotype()
+
+    def test_get_experiment_date_regression(self):
+        """Just testing the date since it comes from two different sources;
+        We expect that BehaviorOphysLimsApi will be earlier (more like when
+        rig was started up), while BehaviorDataLimsApi returns the start of
+        the actual behavior (from pkl file)"""
+        assert (self.bd.get_experiment_date().date()
+                == self.od.get_experiment_date().date())

--- a/allensdk/test/brain_observatory/behavior/test_metadata_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_metadata_processing.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from allensdk.brain_observatory.behavior.metadata_processing import (
+    get_task_parameters)
+
+
+def test_get_task_parameters():
+    data = {
+        "items": {
+            "behavior": {
+                "config": {
+                    "DoC": {
+                        "blank_duration_range": (0.5, 0.6),
+                        "stimulus_window": 6.0,
+                        "response_window": [0.15, 0.75],
+                        "change_time_dist": "geometric",
+                    },
+                    "reward": {
+                        "reward_volume": 0.007,
+                    },
+                    "behavior": {
+                        "task_id": "DoC_untranslated",
+                    },
+                },
+                "params": {
+                    "stage": "TRAINING_3_images_A",
+                },
+                "stimuli": {
+                    "images": {"draw_log": [1]*10}
+                },
+            }
+        }
+    }
+    actual = get_task_parameters(data)
+    expected = {
+        "blank_duration_sec": [0.5, 0.6],
+        "stimulus_duration_sec": 6.0,
+        "omitted_flash_fraction": np.nan,
+        "response_window_sec": [0.15, 0.75],
+        "reward_volume": 0.007,
+        "stage": "TRAINING_3_images_A",
+        "stimulus": "images",
+        "stimulus_distribution": "geometric",
+        "task": "DoC_untranslated",
+        "n_stimulus_frames": 10
+    }
+    for k, v in actual.items():
+        # Special nan checking since pytest doesn't do it well
+        try:
+            if np.isnan(v):
+                assert np.isnan(expected[k])
+            else:
+                assert expected[k] == v
+        except (TypeError, ValueError):
+            assert expected[k] == v
+    assert list(actual.keys()) == list(expected.keys())

--- a/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from allensdk.brain_observatory.behavior.rewards_processing import get_rewards
+
+
+def test_get_rewards():
+    data = {
+        "items": {
+            "behavior": {
+                "trial_log": [
+                    {
+                        'rewards': [(0.007, 1085.965144219165, 64775)],
+                        'trial_params': {
+                            'catch': False, 'auto_reward': False,
+                            'change_time': 5}},
+                    {
+                        'rewards': [],
+                        'trial_params': {
+                            'catch': False, 'auto_reward': False,
+                            'change_time': 4}
+                    }
+                    ]
+                }}}
+    expected = pd.DataFrame(
+        {"volume": [0.007],
+         "timestamps": [1086.965144219165],
+         "auto_rewarded": False}).set_index("timestamps", drop=True)
+
+    pd.testing.assert_frame_equal(expected, get_rewards(data, lambda x: x+1.0))

--- a/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
@@ -24,6 +24,6 @@ def test_get_rewards():
     expected = pd.DataFrame(
         {"volume": [0.007],
          "timestamps": [1086.965144219165],
-         "auto_rewarded": False}).set_index("timestamps", drop=True)
+         "autorewarded": False}).set_index("timestamps", drop=True)
 
     pd.testing.assert_frame_equal(expected, get_rewards(data, lambda x: x+1.0))

--- a/allensdk/test/brain_observatory/behavior/test_running_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_running_processing.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from allensdk.brain_observatory.behavior.running_processing import (
+    get_running_df, calc_deriv, deg_to_dist)
+
+
+@pytest.fixture
+def running_data():
+    return {
+        "items": {
+            "behavior": {
+                "encoders": [
+                    {
+                        "dx": np.array([0., 0.8444478, 0.7076058, 1.4225141,
+                                        1.5040479]),
+                        "vsig": [3.460190074169077, 3.4692217108095065,
+                                 3.4808338150614873, 3.5014775559538975,
+                                 3.5259919982636347],
+                        "vin": [4.996858536847867, 4.99298783543054,
+                                4.995568303042091, 4.996858536847867,
+                                5.00201947207097],
+                    }]}}}
+
+
+@pytest.fixture
+def timestamps():
+    return np.array([0., 0.01670847, 0.03336808, 0.05002418, 0.06672007])
+
+
+@pytest.mark.parametrize(
+    "x,time,expected", [
+        ([1.0, 1.0], [1.0, 2.0], [0.0, 0.0]),
+        ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], [1.0, 1.0, 1.0]),
+        ([1.0, 2.0, 3.0], [1.0, 4.0, 6.0], [1/3, ((1/3)+0.5)/2, 0.5])
+    ]
+)
+def test_calc_deriv(x, time, expected):
+    assert np.all(calc_deriv(x, time) == expected)
+
+
+@pytest.mark.parametrize(
+    "speed,expected", [
+        (np.array([1.0]), [0.09605128650142128]),
+        (np.array([0., 2.0]), [0., 2.0 * 0.09605128650142128])
+    ]
+)
+def test_deg_to_dist(speed, expected):
+    assert np.all(np.allclose(deg_to_dist(speed), expected))
+
+
+def test_get_running_df(running_data, timestamps):
+    expected = pd.DataFrame(
+        {'speed': {
+            0.0: 4.0677840296488785,
+            0.01670847: 4.468231641421186,
+            0.03336808: 4.869192250359061,
+            0.05002418: 4.47027713320348,
+            0.06672007: 4.070849018882336},
+         'dx': {
+            0.0: 0.0,
+            0.01670847: 0.8444478,
+            0.03336808: 0.7076058,
+            0.05002418: 1.4225141,
+            0.06672007: 1.5040479},
+         'v_sig': {
+            0.0: 3.460190074169077,
+            0.01670847: 3.4692217108095065,
+            0.03336808: 3.4808338150614873,
+            0.05002418: 3.5014775559538975,
+            0.06672007: 3.5259919982636347},
+         'v_in': {
+            0.0: 4.996858536847867,
+            0.01670847: 4.99298783543054,
+            0.03336808: 4.995568303042091,
+            0.05002418: 4.996858536847867,
+            0.06672007: 5.00201947207097}})
+    expected.index.name = "timestamps"
+
+    pd.testing.assert_frame_equal(expected,
+                                  get_running_df(running_data, timestamps))

--- a/allensdk/test/brain_observatory/behavior/test_stimulus_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_stimulus_processing.py
@@ -1,0 +1,76 @@
+
+import numpy as np
+import pytest
+
+
+from allensdk.brain_observatory.behavior.stimulus_processing import (
+    get_stimulus_presentations, _get_stimulus_epoch, _get_draw_epochs)
+
+
+data = {
+    "items": {
+        "behavior": {
+            "stimuli": {
+                "images": {
+                    "set_log": [
+                        ('Image', 'im065', 5.809955710916157, 0),
+                        ('Image', 'im061', 314.06612555068784, 6),
+                        ('Image', 'im062', 348.5941232265203, 12),
+                    ],
+                    "draw_log": ([0]+[1]*3 + [0]*3)*3 + [0]
+                }
+            },
+            # "intervalsms": np.array([16.0]*10)
+        }
+    }
+}
+timestamps = np.array([0.016 * i for i in range(19)])
+
+
+@pytest.mark.parametrize(
+    "current_set_ix,start_frame,n_frames,expected", [
+        (0, 0, 18, (0, 6)),
+        (2, 11, 18, (11, 18))
+    ]
+)
+def test_get_stimulus_epoch(current_set_ix, start_frame, n_frames, expected):
+    log = data["items"]["behavior"]["stimuli"]["images"]["set_log"]
+    actual = _get_stimulus_epoch(log, current_set_ix, start_frame, n_frames)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "start_frame,stop_frame,expected", [
+        (0, 6, [(1, 4)]),
+        (0, 11, [(1, 4), (8, 11)])
+    ]
+)
+def test_get_draw_epochs(start_frame, stop_frame, expected):
+    draw_log = data["items"]["behavior"]["stimuli"]["images"]["draw_log"]
+    actual = _get_draw_epochs(draw_log, start_frame, stop_frame)
+    assert actual == expected
+
+
+# def test_get_stimulus_templates():
+#     pass
+#     # TODO
+#     # See below (get_images_dict is a dependency)
+
+
+# def test_get_images_dict():
+#     pass
+#     # TODO
+#     # This is too hard-coded to be testable right now.
+#     # convert_filepath_caseinsensitive prevents using any tempdirs/tempfiles
+
+
+# def test_get_stimulus_presentations():
+#     pass
+#     # TODO
+#     # Monster function with undocumented dependencies
+
+
+# def test_get_visual_stimuli_df():
+#     pass
+#     # TODO
+#     # See above (this is a dependency of get_stimulus_presentations)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ environment:
 install:
   - set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
   - conda config --set always_yes yes --set changeps1 no
-  - conda install conda==4.6.14
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
   - conda install statsmodels


### PR DESCRIPTION
Response to #1147 

Implements all methods relevant to behavior training data, or behavior data from an ophys session.

The new class is named BehaviorDataLimsApi since there already is a BehaviorLimsApi, which appears to be used primarily for mtrain. I didn't want to worry about handling the downstream dependencies so I created a new class.

The new API required rewriting some SQL queries, taking different routes to get (hopefully) the same value. Tagging @wbwakeman to review the SQL. I have a suite of unit tests that compare the behavior of the BehaviorOphysLimsApi to the BehaviorDataLimsApi for relevant methods, which have all passed on my local machine, including the new SQL queries.

Added unit tests for many of the untested methods used by both BehaviorOphysLimsApi and BehaviorDataLimsApi. 

Finally, updated the cache_clear behavior to a mixin class, so that all classes that have memoized methods can clear all their caches without having to implement it each time.
