### PR TITLE
Make environment credentials public (to build forks on Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,16 @@ env:
     - TEST_API_ENDPOINT=http://api.brain-map.org 
     - TEST_COMPLETE=false
     - TEST_BAMBOO=false
+    - LIMS_DBNAME=db
+    - LIMS_PORT=1234
+    - LIMS_PASSWORD=password
+    - LIMS_HOST=host
+    - LIMS_USER=user
+    - MTRAIN_DBNAME=db
+    - MTRAIN_USER=user
+    - MTRAIN_HOST=host
+    - MTRAIN_PORT=1234
+    - MTRAIN_PASSWORD=password
 
 matrix:
   include:


### PR DESCRIPTION
Builds from forks are failing on travis because they don't have access to the environment variables configured for the repository. Since the credentials do not need to be validated, making them public fake credentials in the travis.yml configuration. This makes the variables available to all forks. 

Targeting master for this to fix future builds. I will rebase rc/1.6.0 after this is approved.