### PR TITLE
GH 771: Remove redundant 'sham_change' column from trials

### DIFF
--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -345,6 +345,7 @@ def get_trials(data, licks_df, rewards_df, stimulus_presentations_df, rebase):
 
     trials = pd.DataFrame(all_trial_data).set_index('trial')
     trials.index = trials.index.rename('trials_id')
+    del trials["sham_change"]
 
     return trials
 


### PR DESCRIPTION
Response to #771. I checked for the use of "sham_change" in the repo -- I found some uses internally in the function that produces the trial dataframe, but no downstream functions in the AllenSDK.

Functions using the column:
all in `allensdk.brain_observatory.behavior.trials_processing`  (outside of tests)

`trial_data_from_log` (used only by `get_trials`, could be made private)
`get_change_time` (function defined in local scope of `get_trials`)
`get_change_time_frame_response_latency` (used only by `get_trials_v0`, which seems deprecated/unused? Could be made private/removed.)
