### PR TITLE
Fixed bug requiring additional IDs for BehaviorDataLimsApi

### DIFF
--- a/allensdk/internal/api/behavior_data_lims_api.py
+++ b/allensdk/internal/api/behavior_data_lims_api.py
@@ -102,7 +102,10 @@ class BehaviorDataLimsApi(CachedInstanceMethodMixin, BehaviorBase):
             WHERE
                 ophys_experiment_id IN ({",".join(set(map(str, oed)))});
             """
-            container_id = self.lims_db.fetchone(container_query, strict=True)
+            try:
+                container_id = self.lims_db.fetchone(container_query, strict=True)
+            except OneResultExpectedError:
+                container_id = None
 
             ids_dict.update({"ophys_experiment_ids": oed,
                              "ophys_container_id": container_id})

--- a/allensdk/internal/api/behavior_data_lims_api.py
+++ b/allensdk/internal/api/behavior_data_lims_api.py
@@ -93,6 +93,8 @@ class BehaviorDataLimsApi(CachedInstanceMethodMixin, BehaviorBase):
                 WHERE ophys_session_id = {ids_dict["ophys_session_id"]};
                 """
             oed = self.lims_db.fetchall(oed_query)
+            if len(oed) == 0:
+                oed = None
 
             container_query = f"""
             SELECT DISTINCT


### PR DESCRIPTION
Previously BehaviorDataLimsApi would raise an exception if no container id
was returned from lims id for given ophys id. This has been changed at
allenskd/internal/api/behavior_data_lims_api.py 105 - 108. Now the query will
return None for the container id if the query results in an empty list return.
Resolves: #1354