### PR TITLE
Added cache_spec==True keyword to lfp_writer.write call

### DIFF
--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -625,7 +625,7 @@ def write_probe_lfp_file(session_start_time, log_level, probe):
 
     with pynwb.NWBHDF5IO(probe['lfp']['output_path'], 'w') as lfp_writer:
         logging.info(f"writing probe lfp file to {probe['lfp']['output_path']}")
-        lfp_writer.write(nwbfile)
+        lfp_writer.write(nwbfile, cache_spec=True)
     return {"id": probe["id"], "nwb_path": probe["lfp"]["output_path"]}
 
 


### PR DESCRIPTION
NWB advises to include this keyword in the NWB file write. This keyword caches the extension in the NWB file so it's easier for others to read data. No need to import ecephys.nwb.