### PR TITLE
run_ophys_time_sync can write an output json

### DIFF
--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -284,7 +284,7 @@ class OphysTimeAligner(object):
         photodiode_key = self._keys["photodiode"]
         delay = monitor_delay(self.dataset, timestamps, photodiode_key)
         
-        return timestamps + delay, delta
+        return timestamps + delay, delta, delay
 
     @property
     def behavior_video_timestamps(self):

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -135,7 +135,7 @@ def get_video_length(filename):
 
 
 def get_ophys_data_length(filename):
-    with h5py.File(filename) as f:
+    with h5py.File(filename, "r") as f:
         return f["data"].shape[1]
 
 

--- a/allensdk/internal/pipeline_modules/run_ophys_time_sync.py
+++ b/allensdk/internal/pipeline_modules/run_ophys_time_sync.py
@@ -131,6 +131,7 @@ class TimeSyncWriter:
                 "allensdk_version": allensdk.__version__,
                 "date": str(datetime.datetime.now()),
                 "experiment_id": outputs.experiment_id,
+                "output_h5_path": self.output_h5_path,
                 "ophys_delta": outputs.ophys_delta,
                 "stim_delta": outputs.stimulus_delta,
                 "stim_delay": outputs.stimulus_delay,

--- a/allensdk/internal/pipeline_modules/run_ophys_time_sync.py
+++ b/allensdk/internal/pipeline_modules/run_ophys_time_sync.py
@@ -1,16 +1,25 @@
 import logging
 import argparse
-from allensdk.internal.core.lims_pipeline_module import PipelineModule
-import allensdk.core.json_utilities as ju
-from allensdk.internal.brain_observatory import time_sync as ts
+import os
+import datetime
+import json
+
 import numpy as np
 import h5py
-import os
+
+import allensdk
+from allensdk.internal.core.lims_pipeline_module import PipelineModule
+from allensdk.internal.brain_observatory import time_sync as ts
+from allensdk.brain_observatory.argschema_utilities import \
+    check_write_access_overwrite
 
 
-def write_output(output_file, ophys_times, stim_alignment, eye_alignment,
-                 behavior_alignment, ophys_delta, stim_delta, eye_delta,
-                 behavior_delta):
+def write_output_h5(
+    output_file, ophys_times, stim_alignment, eye_alignment, 
+    behavior_alignment, ophys_delta, stim_delta, stim_delay, eye_delta, 
+    behavior_delta
+):
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     with h5py.File(output_file, "w") as f:
         f['stimulus_alignment'] = stim_alignment
         f['eye_tracking_alignment'] = eye_alignment
@@ -18,25 +27,66 @@ def write_output(output_file, ophys_times, stim_alignment, eye_alignment,
         f['twop_vsync_fall'] = ophys_times
         f['ophys_delta'] = ophys_delta
         f['stim_delta'] = stim_delta
+        f['stim_delay'] = stim_delay
         f['eye_delta'] = eye_delta
         f['behavior_delta'] = behavior_delta
 
 
-def main():
-    parser = argparse.ArgumentParser("Generate brain observatory alignment.")
-    parser.add_argument('input_json')
-    parser.add_argument('--log-level', default=logging.DEBUG)
-    mod = PipelineModule("Generate brain observatory alignment.", parser)
+def write_output_json(
+    path, ophys_delta, stim_delta, stim_delay, eye_delta, behavior_delta
+):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as output_json:
+        json.dump({
+            "allensdk_version": allensdk.__version__,
+            "date": str(datetime.datetime.now()),
+            "ophys_delta": ophys_delta,
+            "stim_delta": stim_delta,
+            "stim_delay": stim_delay,
+            "eye_delta": eye_delta,
+            "behavior_delta": behavior_delta
+        }, output_json, indent=2)
 
-    input_data = mod.input_data()
-    experiment_id = input_data.pop("ophys_experiment_id")
-    sync_file = input_data.pop("sync_file")
-    output_file = input_data.pop("output_file")
+
+def write_outputs(
+    output_h5_path, output_json_path, 
+    ophys_times, stim_alignment, eye_alignment, behavior_alignment, 
+    ophys_delta, stim_delta, stim_delay, eye_delta, behavior_delta
+):
+    """
+    """
+
+    if output_json_path is not None:
+        write_output_json(
+            output_json_path, ophys_delta, stim_delta, stim_delay, eye_delta, 
+            behavior_delta
+        )
+
+    write_output_h5(
+        output_h5_path, ophys_times, stim_alignment, eye_alignment,
+        behavior_alignment, ophys_delta, stim_delta, stim_delay, eye_delta,
+        behavior_delta
+    )
+
+
+def check_outputs_writable(output_json_path, output_h5_path):
+    """ Make sure we can actually write to the specified output paths, 
+    preferably before running an expensive calculation. Allows for creation
+    of intermediate directories
+    """
+
+    check_write_access_overwrite(output_h5_path)
+
+    if output_json_path is not None:
+        check_write_access_overwrite(output_json_path)
+
+
+def run_ophys_time_sync(input_data, experiment_id, sync_file):
 
     aligner = ts.OphysTimeAligner(sync_file, **input_data)
 
     ophys_times, ophys_delta = aligner.corrected_ophys_timestamps
-    stim_times, stim_delta = aligner.corrected_stim_timestamps
+    stim_times, stim_delta, stim_delay = aligner.corrected_stim_timestamps
     eye_times, eye_delta = aligner.corrected_eye_video_timestamps
     beh_times, beh_delta = aligner.corrected_behavior_video_timestamps
 
@@ -53,9 +103,40 @@ def main():
     behavior_alignment = ts.get_alignment_array(beh_times, ophys_times,
                                                 int_method=np.ceil)
 
-    write_output(output_file, ophys_times, stim_alignment, eye_alignment,
-                 behavior_alignment, ophys_delta, stim_delta, eye_delta,
-                 beh_delta)
+    return (ophys_times, ophys_delta, stim_times, stim_delta, stim_delay, 
+        eye_times, eye_delta, beh_times, beh_delta, stim_alignment, 
+        eye_alignment, behavior_alignment)
+
+
+def main():
+    parser = argparse.ArgumentParser("Generate brain observatory alignment.")
+    parser.add_argument('input_json', type=str, 
+        help="path to input json")
+    parser.add_argument("output_json", type=str, nargs="?", 
+        help="path to which output json will be written")
+    parser.add_argument('--log-level', default=logging.DEBUG)
+    mod = PipelineModule("Generate brain observatory alignment.", parser)
+
+    input_data = mod.input_data()
+    experiment_id = input_data.pop("ophys_experiment_id")
+    sync_file = input_data.pop("sync_file")
+
+    output_file = input_data.pop("output_file")
+    output_json_path = mod.args.output_json
+    check_outputs_writable(output_json_path, output_file)
+
+    (
+        ophys_times, ophys_delta, stim_times, stim_delta, stim_delay, 
+        eye_times, eye_delta, beh_times, beh_delta, stim_alignment, 
+        eye_alignment, behavior_alignment
+    ) = run_ophys_time_sync(input_data, experiment_id, sync_file)
+
+    write_outputs(
+        output_file, output_json_path, 
+        ophys_times, stim_alignment, eye_alignment, behavior_alignment, 
+        ophys_delta, stim_delta, stim_delay, eye_delta, beh_delta
+    )
+
 
 
 if __name__ == "__main__": main()

--- a/allensdk/test/internal/brain_observatory/test_run_ophys_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_run_ophys_time_sync.py
@@ -1,0 +1,96 @@
+""" Tests for the executable that synchronizes distinct data streams within an
+ophys experiment. For tests of the logic used by this executable, see 
+test_time_sync
+"""
+
+import os
+import json
+
+import pytest
+import numpy as np
+import h5py
+
+import allensdk
+from allensdk.internal.pipeline_modules.run_ophys_time_sync import (
+    TimeSyncOutputs, TimeSyncWriter, run_ophys_time_sync
+)
+
+
+@pytest.fixture
+def outputs():
+    return TimeSyncOutputs(
+        100,
+        0.35,
+        0,
+        1,
+        2,
+        3,
+        np.linspace(0, 1, 10),
+        np.linspace(1, 2, 10),
+        np.linspace(2, 3, 10),
+        np.linspace(3, 4, 10),
+        np.arange(10),
+        np.arange(10, 20),
+        np.arange(20, 30)
+    )
+
+@pytest.fixture
+def writer(tmpdir_factory):
+    tmpdir_path = str(tmpdir_factory.mktemp("run_ophys_time_sync_tests"))
+    return TimeSyncWriter(
+        os.path.join(tmpdir_path, "data.h5"),
+        os.path.join(tmpdir_path, "output.json")
+    )
+
+
+def test_validate_paths_writable(writer):
+    try:
+        writer.validate_paths()
+    except Exception as err:
+        pytest.fail(f"expected no error. Got: {err.__class__.__name__}(\"{err}\")")
+
+
+@pytest.mark.parametrize("h5_key,expected", [
+    ["stimulus_alignment", np.arange(10)],
+    ["eye_tracking_alignment", np.arange(10, 20)],
+    ["body_camera_alignment", np.arange(20, 30)],
+    ["twop_vsync_fall", np.linspace(0, 1, 10)],
+    ["ophys_delta", 0],
+    ["stim_delta", 1],
+    ["stim_delay", 0.35],
+    ["eye_delta", 2],
+    ["behavior_delta", 3]
+])
+def test_write_output_h5(writer, outputs, h5_key, expected):
+    
+    writer.write_output_h5(outputs)
+
+    with h5py.File(writer.output_h5_path, "r") as obtained_file:
+        obtained = obtained_file[h5_key]
+        
+        if isinstance(expected, np.ndarray):
+            assert np.allclose(obtained, expected)
+        else:
+            assert obtained.value == expected
+
+
+@pytest.mark.parametrize("json_key,expected", [
+    ["allensdk_version", allensdk.__version__],
+    ["experiment_id", 100],
+    ["ophys_delta", 0],
+    ["stim_delta", 1],
+    ["stim_delay", 0.35],
+    ["eye_delta", 2],
+    ["behavior_delta", 3]
+])
+def test_write_output_json(writer, outputs, json_key, expected):
+
+    writer.write_output_json(outputs)
+
+    with open(writer.output_json_path, "r") as jf:
+        obtained_dict = json.load(jf)
+        obtained = obtained_dict[json_key]
+
+        assert obtained == expected
+
+

--- a/allensdk/test/internal/brain_observatory/test_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_time_sync.py
@@ -236,7 +236,6 @@ def test_regression_calculate_camera_alignment(nikon_input,
         assert len(mis_o) < 0.005*len(aligner.ophys_timestamps[1:])
 
 
-@pytest.mark.skipif(reason="No sync")
 @pytest.mark.parametrize("eye_data_length", (None, 5000, 6000))
 def test_get_corrected_eye_times(eye_data_length):
     true_times = np.arange(6000)
@@ -265,7 +264,6 @@ def test_get_corrected_eye_times(eye_data_length):
         assert delta == (len(true_times) - eye_data_length)
 
 
-@pytest.mark.skipif(reason="No sync")
 @pytest.mark.parametrize("behavior_data_length", (None, 5000, 6000))
 def test_get_corrected_behavior_times(behavior_data_length):
     true_times = np.arange(6000)
@@ -294,7 +292,6 @@ def test_get_corrected_behavior_times(behavior_data_length):
         assert delta == (len(true_times) - behavior_data_length)
 
 
-@pytest.mark.skipif(reason="No sync")
 @pytest.mark.parametrize("stim_data_length,start_delay", [
     (None, False),
     (None, True),
@@ -321,7 +318,7 @@ def test_get_corrected_stim_times(stim_data_length, start_delay):
             with patch.object(ts.Dataset, "get_rising_edges",
                           return_value=true_rising) as mock_rising:
                 with patch("logging.info") as mock_log:
-                    times, delta = aligner.corrected_stim_timestamps
+                    times, delta, stim_delay = aligner.corrected_stim_timestamps
 
     if stim_data_length is None:
         mock_log.assert_called_once()
@@ -345,7 +342,6 @@ def test_get_corrected_stim_times(stim_data_length, start_delay):
         assert delta == 0
 
 
-@pytest.mark.skipif(reason="No sync")
 @pytest.mark.parametrize("ophys_data_length", (None, 5000, 6000, 7000))
 def test_get_corrected_ophys_times_nikon(ophys_data_length):
     true_times = np.arange(6000)
@@ -401,7 +397,7 @@ def test_module(input_json):
         t, d = aligner.corrected_ophys_timestamps
         assert np.all(t == f['twop_vsync_fall'].value)
         assert np.all(d == f['ophys_delta'].value)
-        st, sd = aligner.corrected_stim_timestamps
+        st, sd, stim_delay = aligner.corrected_stim_timestamps
         align = ts.get_alignment_array(t, st)
         assert np.allclose(align, f['stimulus_alignment'].value,
                            equal_nan=True)


### PR DESCRIPTION
- optional output json path specified by second positional arg
- output json contains lightweight results along with metadata
- time sync reports monitor delay (and this is written to output json and h5)
- time sync module refactored and tested
- erroneously disabled tests for timesync internals re-enabled
- time sync module outputs documented
- time sync module fails if monitor delay outside configurable bounds

the tests require TEST_INTERNAL=true, so will run in bamboo but not on travis & company