### PR TITLE
ecephys project lims api default constructor takes asynchronous as keyword arg

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'
 
 try:
     from logging import NullHandler

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -565,14 +565,36 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
 
     @classmethod
-    def default(cls, pg_kwargs=None, app_kwargs=None):
+    def default(cls, pg_kwargs=None, app_kwargs=None, asynchronous=True):
+        """ Construct a "straightforward" lims api that can fetch data from 
+        lims2.
+
+        Parameters
+        ----------
+        pg_kwargs : dict
+            High-level configuration for postgres queries. See 
+            allensdk.internal.api.PostgresQueryMixin for details.
+        app_kwargs : dict
+            High-level configuration for http requests. See 
+            allensdk.brain_observatory.ecephys.ecephys_project_api.http_engine.HttpEngine 
+            and AsyncHttpEngine for details.
+        asynchronous : bool
+            If true, (http) queries will be made asynchronously.
+
+        Returns
+        -------
+        EcephysProjectLimsApi
+
+        """
 
         _pg_kwargs = {}
         if pg_kwargs is not None:
             _pg_kwargs.update(pg_kwargs)
 
-        _app_kwargs = {"scheme": "http", "host": "lims2", "asynchronous": True}
+        _app_kwargs = {"scheme": "http", "host": "lims2", "asynchronous": asynchronous}
         if app_kwargs is not None:
+            if "asynchronous" in app_kwargs:
+                raise TypeError("please specify asynchronicity option at the api level rather than for the http engine")
             _app_kwargs.update(app_kwargs)
 
         app_engine_cls = AsyncHttpEngine if _app_kwargs["asynchronous"] else HttpEngine

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
@@ -10,6 +10,9 @@ import pynwb
 
 import allensdk.brain_observatory.ecephys.ecephys_project_cache as epc
 import allensdk.brain_observatory.ecephys.write_nwb.__main__ as write_nwb
+from allensdk.brain_observatory.ecephys.ecephys_project_api.http_engine import (
+    write_bytes_from_coroutine, AsyncHttpEngine
+)
 
 
 @pytest.fixture
@@ -364,3 +367,13 @@ def test_get_probe_lfp_data_continually_failing(tmpdir_factory, mock_api):
     with pytest.raises(ValueError):
         session = cache.get_session_data(sid)
         lfp_file = session.api._probe_nwbfile(pid)
+
+
+def test_from_lims_default(tmpdir_factory):
+    tmpdir = str(tmpdir_factory.mktemp("test_from_lims_default"))
+
+    cache = epc.EcephysProjectCache.from_lims(
+        manifest_path=os.path.join(tmpdir, "manifest.json")
+    )
+    assert isinstance(cache.fetch_api.app_engine, AsyncHttpEngine)
+    assert cache.stream_writer is epc.write_bytes_from_coroutine


### PR DESCRIPTION
Previously it was expecting it as an app_kwarg. That is both illogical (since it is used to specify the app_engine class, not as an arg to its constructor) and disagrees with the interface exposed by the equivalent method on the warehouse api.

PRing into master because this fixes a bug in EcephysProjectCache.from_lims.