### PR TITLE
dont-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Allen SDK
 
+dont merge this
+
 [![Join the chat at https://gitter.im/AllenInstitute/AllenSDK](https://badges.gitter.im/AllenInstitute/AllenSDK.svg)](https://gitter.im/AllenInstitute/AllenSDK?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Documentation Status](https://readthedocs.org/projects/allensdk/badge/?version=latest)](https://allensdk.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
checking whether readthedocs pr builds work despite https://github.com/readthedocs/readthedocs.org/issues/6686 on a repo where the original importer is no longer a maintainer.