### PR TITLE
Change ecephys optotagging table "name" column to "stimulus_name"

### DIFF
--- a/allensdk/brain_observatory/ecephys/optotagging_table/__main__.py
+++ b/allensdk/brain_observatory/ecephys/optotagging_table/__main__.py
@@ -21,11 +21,11 @@ def build_opto_table(args):
         raise ValueError(f"there are {len(start_times) - len(conditions)} extra optotagging sync times!")
 
     optotagging_table = pd.DataFrame({
-        'start_time':start_times,
+        'start_time': start_times,
         'condition': conditions,
         'level': levels
     })
-    optotagging_table = optotagging_table.sort_values(by='start_time', axis=0)    
+    optotagging_table = optotagging_table.sort_values(by='start_time', axis=0)
 
     stop_times = []
     names = []
@@ -37,7 +37,7 @@ def build_opto_table(args):
         conditions.append(condition["condition"])
 
     optotagging_table["stop_time"] = stop_times
-    optotagging_table["name"] = names
+    optotagging_table["stimulus_name"] = names
     optotagging_table["condition"] = conditions
     optotagging_table["duration"] = optotagging_table["stop_time"] - optotagging_table["start_time"]
 
@@ -56,7 +56,6 @@ def main():
     else:
         print(mod.get_output_json(output))
 
-    
+
 if __name__ == "__main__":
     main()
-

--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -745,6 +745,11 @@ def add_probewise_data_to_nwbfile(nwbfile, probes):
 
 
 def add_optotagging_table_to_nwbfile(nwbfile, optotagging_table, tag="optical_stimulation"):
+    # "name" is a pynwb reserved column name that older versions of the
+    # pre-processed optotagging_table may use.
+    if "name" in optotagging_table.columns:
+        optotagging_table = optotagging_table.rename(columns={"name": "stimulus_name"})
+
     opto_ts = pynwb.base.TimeSeries(
         name="optotagging",
         timestamps=optotagging_table["start_time"].values,


### PR DESCRIPTION
Due to newer versions of pynwb reserving "name" for its dynamic tables, an error
occurs when writing the ecephys optotagging table to nwb.

This commit changes the optotagging table "name" column
to "stimulus_name".

Relates to: #1476