### PR TITLE
Gh 1513/bugfix/ophys time aligner sync keys

### DIFF
--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -22,8 +22,8 @@ MAX_MONITOR_DELAY = 0.07     # seconds
 def get_keys(sync_dset: Dataset) -> dict:
     """
     Gets the correct keys for the sync file by searching the sync file
-    line labels. Assumes to use old keys if none of the correct ones are
-    found in line labels
+    line labels. Removes key from the dictionary if it is not in the
+    sync dataset line labels.
     Args:
         sync_dset: The sync dataset to search for keys within
 

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -31,6 +31,10 @@ def get_keys(sync_dset: Dataset) -> dict:
         key_dict: dictionary of key value pairs for finding data in the
                   sync file
     """
+
+    # key_dict contains key value pairs where key is expected label category
+    # and value is the possible data for each category existing in sync dataset
+    # line labels
     key_dict = {
             "photodiode": ["stim_photodiode", "photodiode"],
             "2p": ["2p_vsync"],
@@ -45,13 +49,12 @@ def get_keys(sync_dset: Dataset) -> dict:
     label_set = set(sync_dset.line_labels)
     remove_keys = []
     for key, value in key_dict.items():
-        if isinstance(value, list):
-            value_set = set(value)
-            diff = value_set.intersection(label_set)
-            if len(diff) == 1:
-                key_dict[key] = diff.pop()
-            else:
-                remove_keys.append(key)
+        value_set = set(value)
+        diff = value_set.intersection(label_set)
+        if len(diff) == 1:
+            key_dict[key] = diff.pop()
+        else:
+            remove_keys.append(key)
     if len(remove_keys) > 0:
         logging.warning("Could not find valid lines for the following data "
                         "sources")

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -1,5 +1,6 @@
 from collections import deque
-from typing import Optional, Callable, Any
+from typing import Optional, Callable, Any, List, Dict, Set
+from sets import Set
 
 import numpy as np
 import h5py
@@ -19,7 +20,7 @@ LONG_STIM_THRESHOLD = 0.2     # seconds
 MAX_MONITOR_DELAY = 0.07     # seconds
 
 VERSION_1_KEYS = {
-    "photodiode": "stim_photodiode",
+    "photodiode": "photodiode",
     "2p": "2p_vsync",
     "stimulus": "stim_vsync",
     "eye_camera": "cam2_exposure",
@@ -39,6 +40,32 @@ VERSION_2_KEYS = {
     "lick_sensor": "lick_sensor"
     }
 
+POSSIBLE_KEY_PAIRS = {
+        "photodiode": Set("stim_photodiode", "photodiode"),
+        "eye_camera": Set("cam2_exposure", "eye_tracking"),
+        "behavior_camera": Set("cam1_exposure", "behavior_monitoring"),
+        "lick_sensor": Set("lick_1", "lick_sensor")
+        }
+
+def validate_keys(key_set: Set, dictionary_with_keys: Dict):
+"""
+Validates that all values in the dictionary_with_keys are present in
+the list.
+
+Args:
+    key_set: Set of key values
+    dictionary_with_keys: Dictionary where values should be contained in key_list
+
+Returns:
+    non_matches: returns a list of values not found in the key_set but present in
+                 dictionary
+"""
+    return_keys = []
+    for key, value in dictonary_with_keys:
+        if not key in key_set:
+            return_keys.append(key)
+    return return_keys
+
 
 def get_keys(sync_dset):
     """Get the correct lookup for line labels.
@@ -46,9 +73,30 @@ def get_keys(sync_dset):
     This method is fragile, but not all old data contains the full list
     of keys.
     """
-    if "cam2_exposure" in sync_dset.line_labels:
-        return VERSION_1_KEYS
-    return VERSION_2_KEYS
+    key_dict = {
+            "photodiode": None,
+            "2p": "2p_vsync",
+            "stimulus": "stim_vsync",
+            "eye_camera": None,
+            "behavior_camera": None,
+            "acquiring": "2p_acquiring",
+            "lick_sensor": None
+            }
+    for key, value in POSSIBLE_KEY_PAIRS.items():
+        if value[0] in sync_dset.line_labels:
+            key_dict[key] = value[0]
+        elif value[1] in sync_dset.line_labels:
+            key_dict[key] = value[1]
+        else:
+            logging.warning(f"No key found in sync dataset line labels for key: {key}."
+                             "Assuming old dataset and defaulting to older key option")
+            key_dict[key] = value[0]
+    line_label_set = Set(sync_dset.line_labels)
+    non_found_keys = validate_keys(line_label_set, key_dict)
+    if len(non_found_keys) > 0:
+        logging.warning(f"Keys not found in sync dataset line labels, assuming"
+                         "old file and not all keys are present. Keys not found: {non_found_keys}")
+    return key_dict
 
 
 def monitor_delay(sync_dset, stim_times, photodiode_key,

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -30,7 +30,7 @@ VERSION_1_KEYS = {
 
 # MPE is changing keys. This isn't versioned in the file.
 VERSION_2_KEYS = {
-    "photodiode": "photodiode",
+    "photodiode": "stim_photodiode",
     "2p": "2p_vsync",
     "stimulus": "stim_vsync",
     "eye_camera": "eye_tracking",

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -33,7 +33,7 @@ def get_keys(sync_dset: Dataset) -> dict:
     """
     key_dict = {
             "photodiode": ["stim_photodiode", "photodiode"],
-            "2p": "2p_vsync",
+            "2p": ["2p_vsync"],
             "stimulus": ["stim_vsync", "vsync_stim"],
             "eye_camera": ["cam2_exposure", "eye_tracking",
                            "eye_frame_received"],
@@ -43,6 +43,7 @@ def get_keys(sync_dset: Dataset) -> dict:
             "lick_sensor": ["lick_1", "lick_sensor"]
             }
     label_set = set(sync_dset.line_labels)
+    remove_keys = []
     for key, value in key_dict.items():
         if isinstance(value, list):
             value_set = set(value)
@@ -50,10 +51,11 @@ def get_keys(sync_dset: Dataset) -> dict:
             if len(diff) == 1:
                 key_dict[key] = diff.pop()
             else:
-                key_dict[key] = value[0]
-                logging.warning("No key found in sync dataset line labels for "
-                                f"key: {key}. Assuming old dataset and"
-                                " defaulting to older key option")
+                logging.warning(f"Value not found for key {key}. Deleting"
+                                " key and value from dictionary")
+                remove_keys.append(key)
+    for key in remove_keys:
+        key_dict.pop(key)
     line_label_set = set(sync_dset.line_labels)
     non_found_keys = set(list(key_dict.values())) - line_label_set
     if len(non_found_keys) > 0:

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -39,7 +39,7 @@ def get_keys(sync_dset: Dataset) -> dict:
                            "eye_frame_received"],
             "behavior_camera": ["cam1_exposure", "behavior_monitoring",
                                 "beh_frame_received"],
-            "acquiring": "2p_acquiring",
+            "acquiring": ["2p_acquiring"],
             "lick_sensor": ["lick_1", "lick_sensor"]
             }
     label_set = set(sync_dset.line_labels)
@@ -51,17 +51,13 @@ def get_keys(sync_dset: Dataset) -> dict:
             if len(diff) == 1:
                 key_dict[key] = diff.pop()
             else:
-                logging.warning(f"Value not found for key {key}. Deleting"
-                                " key and value from dictionary")
                 remove_keys.append(key)
-    for key in remove_keys:
-        key_dict.pop(key)
-    line_label_set = set(sync_dset.line_labels)
-    non_found_keys = set(list(key_dict.values())) - line_label_set
-    if len(non_found_keys) > 0:
-        logging.warning("Keys not found in sync dataset line labels, assuming"
-                        " old file and not all keys are present. Keys not "
-                        f"found: {non_found_keys}")
+    if len(remove_keys) > 0:
+        logging.warning("Could not find valid lines for the following data "
+                        "sources")
+        for key in remove_keys:
+            logging.warning(f"{key} (valid line label(s) = {key_dict[key]}")
+            key_dict.pop(key)
     return key_dict
 
 

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -1,6 +1,5 @@
 from collections import deque
 from typing import Optional, Callable, Any, List, Dict, Set
-from sets import Set
 
 import numpy as np
 import h5py
@@ -41,28 +40,30 @@ VERSION_2_KEYS = {
     }
 
 POSSIBLE_KEY_PAIRS = {
-        "photodiode": Set("stim_photodiode", "photodiode"),
-        "eye_camera": Set("cam2_exposure", "eye_tracking"),
-        "behavior_camera": Set("cam1_exposure", "behavior_monitoring"),
-        "lick_sensor": Set("lick_1", "lick_sensor")
+        "photodiode": ("stim_photodiode", "photodiode"),
+        "eye_camera": ("cam2_exposure", "eye_tracking"),
+        "behavior_camera": ("cam1_exposure", "behavior_monitoring"),
+        "lick_sensor": ("lick_1", "lick_sensor")
         }
 
+
 def validate_keys(key_set: Set, dictionary_with_keys: Dict):
-"""
-Validates that all values in the dictionary_with_keys are present in
-the list.
+    """
+    Validates that all values in the dictionary_with_keys are present in
+    the list.
 
-Args:
-    key_set: Set of key values
-    dictionary_with_keys: Dictionary where values should be contained in key_list
+    Args:
+        key_set: Set of key values
+        dictionary_with_keys: Dictionary where values should be contained in
+                              key_list
 
-Returns:
-    non_matches: returns a list of values not found in the key_set but present in
-                 dictionary
-"""
+    Returns:
+        non_matches: returns a list of values not found in the key_set but
+                    present in dictionary
+    """
     return_keys = []
-    for key, value in dictonary_with_keys:
-        if not key in key_set:
+    for key, value in dictionary_with_keys.items():
+        if key not in key_set:
             return_keys.append(key)
     return return_keys
 
@@ -88,14 +89,16 @@ def get_keys(sync_dset):
         elif value[1] in sync_dset.line_labels:
             key_dict[key] = value[1]
         else:
-            logging.warning(f"No key found in sync dataset line labels for key: {key}."
-                             "Assuming old dataset and defaulting to older key option")
+            logging.warning(f"No key found in sync dataset line labels for key:"
+                            f" {key}.Assuming old dataset and defaulting to "
+                            f"older key option")
             key_dict[key] = value[0]
-    line_label_set = Set(sync_dset.line_labels)
+    line_label_set = set(sync_dset.line_labels)
     non_found_keys = validate_keys(line_label_set, key_dict)
     if len(non_found_keys) > 0:
         logging.warning(f"Keys not found in sync dataset line labels, assuming"
-                         "old file and not all keys are present. Keys not found: {non_found_keys}")
+                        "old file and not all keys are present. Keys not "
+                        "found: {non_found_keys}")
     return key_dict
 
 

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -18,6 +18,7 @@ PHOTODIODE_ANOMALY_THRESHOLD = 0.5     # seconds
 LONG_STIM_THRESHOLD = 0.2     # seconds
 MAX_MONITOR_DELAY = 0.07     # seconds
 
+
 def get_keys(sync_dset: Dataset) -> dict:
     """
     Gets the correct keys for the sync file by searching the sync file
@@ -33,9 +34,11 @@ def get_keys(sync_dset: Dataset) -> dict:
     key_dict = {
             "photodiode": ["stim_photodiode", "photodiode"],
             "2p": "2p_vsync",
-            "stimulus": "stim_vsync",
-            "eye_camera": ["cam2_exposure", "eye_tracking"],
-            "behavior_camera": ["cam1_exposure", "behavior_monitoring"],
+            "stimulus": ["stim_vsync", "vsync_stim"],
+            "eye_camera": ["cam2_exposure", "eye_tracking",
+                           "eye_frame_received"],
+            "behavior_camera": ["cam1_exposure", "behavior_monitoring",
+                                "beh_frame_received"],
             "acquiring": "2p_acquiring",
             "lick_sensor": ["lick_1", "lick_sensor"]
             }

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -1,9 +1,5 @@
 from collections import deque
-<<<<<<< HEAD
-from typing import Optional, Callable, Any, List, Dict, Set
-=======
 from typing import Optional, Callable, Any, Dict, Set
->>>>>>> fbe861ba41389e519d4a7eb7e71ac4dbf846c10c
 
 import numpy as np
 import h5py
@@ -40,17 +36,15 @@ def get_keys(sync_dset):
     label_set = set(sync_dset.line_labels)
     for key, value in key_dict.items():
         if isinstance(value, list):
-            diff = label_set - set(value)
-            print(diff)
-            if value[1] in label_set:
-                key_dict[key] = value[1]
-            elif value[0] in label_set:
-                key_dict[key] = value[0]
+            value_set = set(value)
+            diff = value_set - (label_set - value_set)
+            if len(diff) == 1:
+                key_dict[key] = diff[0]
             else:
-                logging.warning("No key found in sync dataset line labels for "
-                                "key: {key}.Assuming old dataset and defaulting"
-                                " to older key option")
                 key_dict[key] = value[0]
+                logging.warning("No key found in sync dataset line labels for "
+                                f"key: {key}.Assuming old dataset and defaulting"
+                                " to older key option")
     line_label_set = set(sync_dset.line_labels)
     non_found_keys = line_label_set - set(list(key_dict.values()))
     if len(non_found_keys) > 0:

--- a/allensdk/test/internal/brain_observatory/test_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_time_sync.py
@@ -547,125 +547,135 @@ def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
     assert obtained == expected
 
 
-@pytest.mark.parametrize("sync_dset, line_labels, expected_line_labels", [
-    (None, ['2p_vsync', 'stim_vsync', 'stim_photodiode', 'acq_trigger',
-            '', 'cam1_exposure', 'cam2_exposure', 'lick_sensor'],
-     {
-         "photodiode": "stim_photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "cam2_exposure",
-         "behavior_camera": "cam1_exposure",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_sensor"
-     }),
-    (None, ['2p_vsync', 'stim_vsync', 'photodiode', 'acq_trigger',
-            '', 'behavior_monitoring', 'eye_tracking', 'lick_1'],
-     {
-         "photodiode": "photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "eye_tracking",
-         "behavior_camera": "behavior_monitoring",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, ['2p_vsync', 'stim_vsync', 'photodiode', 'acq_trigger',
-            '', 'behavior_monitoring', 'lick_1'],
-     {
-         "photodiode": "photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "cam2_exposure",
-         "behavior_camera": "behavior_monitoring",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, ['2p_vsync', '', 'stim_vsync', '', 'photodiode', 'acq_trigger',
-            '', '', 'eye_tracking', 'lick_1'],
-     {
-         "photodiode": "photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "eye_tracking",
-         "behavior_camera": "cam1_exposure",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, ['2p_vsync', 'stim_vsync', 'stim_photodiode', 'acq_trigger',
-            '', 'cam1_exposure', 'cam2_exposure'],
-     {
-         "photodiode": "stim_photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "cam2_exposure",
-         "behavior_camera": "cam1_exposure",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, [],
-     {
-         "photodiode": "stim_photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "cam2_exposure",
-         "behavior_camera": "cam1_exposure",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, ['', 'stim_vsync', 'photodiode', 'acq_trigger', 'eye_tracking',
-            'lick_1'],
-     {
-         "photodiode": "photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "eye_tracking",
-         "behavior_camera": "cam1_exposure",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, ['', '2p_vsync', 'photodiode', 'acq_trigger', 'eye_tracking',
-            'lick_1'],
-     {
-         "photodiode": "photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "stim_vsync",
-         "eye_camera": "eye_tracking",
-         "behavior_camera": "cam1_exposure",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_1"
-     }),
-    (None, ['barcode_ephys', 'vsync_stim', 'stim_photodiode', 'stim_running',
-            'beh_frame_received', 'eye_frame_received', 'face_frame_received',
-            'stim_running_opto', 'stim_trial_opto', 'face_came_frame_readout',
-            'eye_cam_frame_readout', 'beh_cam_frame_readout',
-            'face_cam_exposing', 'eye_cam_exposing', 'beh_cam_exposing',
-            'lick_sensor'],
-     {
-         "photodiode": "stim_photodiode",
-         "2p": "2p_vsync",
-         "stimulus": "vsync_stim",
-         "eye_camera": "eye_frame_received",
-         "behavior_camera": "beh_frame_received",
-         "acquiring": "2p_acquiring",
-         "lick_sensor": "lick_sensor"
-     })
+@pytest.mark.parametrize("sync_dset, line_labels, expected_line_labels,"
+                         "expected_log",
+                         [(None, ['2p_vsync', 'stim_vsync', 'stim_photodiode',
+                                  'acq_trigger', '', 'cam1_exposure',
+                                  'cam2_exposure', 'lick_sensor'],
+                          {
+                            "photodiode": "stim_photodiode",
+                            "2p": "2p_vsync",
+                            "stimulus": "stim_vsync",
+                            "eye_camera": "cam2_exposure",
+                            "behavior_camera": "cam1_exposure",
+                            "acquiring": "2p_acquiring",
+                            "lick_sensor": "lick_sensor"},
+                           [('root', 30,
+                             'Keys not found in sync dataset line labels,'
+                             ' assuming old file and not all keys are present. '
+                             "Keys not found: {'2p_acquiring'}")]),
+                          (None, ['2p_vsync', 'stim_vsync', 'photodiode',
+                                  'acq_trigger', 'behavior_monitoring',
+                                  'eye_tracking', 'lick_1'],
+                          {
+                            "photodiode": "photodiode",
+                            "2p": "2p_vsync",
+                            "stimulus": "stim_vsync",
+                            "eye_camera": "eye_tracking",
+                            "behavior_camera": "behavior_monitoring",
+                            "acquiring": "2p_acquiring",
+                            "lick_sensor": "lick_1"},
+                           [('root', 30,
+                             'Keys not found in sync dataset line labels,'
+                             ' assuming old file and not all keys are present. '
+                             "Keys not found: {'2p_acquiring'}")]),
+                          (None, ['2p_vsync', 'stim_vsync', 'photodiode',
+                                  'acq_trigger', '', 'behavior_monitoring', 'lick_1'],
+                          {
+                            "photodiode": "photodiode",
+                            "2p": "2p_vsync",
+                            "stimulus": "stim_vsync",
+                            "behavior_camera": "behavior_monitoring",
+                            "acquiring": "2p_acquiring",
+                            "lick_sensor": "lick_1"},
+                           [('root', 30,
+                             'Value not found for key eye_camera. Deleting key '
+                             'and value from dictionary'),
+                            ('root', 30,
+                             'Keys not found in sync dataset line labels, '
+                             'assuming old file and not all keys are present. '
+                             "Keys not found: {'2p_acquiring'}")]),
+                          (None, [],
+                          {
+                            "acquiring": "2p_acquiring"},
+                           [('root', 30,
+                             'Value not found for key photodiode.'
+                             ' Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Value not found for key 2p. '
+                             'Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Value not found for key stimulus. '
+                             'Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Value not found for key eye_camera. '
+                             'Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Value not found for key behavior_camera. '
+                             'Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Value not found for key lick_sensor. '
+                             'Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Keys not found in sync dataset line labels,'
+                             ' assuming old file and not all keys are present. '
+                             "Keys not found: {'2p_acquiring'}")]),
+                          (None, ['', 'stim_vsync', 'photodiode', 'acq_trigger',
+                                  'eye_tracking', 'lick_1', 'acq_trigger',
+                                  'cam1_exposure'],
+                          {
+                            "photodiode": "photodiode",
+                            "stimulus": "stim_vsync",
+                            "eye_camera": "eye_tracking",
+                            "behavior_camera": "cam1_exposure",
+                            "acquiring": "2p_acquiring",
+                            "lick_sensor": "lick_1"},
+                           [('root', 30,
+                             'Value not found for key 2p. '
+                             'Deleting key and value from dictionary'),
+                           ('root', 30,
+                            'Keys not found in sync dataset line labels, '
+                            'assuming old file and not all keys are present. '
+                            "Keys not found: {'2p_acquiring'}")]),
+                          (None, ['barcode_ephys', 'vsync_stim',
+                                  'stim_photodiode', 'stim_running',
+                                  'beh_frame_received', 'eye_frame_received',
+                                  'face_frame_received', 'stim_running_opto',
+                                  'stim_trial_opto', 'face_came_frame_readout',
+                                  'eye_cam_frame_readout',
+                                  'beh_cam_frame_readout', 'face_cam_exposing',
+                                  'eye_cam_exposing', 'beh_cam_exposing',
+                                  'lick_sensor'],
+                          {
+                            "photodiode": "stim_photodiode",
+                            "stimulus": "vsync_stim",
+                            "eye_camera": "eye_frame_received",
+                            "behavior_camera": "beh_frame_received",
+                            "acquiring": "2p_acquiring",
+                            "lick_sensor": "lick_sensor"},
+                           [('root', 30,
+                             'Value not found for key 2p. '
+                             'Deleting key and value from dictionary'),
+                            ('root', 30,
+                             'Keys not found in sync dataset line labels, '
+                             'assuming old file and not all keys are present. '
+                             "Keys not found: {'2p_acquiring'}")])
 ])
-def test_get_keys(sync_dset, line_labels, expected_line_labels):
+def test_get_keys(sync_dset, line_labels, expected_line_labels, expected_log,
+                  caplog):
     """
     Test Cases:
-        1) Test Case from Wayne running a job on this branch,
-           simple case with all keys present
-        2) Test Case with alternate key set
+        1) Test Case with V2 keys
+        2) Test Case with V1 keys
         3) Test Case with eye camera key missing
-        4) Test Case with behavior camera key missing
-        5) Test Case with lick sensor key missing
-        6) Test Case with all keys missing
-        7) Test Case with 2p key missing
-        8) Test Case with stimulus key missing
-        9) Test Case with V3 keys
+        4) Test Case with all keys missing
+        5) Test Case with 2p key missing
+        6) Test Case with V3 keys
 
     """
     ds = MockSyncDataset(None, line_labels)
     keys = ts.get_keys(ds)
     assert keys == expected_line_labels
+    assert caplog.record_tuples == expected_log
+
+

--- a/allensdk/test/internal/brain_observatory/test_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_time_sync.py
@@ -634,6 +634,21 @@ def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
          "behavior_camera": "cam1_exposure",
          "acquiring": "2p_acquiring",
          "lick_sensor": "lick_1"
+     }),
+    (None, ['barcode_ephys', 'vsync_stim', 'stim_photodiode', 'stim_running',
+            'beh_frame_received', 'eye_frame_received', 'face_frame_received',
+            'stim_running_opto', 'stim_trial_opto', 'face_came_frame_readout',
+            'eye_cam_frame_readout', 'beh_cam_frame_readout',
+            'face_cam_exposing', 'eye_cam_exposing', 'beh_cam_exposing',
+            'lick_sensor'],
+     {
+         "photodiode": "stim_photodiode",
+         "2p": "2p_vsync",
+         "stimulus": "vsync_stim",
+         "eye_camera": "eye_frame_received",
+         "behavior_camera": "beh_frame_received",
+         "acquiring": "2p_acquiring",
+         "lick_sensor": "lick_sensor"
      })
 ])
 def test_get_keys(sync_dset, line_labels, expected_line_labels):
@@ -648,6 +663,7 @@ def test_get_keys(sync_dset, line_labels, expected_line_labels):
         6) Test Case with all keys missing
         7) Test Case with 2p key missing
         8) Test Case with stimulus key missing
+        9) Test Case with V3 keys
 
     """
     ds = MockSyncDataset(None, line_labels)

--- a/allensdk/test/internal/brain_observatory/test_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_time_sync.py
@@ -558,12 +558,11 @@ def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
                             "stimulus": "stim_vsync",
                             "eye_camera": "cam2_exposure",
                             "behavior_camera": "cam1_exposure",
-                            "acquiring": "2p_acquiring",
                             "lick_sensor": "lick_sensor"},
-                           [('root', 30,
-                             'Keys not found in sync dataset line labels,'
-                             ' assuming old file and not all keys are present. '
-                             "Keys not found: {'2p_acquiring'}")]),
+                           [('root', 30, 'Could not find valid lines for the '
+                                         'following data sources'),
+                            ('root', 30, "acquiring (valid line label(s) = "
+                                         "['2p_acquiring']")]),
                           (None, ['2p_vsync', 'stim_vsync', 'photodiode',
                                   'acq_trigger', 'behavior_monitoring',
                                   'eye_tracking', 'lick_1'],
@@ -573,53 +572,48 @@ def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
                             "stimulus": "stim_vsync",
                             "eye_camera": "eye_tracking",
                             "behavior_camera": "behavior_monitoring",
-                            "acquiring": "2p_acquiring",
                             "lick_sensor": "lick_1"},
-                           [('root', 30,
-                             'Keys not found in sync dataset line labels,'
-                             ' assuming old file and not all keys are present. '
-                             "Keys not found: {'2p_acquiring'}")]),
+                           [('root', 30, 'Could not find valid lines for the '
+                                         'following data sources'),
+                            ('root', 30, "acquiring (valid line label(s) = "
+                                         "['2p_acquiring']")]),
                           (None, ['2p_vsync', 'stim_vsync', 'photodiode',
-                                  'acq_trigger', '', 'behavior_monitoring', 'lick_1'],
+                                  'acq_trigger', '', 'behavior_monitoring',
+                                  'lick_1'],
                           {
                             "photodiode": "photodiode",
                             "2p": "2p_vsync",
                             "stimulus": "stim_vsync",
                             "behavior_camera": "behavior_monitoring",
-                            "acquiring": "2p_acquiring",
                             "lick_sensor": "lick_1"},
-                           [('root', 30,
-                             'Value not found for key eye_camera. Deleting key '
-                             'and value from dictionary'),
-                            ('root', 30,
-                             'Keys not found in sync dataset line labels, '
-                             'assuming old file and not all keys are present. '
-                             "Keys not found: {'2p_acquiring'}")]),
+                           [('root', 30, 'Could not find valid lines for the '
+                                         'following data sources'),
+                            ('root', 30, "eye_camera (valid line label(s) = "
+                                         "['cam2_exposure', 'eye_tracking', "
+                                         "'eye_frame_received']"),
+                            ('root', 30, "acquiring (valid line label(s) = "
+                                         "['2p_acquiring']")]),
                           (None, [],
-                          {
-                            "acquiring": "2p_acquiring"},
-                           [('root', 30,
-                             'Value not found for key photodiode.'
-                             ' Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Value not found for key 2p. '
-                             'Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Value not found for key stimulus. '
-                             'Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Value not found for key eye_camera. '
-                             'Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Value not found for key behavior_camera. '
-                             'Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Value not found for key lick_sensor. '
-                             'Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Keys not found in sync dataset line labels,'
-                             ' assuming old file and not all keys are present. '
-                             "Keys not found: {'2p_acquiring'}")]),
+                          {},
+                           [('root', 30, 'Could not find valid lines for the '
+                                         'following data sources'),
+                            ('root', 30, "photodiode (valid line label(s) = "
+                                          "['stim_photodiode', 'photodiode']"),
+                            ('root', 30, "2p (valid line label(s) = "
+                                          "['2p_vsync']"),
+                            ('root', 30, "stimulus (valid line label(s) = "
+                                          "['stim_vsync', 'vsync_stim']"),
+                            ('root', 30, "eye_camera (valid line label(s) = "
+                                          "['cam2_exposure', 'eye_tracking', "
+                                          "'eye_frame_received']"),
+                            ('root', 30, "behavior_camera (valid line label(s) "
+                                         "= ['cam1_exposure', "
+                                         "'behavior_monitoring', "
+                                         "'beh_frame_received']"),
+                            ('root', 30, "acquiring (valid line label(s) = "
+                                         "['2p_acquiring']"),
+                            ('root', 30, "lick_sensor (valid line label(s) = "
+                                         "['lick_1', 'lick_sensor']")]),
                           (None, ['', 'stim_vsync', 'photodiode', 'acq_trigger',
                                   'eye_tracking', 'lick_1', 'acq_trigger',
                                   'cam1_exposure'],
@@ -628,15 +622,13 @@ def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
                             "stimulus": "stim_vsync",
                             "eye_camera": "eye_tracking",
                             "behavior_camera": "cam1_exposure",
-                            "acquiring": "2p_acquiring",
                             "lick_sensor": "lick_1"},
-                           [('root', 30,
-                             'Value not found for key 2p. '
-                             'Deleting key and value from dictionary'),
-                           ('root', 30,
-                            'Keys not found in sync dataset line labels, '
-                            'assuming old file and not all keys are present. '
-                            "Keys not found: {'2p_acquiring'}")]),
+                           [('root', 30, 'Could not find valid lines for the '
+                                         'following data sources'),
+                            ('root', 30, "2p (valid line label(s) = "
+                                         "['2p_vsync']"),
+                            ('root', 30, "acquiring (valid line label(s) = "
+                                         "['2p_acquiring']")]),
                           (None, ['barcode_ephys', 'vsync_stim',
                                   'stim_photodiode', 'stim_running',
                                   'beh_frame_received', 'eye_frame_received',
@@ -651,15 +643,13 @@ def test_get_stim_data_length(monkeypatch, deserialized_pkl, expected):
                             "stimulus": "vsync_stim",
                             "eye_camera": "eye_frame_received",
                             "behavior_camera": "beh_frame_received",
-                            "acquiring": "2p_acquiring",
                             "lick_sensor": "lick_sensor"},
-                           [('root', 30,
-                             'Value not found for key 2p. '
-                             'Deleting key and value from dictionary'),
-                            ('root', 30,
-                             'Keys not found in sync dataset line labels, '
-                             'assuming old file and not all keys are present. '
-                             "Keys not found: {'2p_acquiring'}")])
+                           [('root', 30, 'Could not find valid lines for the '
+                                         'following data sources'),
+                            ('root', 30, "2p (valid line label(s) = "
+                                         "['2p_vsync']"),
+                            ('root', 30, "acquiring (valid line label(s) = "
+                                         "['2p_acquiring']")])
 ])
 def test_get_keys(sync_dset, line_labels, expected_line_labels, expected_log,
                   caplog):


### PR DESCRIPTION
This fixes the failing bamboo tests as we now search for keys in the sync dataset line labels. If the keys aren't present we assume the file is old and not all keys are present and use the older key value pair.