### PR TITLE
ophys_sessions table does not always have imaging_depth_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Bug Fixes
-- experiment\_table from behavior project cache has NaNs in the 'imaging\_depth' column for MultiScope experiments due to incorrect join in behavior\_project\_lims\_api.py
+- experiment\_table from behavior project cache has NaNs in the 'imaging\_depth' column for MultiScope experiments due to incorrect join in behavior\_project\_lims\_api.py and 4 other places where ophys\_sessions was incorrectly queried for imaging\_depth\_id
 
 
 ## [1.6.0] = 2020-03-23

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -290,7 +290,7 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
                 LEFT JOIN ophys_sessions os ON oe.ophys_session_id = os.id
                 LEFT JOIN specimens sp ON sp.id=os.specimen_id
                 LEFT JOIN donors d ON d.id=sp.donor_id
-                LEFT JOIN imaging_depths id ON id.id=os.imaging_depth_id
+                LEFT JOIN imaging_depths id ON id.id=oe.imaging_depth_id
                 LEFT JOIN structures st ON st.id=oe.targeted_structure_id
                 LEFT JOIN equipment ON equipment.id=os.equipment_id
                 '''

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -104,7 +104,7 @@ class OphysLimsApi(CachedInstanceMethodMixin):
                 SELECT id.depth
                 FROM ophys_experiments oe
                 JOIN ophys_sessions os ON oe.ophys_session_id = os.id
-                LEFT JOIN imaging_depths id ON id.id=os.imaging_depth_id
+                LEFT JOIN imaging_depths id ON id.id=oe.imaging_depth_id
                 WHERE oe.id= {};
                 '''.format(self.get_ophys_experiment_id())
         return self.lims_db.fetchone(query, strict=True)

--- a/allensdk/internal/api/queries/pre_release_sql/cell_specimens_pre_release_query.sql
+++ b/allensdk/internal/api/queries/pre_release_sql/cell_specimens_pre_release_query.sql
@@ -37,7 +37,7 @@ JOIN experiment_containers ec ON ec.id=exa.experiment_container_id AND ec.id=exb
 
 JOIN donors d ON d.id=sp.donor_id 
 JOIN ophys_experiments o ON o.id=exa.ophys_experiment_id 
-JOIN ophys_sessions os ON os.id=o.ophys_session_id JOIN imaging_depths ON imaging_depths.id=os.imaging_depth_id
+JOIN ophys_sessions os ON os.id=o.ophys_session_id JOIN imaging_depths ON imaging_depths.id=o.imaging_depth_id
 JOIN projects p ON p.id=os.project_id
 JOIN structures st ON st.id=os.targeted_structure_id
 JOIN donors_genotypes dgd ON dgd.donor_id=d.id JOIN genotypes tld1 ON tld1.id = dgd.genotype_id AND tld1.genotype_type_id = 177835595 AND tld1.name != 'Camk2a-tTA' --driver1 

--- a/allensdk/internal/api/queries/pre_release_sql/experiment_pre_release_query.sql
+++ b/allensdk/internal/api/queries/pre_release_sql/experiment_pre_release_query.sql
@@ -21,7 +21,7 @@ LEFT JOIN eye_trackings et on et.id = os.eye_tracking_id
 LEFT JOIN well_known_files awkf ON awkf.attachable_id=o.id AND awkf.well_known_file_type_id = 514173041
 --514173063 NWBOphys
 JOIN well_known_files wkf ON wkf.attachable_id=o.id AND wkf.well_known_file_type_id = 514173063
-JOIN specimens sp ON sp.id=os.specimen_id JOIN structures st ON st.id=os.targeted_structure_id JOIN imaging_depths i ON i.id=os.imaging_depth_id
+JOIN specimens sp ON sp.id=os.specimen_id JOIN structures st ON st.id=os.targeted_structure_id JOIN imaging_depths i ON i.id=o.imaging_depth_id
 JOIN donors d ON d.id=sp.donor_id 
 JOIN donors_genotypes dg  ON  dg.donor_id=d.id JOIN genotypes g  ON g.id = dg.genotype_id AND  g.genotype_type_id = 177835595 AND g.name != 'Camk2a-tTA' --driver
 JOIN donors_genotypes dgr ON dgr.donor_id=d.id JOIN genotypes gr ON gr.id=dgr.genotype_id AND gr.genotype_type_id = 177835597 --reporter


### PR DESCRIPTION
fixes 4 places where ophys_sessions table was incorrectly being queried for imaging_depth_id
from Marina:
```
they are not mistakes, per se, because getting imaging_depth from the session works
for Scientifica datasets, which has been our main focus so far. But it does not work for
Mesoscope datasets, which we are starting to work on more now, which is how I found
the problem.
```
these are additional occurrences found from #1448, the first of which was covered in #1452 