### PR TITLE
1153 resolve frequent test cache stimulus failures

### DIFF
--- a/allensdk/test/model/test_glif.py
+++ b/allensdk/test/model/test_glif.py
@@ -37,10 +37,8 @@ import pytest
 from allensdk.api.queries.glif_api import GlifApi
 import allensdk.core.json_utilities as json_utilities
 from allensdk.model.glif.glif_neuron import GlifNeuron
-from allensdk.model.glif.simulate_neuron import simulate_neuron
 from allensdk.core.nwb_data_set import NwbDataSet
 import os
-# import matplotlib.pyplot as plt
 
 
 @pytest.fixture
@@ -111,7 +109,6 @@ def output(neuron_config_file, ephys_sweeps_file):
 
 @pytest.fixture
 def stimulus(neuron_config_file, ephys_sweeps_file):
-    neuron_config = json_utilities.read(neuron_config_file)
     ephys_sweeps = json_utilities.read(ephys_sweeps_file)
     ephys_file_name = 'stimulus.nwb'
 
@@ -151,98 +148,3 @@ def test_run_glifneuron(configured_glif_api, neuron_config_file):
                        "spike_time_steps", "threshold", "voltage"}
 
     assert expected_fields.difference(output.keys()) == set()
-
-
-@pytest.mark.skipif(True, reason="needs nwb file")
-def test_3(configured_glif_api, neuron_config_file, ephys_sweeps_file):
-    neuron_config = json_utilities.read(neuron_config_file)
-    ephys_sweeps = json_utilities.read(ephys_sweeps_file)
-    ephys_file_name = 'stimulus.nwb'
-
-    neuron = GlifNeuron.from_dict(neuron_config)
-
-    # sweep_numbers = [ s['sweep_number'] for s in ephys_sweeps
-    #                  if s['stimulus_units'] == 'Amps' ]
-    sweep_numbers = [7]
-    simulate_neuron(neuron, sweep_numbers,
-                    ephys_file_name, ephys_file_name, 0.05)
-
-
-@pytest.mark.skipif(True, reason="needs nwb file")
-def test_4(output):
-    voltage = output['voltage']
-    threshold = output['threshold']
-    spike_times = output['interpolated_spike_times']
-
-
-@pytest.mark.skipif(True, reason="needs nwb file")
-def test_5(output):
-    voltage = output['voltage']
-    threshold = output['threshold']
-    interpolated_spike_times = output['interpolated_spike_times']
-    spike_times = output['interpolated_spike_times']
-    interpolated_spike_voltages = output['interpolated_spike_voltage']
-    interpolated_spike_thresholds = output['interpolated_spike_threshold']
-    grid_spike_indices = output['spike_time_steps']
-    grid_spike_times = output['grid_spike_times']
-    after_spike_currents = output['AScurrents']
-
-#     # create a time array for plotting
-#     time = np.arange(len(stimulus))*neuron.dt
-#
-#     plt.figure(figsize=(10, 10))
-#
-#     # plot stimulus
-#     plt.subplot(3,1,1)
-#     plt.plot(time, stimulus)
-#     plt.xlabel('time (s)')
-#     plt.ylabel('current (A)')
-#     plt.title('Stimulus')
-#
-#     # plot model output
-#     plt.subplot(3,1,2)
-#     plt.plot(time,  voltage, label='voltage')
-#     plt.plot(time,  threshold, label='threshold')
-#
-#     if grid_spike_indices:
-#         plt.plot(interpolated_spike_times, interpolated_spike_voltages, 'x',
-#                  label='interpolated spike')
-#
-#         plt.plot((grid_spike_indices-1)*neuron.dt, voltage[grid_spike_indices-1], '.',
-#                  label='last step before spike')
-#
-#     plt.xlabel('time (s)')
-#     plt.ylabel('voltage (V)')
-#     plt.legend(loc=3)
-#     plt.title('Model Response')
-#
-#     # plot after spike currents
-#     plt.subplot(3,1,3)
-#     for ii in range(np.shape(after_spike_currents)[1]):
-#         plt.plot(time, after_spike_currents[:,ii])
-#     plt.xlabel('time (s)')
-#     plt.ylabel('current (A)')
-#     plt.title('After Spike Currents')
-#
-#     plt.tight_layout()
-#     plt.show()
-
-
-@pytest.mark.skipif(True, reason="needs nwb file")
-def test_6(configured_glif_api, neuron_config_file, stimulus):
-    # define your own custom voltage reset rule
-    # this one linearly scales the input voltage
-    def custom_voltage_reset_rule(neuron, voltage_t0, custom_param_a, custom_param_b):
-        return custom_param_a * voltage_t0 + custom_param_b
-
-    # initialize a neuron from a neuron config file
-    neuron_config = json_utilities.read(neuron_config_file)
-    neuron = GlifNeuron.from_dict(neuron_config)
-
-    # configure a new method and overwrite the neuron's old method
-    method = neuron.configure_method('custom', custom_voltage_reset_rule,
-                                     {'custom_param_a': 0.1, 'custom_param_b': 0.0})
-    neuron.voltage_reset_method = method
-
-    truncate = 56041
-    output = neuron.run(stimulus[0:truncate])

--- a/allensdk/test/model/test_glif.py
+++ b/allensdk/test/model/test_glif.py
@@ -85,7 +85,6 @@ def configured_glif_api(glif_api, neuronal_model_id, neuron_config_file,
     return glif_api
 
 
-
 @pytest.fixture
 def output(neuron_config_file, ephys_sweeps_file):
     neuron_config = json_utilities.read(neuron_config_file)
@@ -145,9 +144,13 @@ def test_run_glifneuron(configured_glif_api, neuron_config_file):
     # simulate the neuron
     output = neuron.run(stimulus)
 
-    voltage = output['voltage']
-    threshold = output['threshold']
-    spike_times = output['interpolated_spike_times']
+    expected_fields = {"AScurrents", "grid_spike_times",
+                       "interpolated_spike_threshold",
+                       "interpolated_spike_times",
+                       "interpolated_spike_voltage",
+                       "spike_time_steps", "threshold", "voltage"}
+
+    assert expected_fields.difference(output.keys()) == set()
 
 
 @pytest.mark.skipif(True, reason="needs nwb file")

--- a/allensdk/test/model/test_glif.py
+++ b/allensdk/test/model/test_glif.py
@@ -121,12 +121,6 @@ def stimulus(neuron_config_file, ephys_sweeps_file):
     return stimulus
 
 
-def test_cache_stimulus(neuron_config_file, ephys_sweeps_file, fn_temp_dir,
-                        configured_glif_api):
-    nwb_path = os.path.join(fn_temp_dir, 'stimulus.nwb')
-    configured_glif_api.cache_stimulus_file(nwb_path)
-
-
 def test_run_glifneuron(configured_glif_api, neuron_config_file):
     # initialize the neuron
     neuron_config = json_utilities.read(neuron_config_file)


### PR DESCRIPTION
I ended up just removing the `test_cache_stimulus` test as it was really only testing whether it was possible to download a specific stimulus nwb from "api.brain-map.org".

If there's a good argument to keep it or create a mocked version (which I don't necessarily get the point of... to check that the method gets called?) do let me know!