### PR TITLE
GH-1404: Handle monitor delay errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 - A new mixin for managing processing parameters for Session objects
 
 ### Changed
+- Monitor delay calculation is updated to properly handle photodiode streams that end
+on a rising edge. We are no longer providing a default delay value in case of error.
 
 ### Bug Fixes
 - experiment\_table from behavior project cache has NaNs in the 'imaging\_depth' column for MultiScope experiments due to incorrect join in behavior\_project\_lims\_api.py and 4 other places where ophys\_sessions was incorrectly queried for imaging\_depth\_id

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -1,3 +1,6 @@
+from collections import deque
+from typing import Optional, Callable, Any
+
 import numpy as np
 import h5py
 from allensdk.brain_observatory.sync_dataset import Dataset
@@ -9,14 +12,11 @@ except ImportError:
     cv2 = None
 
 TRANSITION_FRAME_INTERVAL = 60
-SHORT_PHOTODIODE_MIN = 0.1 # seconds
-SHORT_PHOTODIODE_MAX = 0.5 # seconds
-REG_PHOTODIODE_MIN = 1.9 # seconds
-REG_PHOTODIODE_MAX = 2.1 # seconds
-PHOTODIODE_ANOMALY_THRESHOLD = 0.5 # seconds
-LONG_STIM_THRESHOLD = 0.2 # seconds
-ASSUMED_DELAY = 0.0215 # seconds
-MAX_MONITOR_DELAY = 0.07 # seconds
+REG_PHOTODIODE_INTERVAL = 1.0     # seconds
+REG_PHOTODIODE_STD = 0.05    # seconds
+PHOTODIODE_ANOMALY_THRESHOLD = 0.5     # seconds
+LONG_STIM_THRESHOLD = 0.2     # seconds
+MAX_MONITOR_DELAY = 0.07     # seconds
 
 VERSION_1_KEYS = {
     "photodiode": "stim_photodiode",
@@ -53,58 +53,103 @@ def get_keys(sync_dset):
 
 def monitor_delay(sync_dset, stim_times, photodiode_key,
                   transition_frame_interval=TRANSITION_FRAME_INTERVAL,
-                  max_monitor_delay=MAX_MONITOR_DELAY,
-                  assumed_delay=ASSUMED_DELAY):
+                  max_monitor_delay=MAX_MONITOR_DELAY):
     """Calculate monitor delay."""
-    try:
-        transitions = stim_times[::transition_frame_interval]
-        photodiode_events = get_real_photodiode_events(sync_dset, photodiode_key)
-        transition_events = photodiode_events[0:len(transitions)]
+    transitions = stim_times[::transition_frame_interval]
+    photodiode_events = get_real_photodiode_events(sync_dset, photodiode_key)
+    transition_events = photodiode_events[0:len(transitions)]
 
-        delay = np.mean(transition_events-transitions)
-        logging.info("Calculated monitor delay: %s", delay)
+    delays = transition_events - transitions
+    delay = np.mean(delays)
+    logging.info(f"Calculated monitor delay: {delay}. \n "
+                 f"Max monitor delay: {np.max(delays)}. \n "
+                 f"Min monitor delay: {np.min(delays)}.\n "
+                 f"Std monitor delay: {np.std(delays)}.")
 
-        if delay < 0 or delay > max_monitor_delay:
-            delay = assumed_delay
-            logging.warning("Setting delay to assumed value: %s", delay)
-    except (IndexError, ValueError) as e:
-        logging.error(e)
-        delay = assumed_delay
-        logging.warning("Bad photodiode signal, setting delay to assumed "
-                        "value: %s", delay)
-
+    if delay < 0 or delay > max_monitor_delay:
+        raise ValueError(f"Delay ({delay}s) falls outside expected value "
+                         f"range (0-{MAX_MONITOR_DELAY}s).")
     return delay
+
+
+def _find_last_n(arr: np.ndarray, n: int,
+                 cond: Callable[[Any], bool]) -> Optional[int]:
+    """
+    Find the final index where the prior `n` values in an array meet
+    the condition `cond` (inclusive).
+    Parameters
+    ==========
+    arr: numpy.1darray
+    n: int
+    cond: Callable that returns True if condition is met, False
+    otherwise. Should be able to be applied to the array elements
+    without any additional arguments.
+    """
+    reversed_ix = _find_n(arr[::-1], n, cond)
+    if reversed_ix is not None:
+        reversed_ix = len(arr) - reversed_ix - 1
+    return reversed_ix
+
+
+def _find_n(arr: np.ndarray, n: int,
+            cond: Callable[[Any], bool]) -> Optional[int]:
+    """
+    Find the index where the next `n` values in an array meet the
+    condition `cond` (inclusive).
+    Parameters
+    ==========
+    arr: numpy.1darray
+    n: int
+    cond: Callable that returns True if condition is met, False
+    otherwise. Should be able to be applied to the array elements
+    without any additional arguments.
+    """
+    if len(arr) < n:
+        return None
+    queue = deque(np.apply_along_axis(cond, 0, arr[:n]), maxlen=n)
+    i = 0
+    while queue.count(True) < n:
+        try:
+            i += 1
+            queue.append(cond(arr[i+n-1]))
+        except IndexError:
+            return None
+    return i
 
 
 def get_photodiode_events(sync_dset, photodiode_key):
     """Returns the photodiode events with the start/stop indicators and
-    the window init flash stripped off.
+    the window init flash stripped off. These transitions occur roughly
+    ~1.0s apart, since the sync square changes state every N frames
+    (where N = 60, and frame rate is 60 Hz). Because there are no
+    markers for when the first transition of this type started, we
+    estimate based on the event intervals. For the first valid event,
+    find the first two events that both meet the following criteria:
+        The next event occurs ~1.0s later
+    First the last valid event, find the first two events that both meet
+    the following criteria:
+        The last valid event occured ~1.0s before
     """
-    all_events = sync_dset.get_events_by_line(photodiode_key)
-    pdr = sync_dset.get_rising_edges(photodiode_key)
-    pdf = sync_dset.get_falling_edges(photodiode_key)
-
-    all_events_sec = all_events/sync_dset.sample_freq
-    pdr_sec = pdr/sync_dset.sample_freq
-    pdf_sec = pdf/sync_dset.sample_freq
-
-    pdf_diff = np.ediff1d(pdf_sec, to_end=0)
-    pdr_diff = np.ediff1d(pdr_sec, to_end=0)
-
-    reg_pd_falling = pdf_sec[(pdf_diff >= REG_PHOTODIODE_MIN) &
-                             (pdf_diff <= REG_PHOTODIODE_MAX)]
-
-    short_pd_rising = pdr_sec[(pdr_diff >= SHORT_PHOTODIODE_MIN) &
-                              (pdr_diff <= SHORT_PHOTODIODE_MAX)]
-
-    first_falling = reg_pd_falling[0]
-    last_falling = reg_pd_falling[-1]
-
-    end_indicators = short_pd_rising[short_pd_rising > last_falling]
-    first_end_indicator = end_indicators[0]
-
-    pd_events =  all_events_sec[(all_events_sec >= first_falling) &
-                                (all_events_sec < first_end_indicator)]
+    all_events = sync_dset.get_events_by_line(photodiode_key, units="seconds")
+    all_events_diff = np.ediff1d(all_events, to_begin=0, to_end=0)
+    all_events_diff_prev = all_events_diff[:-1]
+    all_events_diff_next = all_events_diff[1:]
+    min_interval = REG_PHOTODIODE_INTERVAL - REG_PHOTODIODE_STD
+    max_interval = REG_PHOTODIODE_INTERVAL + REG_PHOTODIODE_STD
+    if not len(all_events):
+        raise ValueError("No photodiode events found. Please check "
+                         "the input data for errors. ")
+    first_valid_index = _find_n(
+        all_events_diff_next, 2,
+        lambda x: (x >= min_interval) & (x <= max_interval))
+    last_valid_index = _find_last_n(
+        all_events_diff_prev, 2,
+        lambda x: (x >= min_interval) & (x <= max_interval))
+    if first_valid_index is None:
+        raise ValueError("Can't find valid start event")
+    if last_valid_index is None:
+        raise ValueError("Can't find valid end event")
+    pd_events = all_events[first_valid_index:last_valid_index+1]
     return pd_events
 
 
@@ -174,7 +219,7 @@ def corrected_video_timestamps(video_name, timestamps, data_length):
                          "%s", video_name, data_length, len(timestamps))
     else:
         logging.info("No data length provided for %s", video_name)
-    
+
     return timestamps, delta
 
 
@@ -283,7 +328,7 @@ class OphysTimeAligner(object):
 
         photodiode_key = self._keys["photodiode"]
         delay = monitor_delay(self.dataset, timestamps, photodiode_key)
-        
+
         return timestamps + delay, delta, delay
 
     @property

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -97,6 +97,7 @@ As of the 1.7.0 release:
 
 - Added functionality so internal users can now access `eye_tracking` ellipse fit data from behavior + ophys Session objects
 - Added a new mixin for managing processing parameters for Session objects
+- Update the monitor delay calculation to better handle edge cases; no longer provide a default delay value if encounter an error
 
 What's New - 1.6.0 (March 23, 2020)
 -----------------------------------------------------------------------


### PR DESCRIPTION
Updated algorithm from from @dougollerenshaw:
1. Every transition from rise/fall or fall/rise represents a
change in the state of the sync square. Call these ‘photodiode events’
2. During the experiment, the sync square changes state every N
frames (where N = 60 by default). Let’s call these ‘sentinel frames’
3. A transition marks a ‘sentinel frame’ if the next photodiode
transition is roughly 1.0s after the previous OR 1.0s before the
next (for N = 60 frames at a 60 Hz display rate). Call these ‘valid transitions’

We can't just use contiguous events because of noisy data, so like before we're looking for the start and end events. The main difference is that we allow the stream to start/end on either kind of edge (rising/falling). There was an issue with the last (valid) edge getting cut off when it ended on a rising edge, resulting in an error that set the delay to default. 

In addition to updating the unit tests, I've also run regression testing for the 138 experiments for which we have the computed monitor delay output.

Out of 138 experiments, there were 18 that had the default value for the delay=`0.0351`. Of the remaining 120, the monitor delay was computed exactly the same for 116. 
![Screen Shot 2020-03-20 at 2 00 23 PM](https://user-images.githubusercontent.com/34227334/77207327-558b3500-6ab6-11ea-8bf9-9e6cba7a6ded.png)


For the 4 experiments that returned different results, all were negligible differences:
![Screen Shot 2020-03-20 at 2 00 10 PM](https://user-images.githubusercontent.com/34227334/77207357-6471e780-6ab6-11ea-8f74-75c6120cd2aa.png)

The 18 experiments that previously returned the default value (due to code error) were computed with values in the expected range:
![Screen Shot 2020-03-20 at 2 00 17 PM](https://user-images.githubusercontent.com/34227334/77207400-7fdcf280-6ab6-11ea-9f10-a33f55246590.png)

Note that the job will no longer return a default value for the monitor delay. If a data issue is encountered it will throw an error instead.