### PR TITLE
Add additional possible sync file line label keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Internal users can now access `eye_tracking` ellipse fit data from behavior + ophys Session objects
 - A new mixin for managing processing parameters for Session objects
+- Added support for additional sync file line labels
 
 ### Changed
 - Monitor delay calculation is updated to properly handle photodiode streams that end

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -89,12 +89,30 @@ class Dataset(object):
     FRAME_KEYS = ('frames', 'stim_vsync')
     PHOTODIODE_KEYS = ('photodiode', 'stim_photodiode')
     OPTOGENETIC_STIMULATION_KEYS = ("LED_sync", "opto_trial")
-    EYE_TRACKING_KEYS = ("cam2_exposure",  # clocks eye tracking frame pulses (port 0, line 9)
-                         "eyetracking")  # previous line label for eye tracking (prior to ~ Oct. 2018)
-    BEHAVIOR_TRACKING_KEYS = ("cam1_exposure",)  # clocks behavior tracking frame pulses (port 0, line 8)
+    EYE_TRACKING_KEYS = ("eye_frame_received",  # Expected eye tracking line label after 3/27/2020
+                         "cam2_exposure",  # clocks eye tracking frame pulses (port 0, line 9)
+                         "eyetracking",  # previous line label for eye tracking (prior to ~ Oct. 2018)
+                         "eye_tracking")  # An undocumented, but possible eye tracking line label
+    BEHAVIOR_TRACKING_KEYS = ("beh_frame_received",  # Expected behavior line label after 3/27/2020
+                              "cam1_exposure",  # clocks behavior tracking frame pulses (port 0, line 8)
+                              "behavior_monitoring")
+
+    DEPRECATED_KEYS = {"cam2_exposure",
+                       "eyetracking",
+                       "eye_tracking",
+                       "cam1_exposure",
+                       "behavior_monitoring"}
 
     def __init__(self, path):
         self.dfile = self.load(path)
+        self._check_line_labels()
+
+    def _check_line_labels(self):
+        deprecated_keys = set(self.line_labels) & self.DEPRECATED_KEYS
+        if deprecated_keys:
+            logger.info(f"The loaded sync file contains uses the following "
+                        f"deprecated line label keys: {deprecated_keys}. "
+                        f"Consider updating the sync file line labels.")
 
     def _process_times(self):
         """

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -98,6 +98,7 @@ As of the 1.7.0 release:
 - Added functionality so internal users can now access `eye_tracking` ellipse fit data from behavior + ophys Session objects
 - Added a new mixin for managing processing parameters for Session objects
 - Update the monitor delay calculation to better handle edge cases; no longer provide a default delay value if encounter an error
+- Added support for additional sync file line labels
 
 What's New - 1.6.0 (March 23, 2020)
 -----------------------------------------------------------------------


### PR DESCRIPTION
This commits adds additional sync file line label keys
to the tuple of possible keys for accessing 1) eye tracking and
2) behavior camera frame time information.

Eye tracking camera line labels added:

- eye_tracking: A previously undocumented line label

- eye_cam_frame_acq: The future (after ~ April 2020) intended
  line label key for accessing eye tracking camera frame time information.

Behavior camera line labels added:

- behavior_monitoring: A previously undocumented line label

- beh_cam_frame_acq: The future (after ~ April 2020) intended
  line label key for accessing behavior camera frame time
  information.

This commit also adds some simple logging to check if a loaded
sync file contains keys which are not the future intended ones.