### PR TITLE
set exclusive upper bounds for all dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,8 @@ install:
   - conda install statsmodels
   - pip install Pillow
   - pip install codecov
-  - pip install -r test_requirements.txt
+  - pip install -r requirements.txt -U
+  - pip install -r test_requirements.txt -U
   - pip install .
 
 test_script:

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,16 +1,36 @@
-pep8==1.7.0
-flake8>=1.5.0
-pylint>=1.5.4
-numpydoc>=0.6.0
-jupyter>=1.0.0
-matplotlib>=1.4.3
-simplejson
-h5py
-pandas
-scipy
-requests_toolbelt
-pynrrd
-SimpleITK
-scikit-image
-statsmodels
-sklearn
+pep8==1.7.0,<2.0.0
+flake8>=1.5.0,<4.0.0
+pylint>=1.5.4,<3.0.0
+numpydoc>=0.6.0,<1.0.0
+jupyter>=1.0.0,<2.0.0
+# from here on, this file should contain a subset of the packages specified in requirements.txt
+# some packages are excluded because they can't be installed on readthedocs
+# these ought to be mocked out in doc_template/conf.py so that docs are generated for allensdk modules that import 
+# those packages
+# known examples: tables
+psycopg2-binary>=2.7,<3.0.0
+h5py>=2.8,<3.0.0
+matplotlib>=1.4.3,<4.0.0
+numpy>=1.15.4,<1.19.0
+pandas>=0.25.1,<=0.25.3
+jinja2>=2.7.3,<2.12.0
+scipy>=0.15.1,<2.0.0
+six>=1.9.0,<2.0.0
+pynrrd>=0.2.1,<1.0.0
+future >= 0.14.3,<1.0.0
+requests<3.0.0
+requests-toolbelt<1.0.0
+simplejson>=3.10.0,<4.0.0
+scikit-image>=0.14.0,<0.17.0
+scikit-build<1.0.0
+statsmodels==0.9.0
+simpleitk<2.0.0
+argschema<2.0.0
+marshmallow==3.0.0rc6
+glymur==0.8.19
+xarray<0.16.0
+hdmf==1.0.2
+pynwb==1.0.2
+seaborn<1.0.0
+aiohttp==3.6.2
+nest_asyncio==1.2.0

--- a/doc_template/conf.py
+++ b/doc_template/conf.py
@@ -299,6 +299,11 @@ skip_autodoc_names = [ 'DEFAULTS' ]
 
 numpydoc_show_class_members = False
 
+# some dependencies don't install correctly on readthedocs. Listing them here
+# allows allensdk modules which import them to still get autodocs
+autodoc_mock_imports = ["tables"]
+
+
 def skip_autodoc(app, what, name, obj, skip, options):
     #TODO: also check obj/module name, documentation isn't great though,
     # see: http://sphinx-doc.org/ext/autodoc.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,28 +1,28 @@
-psycopg2-binary>=2.7
-h5py>=2.8
-matplotlib>=1.4.3
-numpy>=1.15.4
+psycopg2-binary>=2.7,<3.0.0
+h5py>=2.8,<3.0.0
+matplotlib>=1.4.3,<4.0.0
+numpy>=1.15.4,<1.19.0
 pandas>=0.25.1,<=0.25.3
-jinja2>=2.7.3
-scipy>=0.15.1
-six>=1.9.0
-pynrrd>=0.2.1
-future >= 0.14.3
-requests
-requests-toolbelt
-simplejson>=3.10.0
-scikit-image>=0.14.0
-scikit-build
+jinja2>=2.7.3,<2.12.0
+scipy>=0.15.1,<2.0.0
+six>=1.9.0,<2.0.0
+pynrrd>=0.2.1,<1.0.0
+future >= 0.14.3,<1.0.0
+requests<3.0.0
+requests-toolbelt<1.0.0
+simplejson>=3.10.0,<4.0.0
+scikit-image>=0.14.0,<0.17.0
+scikit-build<1.0.0
 statsmodels==0.9.0
-simpleitk
-argschema
+simpleitk<2.0.0
+argschema<2.0.0
 marshmallow==3.0.0rc6
 glymur==0.8.19
-xarray
+xarray<0.16.0
 hdmf==1.0.2
 pynwb==1.0.2
 tables==3.5.1 # pinning this because updates tend to not include wheels immediately
-seaborn
+seaborn<1.0.0
 aiohttp==3.6.2
 nest_asyncio==1.2.0
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,13 +1,15 @@
-pep8==1.7.0
-pytest>=4.4.0
-pytest-cov>=2.6.1
-pytest-cover>=3.0.0
-pytest-pep8>=1.0.6
-pytest-xdist>=1.14
-pytest-mock>=1.5.0
-mock>=1.0.1
-coverage>=3.7.1
-flake8>=1.5.0
-pylint>=1.5.4
-numpydoc>=0.6.0
-jupyter>=1.0.0
+pytest>=4.4.0,<6.0.0
+pytest-cov>=2.6.1,<3.0.0
+pytest-cover>=3.0.0,<4.0.0
+pytest-pep8>=1.0.6,<2.0.0
+pytest-xdist>=1.14,<2.0.0
+pytest-mock>=1.5.0,<3.0.0
+mock>=1.0.1,<5.0.0
+coverage>=3.7.1,<6.0.0
+# these overlap with requirements specified in doc_requirements. As long as they are needed, these specifications must be kept in sync
+# TODO: see if we can avoid duplicating these requirements - this will involved surveying CI
+pep8==1.7.0,<2.0.0
+flake8>=1.5.0,<4.0.0
+pylint>=1.5.4,<3.0.0
+numpydoc>=0.6.0,<1.0.0
+jupyter>=1.0.0,<2.0.0


### PR DESCRIPTION
I went through and bounded each dependency using my best guess of the next version which might introduce breaking changes (I expect this will be wrong a few times, since Python packages often don't follow semantic versioning strictly). This will (hopefully) help us to avoid unintentional dependency-based breaking changes while still allowing for upgrades.

We have a lot of duplicate requirements. In some cases (test_requirements vs doc_requirements) I think these can be dissolved by updating our ci. In others, (requirements vs doc_requirements) it is a bit more tricky (some packages can't be installed on readthedocs, at least using pip). In the meantime, we need to make sure that duplicated requirements are clearly called out and updated.

We might need to iterate a bit on the docs_requirements (using the readthedocs branch build) before merging.