### PR TITLE
filter out invalid ecephys spike times

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -12,7 +12,8 @@ from .ecephys_session_api import EcephysSessionApi
 from allensdk.brain_observatory.nwb.nwb_api import NwbApi
 import allensdk.brain_observatory.ecephys.nwb  # noqa Necessary to import pyNWB namespaces
 from allensdk.brain_observatory.ecephys import get_unit_filter_value
-
+from allensdk.brain_observatory.ecephys.write_nwb.__main__ import \
+    remove_invalid_spikes_from_units
 
 color_triplet_re = re.compile(r"\[(-{0,1}\d*\.\d*,\s*)*(-{0,1}\d*\.\d*)\]")
 
@@ -319,6 +320,8 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
         units = units[units["amplitude_cutoff"] <= self.amplitude_cutoff_maximum]
         units = units[units["presence_ratio"] >= self.presence_ratio_minimum]
         units = units[units["isi_violations"] <= self.isi_violations_maximum]
+
+        units = remove_invalid_spikes_from_units(units)
         return units
 
     def get_metadata(self):

--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -186,6 +186,81 @@ def scale_amplitudes(spike_amplitudes, templates, spike_templates, scale_factor=
     return spike_amplitudes
 
 
+def remove_invalid_spikes(
+    row: pd.Series, 
+    times_key: str = "spike_times", 
+    amps_key: str = "spike_amplitudes"
+) -> pd.Series:
+    """ Given a row from a units table, ensure that invalid spike times and 
+    corresponding amplitudes are removed. Also ensure the spikes are sorted 
+    ascending in time.
+
+    Parameters
+    ----------
+    row : a row representing a single sorted unit
+    times_key : name of column containing spike times
+    amps_key : name of column containing spike amplitudes
+
+    Returns
+    -------
+    A version of the input row, with spike times sorted and invalid times 
+    removed
+
+    Notes
+    -----
+    This function is needed because currently released NWB files might have 
+    invalid spike times. It can be removed if these files are updated.
+
+    """
+
+    out = row.copy(deep=True)
+
+    spikes = np.array(out.pop(times_key))
+    amps = np.array(out.pop(amps_key))
+
+    valid = spikes >= 0
+    spikes = spikes[valid]
+    amps = amps[valid]
+
+    order = np.argsort(spikes)
+    out[times_key] = spikes[order]
+    out[amps_key] = amps[order]
+
+    return out
+
+
+def remove_invalid_spikes_from_units(
+    units: pd.DataFrame,
+    times_key: str = "spike_times", 
+    amps_key: str = "spike_amplitudes"
+) -> pd.DataFrame:
+    """ Given a units table, ensure that invalid spike times and 
+    corresponding amplitudes are removed. Also ensure the spikes are sorted 
+    ascending in time.
+
+    Parameters
+    ----------
+    units : A units table
+    times_key : name of column containing spike times
+    amps_key : name of column containing spike amplitudes
+
+    Returns
+    -------
+    A version of the input table, with spike times sorted and invalid times 
+    removed
+
+    Notes
+    -----
+    This function is needed because currently released NWB files might have 
+    invalid spike times. It can be removed if these files are updated.
+
+    """
+
+    remover = partial(
+        remove_invalid_spikes, times_key=times_key, amps_key=amps_key)
+    return units.apply(remover, axis=1)
+
+
 def group_1d_by_unit(data, data_unit_map, local_to_global_unit_map=None):
     sort_order = np.argsort(data_unit_map, kind="stable")
     data_unit_map = data_unit_map[sort_order]
@@ -639,6 +714,7 @@ def add_probewise_data_to_nwbfile(nwbfile, probes):
     electrodes_table = fill_df(pd.concat(list(channel_tables.values())))
     nwbfile.electrodes = pynwb.file.ElectrodeTable().from_dataframe(electrodes_table, name='electrodes')
     units_table = pd.concat(unit_tables).set_index(keys='id', drop=True)
+    units_table = remove_invalid_spikes_from_units(units_table)
     nwbfile.units = pynwb.misc.Units.from_dataframe(fill_df(units_table), name='units')
 
     add_ragged_data_to_dynamic_table(

--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -215,15 +215,15 @@ def remove_invalid_spikes(
 
     out = row.copy(deep=True)
 
-    spikes = np.array(out.pop(times_key))
+    spike_times = np.array(out.pop(times_key))
     amps = np.array(out.pop(amps_key))
 
-    valid = spikes >= 0
-    spikes = spikes[valid]
+    valid = spike_times >= 0
+    spike_times = spike_times[valid]
     amps = amps[valid]
 
-    order = np.argsort(spikes)
-    out[times_key] = spikes[order]
+    order = np.argsort(spike_times)
+    out[times_key] = spike_times[order]
     out[amps_key] = amps[order]
 
     return out

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_session_nwb_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_session_nwb_api.py
@@ -24,4 +24,4 @@ import allensdk.brain_observatory.ecephys.ecephys_session_api.ecephys_nwb_sessio
 ])
 def test_clobbering_merge(left, right, expected, left_on, right_on):
     obtained = ensa.clobbering_merge(left, right, left_on=left_on, right_on=left_on)
-    pd.testing.assert_frame_equal
+    pd.testing.assert_frame_equal(expected, obtained, check_like=True)

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_session_nwb_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_session_nwb_api.py
@@ -24,4 +24,4 @@ import allensdk.brain_observatory.ecephys.ecephys_session_api.ecephys_nwb_sessio
 ])
 def test_clobbering_merge(left, right, expected, left_on, right_on):
     obtained = ensa.clobbering_merge(left, right, left_on=left_on, right_on=left_on)
-    pd.testing.assert_frame_equal(expected, obtained, check_like=True)
+    pd.testing.assert_frame_equal


### PR DESCRIPTION
and make sure the others are sorted. This fix is applied on read (to cover currently released NWB files) as well as on write. The read-time fix can be removed if new NWBs are released in the future.

See #1349 and [this comment](https://github.com/AllenInstitute/AllenSDK/pull/1350#issuecomment-583157002) for more info + rationale.