### PR TITLE
version and cache spec

### DIFF
--- a/allensdk/brain_observatory/ecephys/nwb/AIBS_ecephys_namespace.yaml
+++ b/allensdk/brain_observatory/ecephys/nwb/AIBS_ecephys_namespace.yaml
@@ -1,5 +1,6 @@
 namespaces:
 - doc: ""
+  version: 0.2.0
   name: AIBS_ecephys
   schema:
   - namespace: core

--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -775,10 +775,9 @@ def write_ecephys_nwb(
                                                  eye_gaze_data=eye_gaze_data)
 
     Manifest.safe_make_parent_dirs(output_path)
-    io = pynwb.NWBHDF5IO(output_path, mode='w')
-    logging.info(f"writing session nwb file to {output_path}")
-    io.write(nwbfile)
-    io.close()
+    with pynwb.NWBHDF5IO(output_path, mode='w') as io:
+        logging.info(f"writing session nwb file to {output_path}")
+        io.write(nwbfile, cache_spec=True)
 
     probes_with_lfp = [p for p in probes if p["lfp"] is not None]
     probe_outputs = write_probewise_lfp_files(probes_with_lfp, session_start_time, pool_size=pool_size)


### PR DESCRIPTION
addresses #1330 

Adds required version to namespace and caches spec in file. This should allow pynwb to read the file without needing to import from allensdk.

