### PR TITLE
Added version for AIBS_ophys_behavior_namespace

### DIFF
--- a/allensdk/brain_observatory/nwb/AIBS_ophys_behavior_namespace.yaml
+++ b/allensdk/brain_observatory/nwb/AIBS_ophys_behavior_namespace.yaml
@@ -2,6 +2,7 @@ namespaces:
 - doc: "LabMetaData extensions: ['OphysBehaviorMetaData', 'OphysBehaviorTaskParameters']\
     \ (AIBS_ophys_behavior)"
   name: AIBS_ophys_behavior
+  version: 0.1.0
   schema:
   - namespace: core
   - source: AIBS_ophys_behavior_extension.yaml


### PR DESCRIPTION
NWB allows you to create extensions composed of custom data structures.
Allen has been using this feature to add meta-data that is not in the core NWB.
As we find better ways to store this data, and as Allen's needs evolve,
we will want to change the extensions to meet these needs. This version number
is the version of the extension AIBS_ophys_behavior_extension.yaml. It allows us to make
changes to the extension in an organized way so we can have an understanding
of what state of the extension was used for a certain file even as we update it for other files.

Resolves: #1359 #1382