### PR TITLE
User-given value of 'filter' now being used

### DIFF
--- a/allensdk/ephys/ephys_extractor.py
+++ b/allensdk/ephys/ephys_extractor.py
@@ -122,7 +122,8 @@ class EphysSweepFeatureExtractor:
         thresholds = ft.refine_threshold_indexes(v, t, upstrokes, self.thresh_frac,
                                                  self.filter, dvdt)
         thresholds, peaks, upstrokes, clipped = ft.check_thresholds_and_peaks(v, t, thresholds, peaks,
-                                                                     upstrokes, self.end, self.max_interval)
+                                                                     upstrokes, self.end, self.max_interval,
+                                                                             dvdt=dvdt, filter=self.filter)
         if not thresholds.size:
             # Save time if no spikes detected
             self._spikes_df = DataFrame()


### PR DESCRIPTION
While calling the _process_individual_spikes() function, the custom filter value was not being used in ft.filter_putative_spikes(). Instead it would use the default of 10. Added the filter parameter to the function call.