### PR TITLE
Fix failing nightly test: ignore test_optimize_run without neuron

### DIFF
--- a/allensdk/test/internal/biophysical/conftest.py
+++ b/allensdk/test/internal/biophysical/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# ignore test_optimize_run.py if don't have neuron installed
+collect_ignore = []
+if os.getenv("TEST_NEURON") != 'true':
+    collect_ignore.append("test_optimize_run.py")


### PR DESCRIPTION
This test was failing because the patch was importing neuron even though the test was marked to skip without neuron.

Just adding the whole file to skip using `conftest.py` if neuron doesn't exist so that it bypasses this issue.