### PR TITLE
BF: do not pin versions of pynwb and hdmf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,9 @@ argschema<2.0.0
 marshmallow==3.0.0rc6
 glymur==0.8.19
 xarray<0.16.0
-hdmf==1.0.2
-pynwb==1.0.2
+hdmf>=1.0.2
+pynwb>=1.0.2,<2.0.0
 tables==3.5.1 # pinning this because updates tend to not include wheels immediately
 seaborn<1.0.0
 aiohttp==3.6.2
 nest_asyncio==1.2.0
-


### PR DESCRIPTION
See https://github.com/AllenInstitute/AllenSDK/issues/1325 for rationale.
Ideal solution could leave them pinned in requirements.txt but should
provide handling in setup.py to specify them for install_requires with
>= instead of ==

Closes #1325

Feel welcome to reject this PR and provide an alternative solution