### PR TITLE
pin glymur (new gdal dependency breaks pip install)

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 try:
     from logging import NullHandler

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ statsmodels==0.9.0
 simpleitk
 argschema
 marshmallow==3.0.0rc6
-glymur
+glymur==0.8.19
 xarray
 hdmf==1.0.2
 pynwb==1.0.2
@@ -25,3 +25,4 @@ tables==3.5.1 # pinning this because updates tend to not include wheels immediat
 seaborn
 aiohttp==3.6.2
 nest_asyncio==1.2.0
+


### PR DESCRIPTION
This is a bugfix. Glymur has added a dependency on GDAL (for features we don't use). GDAL has a nontrivial install process, which is breaking simple pip installations for our users.