### PR TITLE
Gh 1152/behavior session lims

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_data_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_data_session.py
@@ -1,0 +1,191 @@
+from typing import Any, Optional, List, Dict, Type, Tuple
+import logging
+import pandas as pd
+import numpy as np
+import inspect
+
+from allensdk.internal.api.behavior_data_lims_api import BehaviorDataLimsApi
+from allensdk.brain_observatory.behavior.internal import BehaviorBase
+from allensdk.brain_observatory.running_speed import RunningSpeed
+
+BehaviorDataApi = Type[BehaviorBase]
+
+
+class BehaviorDataSession(object):
+    def __init__(self, api: Optional[BehaviorDataApi] = None):
+        self.api = api
+
+    @classmethod
+    def from_lims(cls, behavior_session_id: int) -> "BehaviorDataSession":
+        return cls(api=BehaviorDataLimsApi(behavior_session_id))
+
+    @classmethod
+    def from_nwb_path(
+            cls, nwb_path: str, **api_kwargs: Any) -> "BehaviorDataSession":
+        return NotImplementedError
+
+    @property
+    def behavior_session_id(self) -> int:
+        """Unique identifier for this experimental session.
+        :rtype: int
+        """
+        return self.api.behavior_session_id
+
+    @property
+    def ophys_session_id(self) -> Optional[int]:
+        """The unique identifier for the ophys session associated
+        with this behavior session (if one exists)
+        :rtype: int
+        """
+        return self.api.ophys_session_id
+
+    @property
+    def ophys_experiment_ids(self) -> Optional[List[int]]:
+        """The unique identifiers for the ophys experiment(s) associated
+        with this behavior session (if one exists)
+        :rtype: int
+        """
+        return self.api.ophys_experiment_ids
+
+    @property
+    def licks(self) -> pd.DataFrame:
+        """Get lick data from pkl file.
+
+        Returns
+        -------
+        np.ndarray
+            A dataframe containing lick timestamps.
+        """
+        return self.api.get_licks()
+
+    @property
+    def rewards(self) -> pd.DataFrame:
+        """Get reward data from pkl file.
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe containing timestamps of delivered rewards.
+        """
+        return self.api.get_rewards()
+
+    @property
+    def running_data_df(self) -> pd.DataFrame:
+        """Get running speed data.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataframe containing various signals used to compute running speed.
+        """
+        return self.api.get_running_data_df()
+
+    def running_speed(self) -> RunningSpeed:
+        """Get running speed using timestamps from
+        self.get_stimulus_timestamps.
+
+        NOTE: Do not correct for monitor delay.
+
+        Returns
+        -------
+        RunningSpeed (NamedTuple with two fields)
+            timestamps : np.ndarray
+                Timestamps of running speed data samples
+            values : np.ndarray
+                Running speed of the experimental subject (in cm / s).
+        """
+        return self.api.get_running_speed()
+
+    @property
+    def stimulus_presentations(self) -> pd.DataFrame:
+        """Get stimulus presentation data.
+
+        NOTE: Uses timestamps that do not account for monitor delay.
+
+        Returns
+        -------
+        pd.DataFrame
+            Table whose rows are stimulus presentations
+            (i.e. a given image, for a given duration, typically 250 ms)
+            and whose columns are presentation characteristics.
+        """
+        return self.api.get_stimulus_presentations()
+
+    @property
+    def stimulus_templates(self) -> Dict[str, np.ndarray]:
+        """Get stimulus templates (movies, scenes) for behavior session.
+
+        Returns
+        -------
+        Dict[str, np.ndarray]
+            A dictionary containing the stimulus images presented during the
+            session. Keys are data set names, and values are 3D numpy arrays.
+        """
+        return self.api.get_stimulus_templates()
+
+    @property
+    def stimulus_timestamps(self) -> np.ndarray:
+        """Get stimulus timestamps from pkl file.
+
+        NOTE: Located with behavior_session_id
+
+        Returns
+        -------
+        np.ndarray
+            Timestamps associated with stimulus presentations on the monitor
+            that do no account for monitor delay.
+        """
+        return self.api.get_stimulus_timestamps()
+
+    @property
+    def task_parameters(self) -> dict:
+        """Get task parameters from pkl file.
+
+        Returns
+        -------
+        dict
+            A dictionary containing parameters used to define the task runtime
+            behavior.
+        """
+        return self.api.get_task_parameters()
+
+    @property
+    def trials(self) -> pd.DataFrame:
+        """Get trials from pkl file
+
+        Returns
+        -------
+        pd.DataFrame
+            A dataframe containing behavioral trial start/stop times,
+            and trial data
+        """
+        return self.api.get_trials()
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        """Return metadata about the session.
+        :rtype: dict
+        """
+        return self.api.get_metadata()
+
+    def cache_clear(self) -> None:
+        """Convenience method to clear the api cache, if applicable."""
+        try:
+            self.api.cache_clear()
+        except AttributeError:
+            logging.getLogger("BehaviorOphysSession").warning(
+                "Attempted to clear API cache, but method `cache_clear`"
+                f" does not exist on {self.api.__class__.__name__}")
+
+    def list_api_methods(self) -> List[Tuple[str, str]]:
+        """Convenience method to expose list of API `get` methods. These methods
+        can be accessed by referencing the API used to initialize this
+        BehaviorDataSession via its `api` instance attribute.
+        :rtype: list of tuples, where the first value in the tuple is the
+        method name, and the second value is the method docstring.
+        """
+        methods = [m for m in inspect.getmembers(self.api, inspect.ismethod)
+                   if m[0].startswith("get_")]
+        docs = [inspect.getdoc(m[1]) or "" for m in methods]
+        method_names = [m[0] for m in methods]
+        return list(zip(method_names, docs))

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -196,8 +196,8 @@ class BehaviorOphysSession(object):
             self.api.cache_clear()
         except AttributeError:
             logging.getLogger("BehaviorOphysSession").warning(
-                f"Attempted to clear API cache, but method `clear_cache`"
-                " does not exist on {self.api.__name__}")
+                "Attempted to clear API cache, but method `cache_clear`"
+                f" does not exist on {self.api.__class__.__name__}")
 
     def get_roi_masks(self, cell_specimen_ids=None):
         """ Obtains boolean masks indicating the location of one or more cell's ROIs in this session.

--- a/allensdk/brain_observatory/behavior/internal/behavior_base.py
+++ b/allensdk/brain_observatory/behavior/internal/behavior_base.py
@@ -12,7 +12,7 @@ class BehaviorBase(abc.ABC):
     behavior session data.
 
     Child classes should be instantiated with a fetch API that implements these
-    methods. Both fetch API and session object should inherit from this base.
+    methods.
     """
     @abc.abstractmethod
     def get_licks(self) -> pd.DataFrame:

--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_session.py
@@ -1,0 +1,58 @@
+import logging
+
+from allensdk.brain_observatory.behavior.behavior_data_session import (
+    BehaviorDataSession)
+
+
+class DummyApi(object):
+    def __init__(self):
+        pass
+
+    def get_method(self):
+        """Method docstring"""
+        pass
+
+    def get_no_docstring_method(self):
+        pass
+
+    def _other_method(self):
+        """Other Method docstring"""
+        pass
+
+
+class DummyApiCache(object):
+    def cache_clear(self):
+        pass
+
+
+class TestBehaviorDataSession:
+    """Tests for BehaviorDataSession.
+       The vast majority of methods in BehaviorDataSession are simply calling
+       functions from the underlying API. The API required for instantiating a
+       BehaviorDataSession is annotated to show that it requires an class that
+       inherits from BehaviorBase, it is ensured that those methods exist in
+       the API class. These methods should be covered by unit tests on the
+       API class and will not be re-tested here.
+    """
+    @classmethod
+    def setup_class(cls):
+        cls.behavior_session = BehaviorDataSession(api=DummyApi())
+
+    def test_list_api_methods(self):
+        expected = [("get_method", "Method docstring"),
+                    ("get_no_docstring_method", "")]
+        actual = self.behavior_session.list_api_methods()
+        assert expected == actual
+
+    def test_cache_clear_raises_warning(self, caplog):
+        expected_msg = ("Attempted to clear API cache, but method"
+                        " `cache_clear` does not exist on DummyApi")
+        self.behavior_session.cache_clear()
+        assert caplog.record_tuples == [
+            ("BehaviorOphysSession", logging.WARNING, expected_msg)]
+
+    def test_cache_clear_no_warning(self, caplog):
+        caplog.clear()
+        bs = BehaviorDataSession(api=DummyApiCache())
+        bs.cache_clear()
+        assert len(caplog.record_tuples) == 0


### PR DESCRIPTION
Response to #1152 

Adds a BehaviorDataSession object.

Originally we were planning on inheriting from BehaviorBase, but to preserve behavior with BehaviorOphysSession, we also need to be able to access the methods as properties. I think it it unnecessarily verbose to implement both the `get` method as well as the property (returning the same data) in the session object, so I defaulted to the prior behavior.

Tests on this are sparse because the majority of the calls just invoke the API that the BehaviorDataSession object was instantiated with.
