### PR TITLE
#1461 Demixing modified to allow image stack to be loaded in blocks

### DIFF
--- a/allensdk/internal/brain_observatory/demixer.py
+++ b/allensdk/internal/brain_observatory/demixer.py
@@ -29,20 +29,18 @@ def identify_valid_masks(mask_array):
     return valid_masks
 
 
-def demix_time_dep_masks(raw_traces, stack, masks):
+def demix_time_dep_masks(raw_traces, stack, masks, block_size=1000):
     '''
 
     :param raw_traces: extracted traces
     :param stack: movie (same length as traces)
     :param masks: binary roi masks
+    :param block_size: number of movie frames to read at a time
     :return: demixed traces
     '''
     N, T = raw_traces.shape
     _, x, y = masks.shape
     P = x * y
-
-    if len(stack.shape) == 3:
-        stack = stack.reshape(T, P)
 
     num_pixels_in_mask = np.sum(masks, axis=(1, 2))
     F = raw_traces.T * num_pixels_in_mask  # shape (T,N)
@@ -59,9 +57,14 @@ def demix_time_dep_masks(raw_traces, stack, masks):
         weighted_mask_sum = F[:, t]
         drop_test = (weighted_mask_sum == 0)
 
+        block_t = t % block_size
+        if block_t == 0: # load next block into memory
+            block_T = np.min([(T - t), block_size])
+            stack_block = stack[t: t + block_size].reshape(block_T, P)
+
         if np.sum(drop_test == 0):
             norm_mat = sparse.diags(num_pixels_in_mask / weighted_mask_sum, offsets=0)
-            stack_t = sparse.diags(stack[t], offsets=0)
+            stack_t = sparse.diags(stack_block[block_t], offsets=0)
 
             flat_weighted_masks = norm_mat.dot(flat_masks.dot(stack_t))
 


### PR DESCRIPTION
**Changes**
`demix_time_dep_masks()` in both `allensdk.brain_observatory.demixer` and `allensdk.internal.brain_observatory.demixer` modified by adding an optional `block_size` argument. `stack` can then be passed as an hdf5 handle and loaded into memory and reshaped in blocks. The previous behaviour of passing the h5 stack data array still works.

**Concern**
In the case of `roi_masks.calculate_traces()`, the **h5 stack file path** is passed instead of an hdf5 handle or the pre-loaded stack. Thus the function itself ensures that the stack file is **opened safely within a context manager.** This would be a more substantial change to the code, as it changes the allowed types for the `stack` argument, but I could modify my pull request so that `demix_time_dep_masks()` necessarily takes an h5 stack file path and handles the file reading context. 

**Impact**
The only function in the repo that calls `demix_time_dep_masks()` currently is `allensdk.internal.pipeline_modules.run_demixing.py` which preloads the h5 stack for this function only. I could easily modify it to pass the **h5 stack file path** instead of preloading the stack.

Please do let me know what the preferred procedure is.