### PR TITLE
Calculate `vsynccount` if key not available for time_sync module

### DIFF
--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -139,9 +139,30 @@ def get_ophys_data_length(filename):
         return f["data"].shape[1]
 
 
-def get_stim_data_length(filename):
+def get_stim_data_length(filename: str) -> int:
+    """Get stimulus data length from .pkl file.
+
+    Parameters
+    ----------
+    filename : str
+        Path of stimulus data .pkl file.
+
+    Returns
+    -------
+    int
+        Stimulus data length.
+    """
     stim_data = pd.read_pickle(filename)
-    return stim_data["vsynccount"]
+
+    # A subset of stimulus .pkl files do not have the "vsynccount" field.
+    # MPE *won't* be backfilling the "vsynccount" field for these .pkl files.
+    # So the least worst option is to recalculate the vsync_count.
+    try:
+        vsync_count = stim_data["vsynccount"]
+    except KeyError:
+        vsync_count = len(stim_data["items"]["behavior"]["intervalsms"]) + 1
+
+    return vsync_count
 
 
 def corrected_video_timestamps(video_name, timestamps, data_length):

--- a/allensdk/test/internal/brain_observatory/test_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_time_sync.py
@@ -434,3 +434,18 @@ def test_monitor_delay(scientifica_input):
         delay = ts.monitor_delay(dset, stim_times, "stim_photodiode",
                                  assumed_delay=30)
         assert delay == 30
+
+
+@pytest.mark.parametrize("deserialized_pkl,expected", [
+    ({"vsynccount": 100}, 100),
+    ({"items": {"behavior": {"intervalsms": [2, 2, 2, 2, 2]}}}, 6),
+    ({"vsynccount": 20, "items": {"behavior": {"intervalsms": [3, 3]}}}, 20)
+])
+def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
+    def mock_read_pickle(*args, **kwargs):
+        return deserialized_pkl
+
+    monkeypatch.setattr(ts.pd, "read_pickle", mock_read_pickle)
+    obtained = ts.get_stim_data_length("dummy_filepath")
+
+    assert obtained == expected


### PR DESCRIPTION
Relates to: #1177