### PR TITLE
GH-712: Fix auto-rewarded in rewards results

### DIFF
--- a/allensdk/brain_observatory/behavior/rewards_processing.py
+++ b/allensdk/brain_observatory/behavior/rewards_processing.py
@@ -3,15 +3,15 @@ from collections import defaultdict
 
 
 def get_rewards(data, stimulus_rebase_function):
-    trial_df = pd.DataFrame(data["items"]["behavior"]['trial_log'])
-    rewards_dict = {'volume': [], 'timestamps': [], 'autorewarded': []}
+    trial_df = pd.DataFrame(data["items"]["behavior"]["trial_log"])
+    rewards_dict = {"volume": [], "timestamps": [], "autorewarded": []}
     for idx, trial in trial_df.iterrows():
         rewards = trial["rewards"]  # as i write this there can only ever be one reward per trial
         if rewards:
             rewards_dict["volume"].append(rewards[0][0])
             rewards_dict["timestamps"].append(stimulus_rebase_function(rewards[0][1]))
-            rewards_dict["autorewarded"].append('auto_rewarded' in trial['trial_params'])
+            rewards_dict["autorewarded"].append(trial["trial_params"]["auto_reward"])
 
-    df = pd.DataFrame(rewards_dict).set_index('timestamps', drop=True)
+    df = pd.DataFrame(rewards_dict).set_index("timestamps", drop=True)
 
     return df

--- a/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
@@ -9,21 +9,26 @@ def test_get_rewards():
             "behavior": {
                 "trial_log": [
                     {
-                        'rewards': [(0.007, 1085.965144219165, 64775)],
+                        'rewards': [(0.007, 1085.96, 64775)],
                         'trial_params': {
                             'catch': False, 'auto_reward': False,
                             'change_time': 5}},
                     {
+                        'rewards': [(0.007, 1090.01, 64780)],
+                        'trial_params': {
+                            'catch': False, 'auto_reward': True,
+                            'change_time': 6}},
+                    {
                         'rewards': [],
                         'trial_params': {
                             'catch': False, 'auto_reward': False,
-                            'change_time': 4}
-                    }
+                            'change_time': 4},
+                    },
                     ]
                 }}}
     expected = pd.DataFrame(
-        {"volume": [0.007],
-         "timestamps": [1086.965144219165],
-         "autorewarded": False}).set_index("timestamps", drop=True)
+        {"volume": [0.007, 0.007],
+         "timestamps": [1086.96, 1091.01],
+         "autorewarded": [False, True]}).set_index("timestamps", drop=True)
 
     pd.testing.assert_frame_equal(expected, get_rewards(data, lambda x: x+1.0))


### PR DESCRIPTION
Fixes a bug where auto-rewarded trials were not properly
attributed in the rewards property of a visual behavior
Session. Update tests to cover multiple values of 'auto_reward'.