### PR TITLE
GH #1321: Use pkl file to access lick information in ophys_sessions

### DIFF
--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_lims_api.py
@@ -32,6 +32,22 @@ def MockBehaviorDataLimsApi():
                             "lick_events": [2, 6, 9],
                         }],
                         "intervalsms": np.array([16.0]*10),
+                        "trial_log": [
+                            {
+                                "events":
+                                    [
+                                        ["trial_start", 2, 2],
+                                        ["trial_end", 3, 3],
+                                    ],
+                            },
+                            {
+                                "events":
+                                    [
+                                        ["trial_start", 4, 4],
+                                        ["trial_start", 5, 5],
+                                    ],
+                            },
+                        ],
                     },
                 },
                 "session_uuid": 123456,

--- a/allensdk/test/brain_observatory/behavior/test_sync.py
+++ b/allensdk/test/brain_observatory/behavior/test_sync.py
@@ -1,0 +1,29 @@
+from allensdk.brain_observatory.behavior.sync import frame_time_offset
+
+
+def test_frame_time_offset():
+    mock_data = {
+        "items": {
+            "behavior": {
+                "trial_log":
+                    [
+                        {
+                            "events":
+                                [
+                                    ["trial_start", 2, 1],
+                                    ["trial_end", 3, 2],
+                                ],
+                        },
+                        {
+                            "events":
+                                [
+                                    ["trial_start", 4, 3],
+                                    ["trial_start", 5, 4],
+                                ],
+                        },
+                    ],
+                },
+            },
+        }
+    actual = frame_time_offset(mock_data)
+    assert 1. == actual


### PR DESCRIPTION
Fixes #1321 

Use pkl file to access lick information, even for ophys_sessions.
The access to sync file licks is maintained with `get_sync_licks`, but these are not used to create the trials dataframe from `get_trials`.

Also fixes the time stream alignment for licks and trials. Since licks can occur outside of a trial context, they were retrieved via the frame number in the lick sensor log (aligning to `intervalsms`). However, there is no data for when the first frame in `intervalsms` occurred, so it was out-of-sync with the `trial_log` time stream (which contains frame number and timestamp for events). To compute the time the first `intervalms` occurred, use a linear regression for the frames and timestamps in `trial_start` and `trial_end` events in the `trial_log`. This is more accurate than just subtracting the first `trial_start`, since there can be some jitter with the refresh rate.

The `stimulus_rebase_function` was also updated with the more accurate linear regression.
