### PR TITLE
Updating Python and AllenSDK versions on the AllenSDK docker image

### DIFF
--- a/doc_template/install.rst
+++ b/doc_template/install.rst
@@ -71,9 +71,7 @@ example Dockerfiles are available.
 
  #. Ensure you have Docker installed.
 
- #. Use Docker to build one of the images.
- 
-     Anaconda::
+ #. Use Docker to build the image::
 
          docker pull alleninstitute/allensdk
  
@@ -81,12 +79,17 @@ example Dockerfiles are available.
  
  #. Run the docker image::
  
-     docker run -i -t -p 8888:8888 -v /data:/data alleninstitute/allensdk /bin/bash
+     docker run -i -t -p 8888:8888 alleninstitute/allensdk /bin/bash
+
+ #. Run the SDK tests::
+
      cd allensdk
      make test
  
  #. Start a Jupyter Notebook::
  
      cd allensdk/doc_template/examples_root/examples/nb
-     jupyter-notebook --ip=* --no-browser
+     jupyter notebook --ip=* --no-browser --allow-root
+
+     On your host machine, navigate to the path provided by the last command in your browser.
      

--- a/doc_template/install.rst
+++ b/doc_template/install.rst
@@ -91,5 +91,5 @@ example Dockerfiles are available.
      cd allensdk/doc_template/examples_root/examples/nb
      jupyter notebook --ip=* --no-browser --allow-root
 
-     On your host machine, navigate to the path provided by the last command in your browser.
+     Using the browser on your host machine, navigate to the path provided by the output from the jupyter notebook command.
      

--- a/doc_template/install.rst
+++ b/doc_template/install.rst
@@ -73,9 +73,9 @@ example Dockerfiles are available.
 
  #. Use Docker to build the image::
 
-         docker pull alleninstitute/allensdk
+     docker pull alleninstitute/allensdk
  
-     Other docker configurations are also available under docker directory in the source repository.
+    Other docker configurations are also available under docker directory in the source repository.
  
  #. Run the docker image::
  
@@ -91,5 +91,5 @@ example Dockerfiles are available.
      cd allensdk/doc_template/examples_root/examples/nb
      jupyter notebook --ip=* --no-browser --allow-root
 
-     Using the browser on your host machine, navigate to the path provided by the output from the jupyter notebook command.
+    Using the browser on your host machine, navigate to the path provided by the output from the jupyter notebook command.
      

--- a/docker/allensdk/Dockerfile
+++ b/docker/allensdk/Dockerfile
@@ -1,11 +1,29 @@
-# DOCKER-VERSION 1.11.1
+# DOCKER-VERSION 2.2.0.5
 #
 # docker build --tag alleninstitute/allensdk .
 # docker run -it alleninstitute/allensdk /bin/bash
 #
-FROM alleninstitute/anaconda_neuron_1370
+FROM continuumio/anaconda3
 
-MAINTAINER Tim Fliss <timf@alleninstitute.org>
+WORKDIR /root
 
-COPY . ./allensdk/
-RUN  pip install ./allensdk
+# Add AllenSDK and NEURON libraries
+RUN pip install -q allensdk neuron
+
+# Install NEURON
+RUN wget https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.x86_64-linux.deb; \
+	dpkg -i nrn-7.7.x86_64-linux.deb; \
+	apt-get install -yq \
+		make \
+		gcc \
+		build-essential \
+		libncurses5-dev \
+		libreadline-dev \
+		libx11-dev;
+
+# Setup example notebooks and python tests
+RUN wget https://github.com/AllenInstitute/AllenSDK/archive/rc/1.7.1.tar.gz; \
+	tar xvzf 1.7.1.tar.gz; \
+	mv AllenSDK-rc-1.7.1 allensdk; \
+	cd allensdk; \
+	pip install -r test_requirements.txt; \

--- a/docker/allensdk/Dockerfile
+++ b/docker/allensdk/Dockerfile
@@ -5,15 +5,19 @@
 #
 FROM continuumio/anaconda3
 
-WORKDIR /root
+LABEL maintainer="isaak.willett@alleninstitute.org"
+
+WORKDIR /usr/src/app
 
 # Add AllenSDK and NEURON libraries
-RUN pip install -q allensdk neuron
+RUN pip install allensdk neuron
+
 
 # Install NEURON
 RUN wget https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.x86_64-linux.deb; \
 	dpkg -i nrn-7.7.x86_64-linux.deb; \
-	apt-get install -yq \
+	apt-get update; \
+	apt-get install -y \
 		make \
 		gcc \
 		build-essential \
@@ -22,8 +26,8 @@ RUN wget https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.x86_64-linux.d
 		libx11-dev;
 
 # Setup example notebooks and python tests
-RUN wget https://github.com/AllenInstitute/AllenSDK/archive/rc/1.7.1.tar.gz; \
-	tar xvzf 1.7.1.tar.gz; \
-	mv AllenSDK-rc-1.7.1 allensdk; \
+RUN wget https://github.com/AllenInstitute/AllenSDK/archive/master.tar.gz; \
+	tar xvzf master.tar.gz; \
+	mv AllenSDK-master allensdk; \
 	cd allensdk; \
 	pip install -r test_requirements.txt; \


### PR DESCRIPTION
Updating the main AllenSDK docker image:
- Latest base image of anaconda3
- Python 3.7.6
- AllenSDK 1.7.0
- NEURON 7.7

To test:
- I built the docker image, cd into allensdk, and ran make test
- I ran several of the Jupyter notebooks and made sure their output was the same as my Mac running Python 3.7.6, AllenSDK 1.7.0, and NEURON 7.7.

<img width="1440" alt="Screen Shot 2020-05-19 at 3 39 25 AM" src="https://user-images.githubusercontent.com/11025905/82302848-23983100-9988-11ea-9bd4-8e2273e2f828.png">
<img width="1440" alt="Screen Shot 2020-05-19 at 3 51 36 AM" src="https://user-images.githubusercontent.com/11025905/82302849-23983100-9988-11ea-9331-612cb33d6a7f.png">
<img width="1440" alt="Screen Shot 2020-05-19 at 3 52 54 AM" src="https://user-images.githubusercontent.com/11025905/82302851-2430c780-9988-11ea-8f15-d5a935053c8f.png">
<img width="1440" alt="Screen Shot 2020-05-19 at 3 55 02 AM" src="https://user-images.githubusercontent.com/11025905/82302853-2430c780-9988-11ea-8f5e-515b6bb39f64.png">

Resolves: #1535 