### PR TITLE
Added pull request template to root directory of repo

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,35 @@
+# Overview:
+Give a brief overview of the issue you are solving. Succintly explain the GitHub issue you are addressin and the underlying problem of the ticket.
+
+# Addresses:
+Add a link to the issue on Github board
+
+# Type of Fix:
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Change
+
+# Solution:
+Outline your solution to the previously described issue and underlying cause. This section should include a brief description of your proposed solution and how it addresses the cause of the ticket.
+
+# Adds:
+Include a bulleted list or check box list of the implemented changes in brief, as well as the addition of supplementary materials(unit tests, integration tests, etc..)
+
+# Validation:
+Describe how you have validated that your solution addresses the root cause of the ticket. What have you done to ensure that your addition is bug free and works as expected. Please provide specific instructions so we can reproduce and list any relevant details about your configuration.
+- Screenshots
+- Unit Tests
+- Script to reproduce error
+- Configuration details
+
+# Checklist
+ - [ ] My code follows Google style guide
+ - [ ] My code is unit tested where appropriate and does not decrease test coverage
+ - [ ] I have performed a self review of my own code
+ - [ ] I have commented my code, specifically adding doc strings to any added functions
+ - [ ] I have updated the documentation of the repository where appropriate
+
+# Notes:
+Use this section to add anything you think worth mentioning to the reader of the ticket.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,35 +1,83 @@
+<!--Thank you for contributing to AllenSDK, your work and time will help to
+advance open science!-->
+
 # Overview:
-Give a brief overview of the issue you are solving. Succintly explain the GitHub issue you are addressin and the underlying problem of the ticket.
+<!-- Give a brief overview of the issue you are solving. Succinctly
+explain the GitHub issue you are addressing and the underlying problem
+of the ticket
+example: 
+Science team is not able to load max or avg projections for ophys
+session #blah. A ITK image cannot be created because input resolution is (0,0).
+It was found through investigation that LIMs was returning a 0 pixel resolution
+for this behavior session.-->
 
 # Addresses:
-Add a link to the issue on Github board
+<!-- Add a link to the issue on Github board
+example: 
+Addresses issue [#1234](git_hub_ticket_url)-->
 
 # Type of Fix:
-
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Breaking change (fix or feature that would cause existing
+      functionality to not work as expected)
 - [ ] Documentation Change
 
 # Solution:
-Outline your solution to the previously described issue and underlying cause. This section should include a brief description of your proposed solution and how it addresses the cause of the ticket.
+<!-- Outline your solution to the previously described issue and
+underlying cause. This section should include a brief description of
+your proposed solution and how it addresses the cause of the ticket
+example:
+Solution to this problem is to update the value of the pixel resolution to
+0.78125 (scientifica resolution) if pixel resolution is returned as 0. This 
+will address the underlying problem by providing a fallback value if the data
+is not available from LIMs to query. A downfall is if default resolution is disparate
+from actual resolution that wasn't saved, images might appear very distorted.
+An alternative solution is to update the LIMs db to have the correct data for 
+all microscope sessions.-->
 
 # Adds:
-Include a bulleted list or check box list of the implemented changes in brief, as well as the addition of supplementary materials(unit tests, integration tests, etc..)
+<!-- Include a bulleted list or check box list of the implemented changes
+in brief, as well as the addition of supplementary materials(unit tests,
+integration tests, etc
+example:
+- Check for 0 pixel resolution coming from LIMs
+- Assignment of default scientifica value of 0.78125 in case of zero return
+- Unit tests for the resolution gettr function to test for various edge cases
+-->
 
 # Validation:
-Describe how you have validated that your solution addresses the root cause of the ticket. What have you done to ensure that your addition is bug free and works as expected. Please provide specific instructions so we can reproduce and list any relevant details about your configuration.
-- Screenshots
-- Unit Tests
-- Script to reproduce error
-- Configuration details
+<!-- Describe how you have validated that your solution addresses the
+root cause of the ticket. What have you done to ensure that your
+addition is bug free and works as expected. Please provide specific
+instructions so we can reproduce and list any relevant details about
+your configuration
+example:
+- Screenshot of max projection from failing session
+- Screenshot of avg projection from failing session
+- Screenshot of passing unit tests
+- Description of unit test cases
+- Attached script to create max and avg projections of behavior session
+- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
+### Screenshots:
+### Unit Tests:
+### Script to reproduce error and fix:
+### Configuration details:
 
 # Checklist
- - [ ] My code follows Google style guide
- - [ ] My code is unit tested where appropriate and does not decrease test coverage
- - [ ] I have performed a self review of my own code
- - [ ] I have commented my code, specifically adding doc strings to any added functions
- - [ ] I have updated the documentation of the repository where appropriate
+- [ ] My code follows Google style guide
+- [ ] My code is unit tested where appropriate and does not decrease
+      test coverage
+- [ ] I have performed a self review of my own code
+- [ ] I have commented my code, specifically adding doc strings to any
+      added functions
+- [ ] I have updated the documentation of the repository where
+      appropriate
 
 # Notes:
-Use this section to add anything you think worth mentioning to the reader of the ticket.
+<!-- Use this section to add anything you think worth mentioning to the
+reader of the ticket
+example:
+I noticed that values from LIMs query for pixel resolution are returning zero
+I have made a new ticket to address this error at #5678. I believe this is an 
+error as all sessions should have a pixel resolution provided by the microscope.-->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -40,7 +40,7 @@ from actual resolution that wasn't saved, images might appear very distorted.
 An alternative solution is to update the database to cover the missing 
 experiment resolutions.-->
 
-# Adds:
+# Changes:
 <!-- Include a bulleted list or check box list of the implemented changes
 in brief, as well as the addition of supplementary materials(unit tests,
 integration tests, etc
@@ -53,7 +53,7 @@ example:
 # Validation:
 <!-- Describe how you have validated that your solution addresses the
 root cause of the ticket. What have you done to ensure that your
-addition is bug free and works as expected. Please provide specific
+addition is bug free and works as expected? Please provide specific
 instructions so we can reproduce and list any relevant details about
 your configuration
 example:

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -65,19 +65,19 @@ example:
 ### Configuration details:
 
 # Checklist
-- [ ] My code follows Google style guide
+- [ ] My code follows [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
 - [ ] My code is unit tested where appropriate and does not decrease
       test coverage
 - [ ] I have performed a self review of my own code
-- [ ] I have commented my code, specifically adding doc strings to any
-      added functions
+- [ ] My code is well-documented, and the docstrings conform to [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [ ] I have updated the documentation of the repository where
       appropriate
+- [ ] The header on my commit includes the issue number
 
 # Notes:
 <!-- Use this section to add anything you think worth mentioning to the
-reader of the ticket
+reader of the issue
 example:
 I noticed that values from LIMs query for pixel resolution are returning zero
-I have made a new ticket to address this error at #5678. I believe this is an 
+I have made a new issue to address this error at #5678. I believe this is an 
 error as all sessions should have a pixel resolution provided by the microscope.-->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,15 +1,17 @@
 <!--Thank you for contributing to AllenSDK, your work and time will help to
-advance open science!-->
+advance open science! For full contribution guidelines check out our
+guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->
 
 # Overview:
 <!-- Give a brief overview of the issue you are solving. Succinctly
 explain the GitHub issue you are addressing and the underlying problem
 of the ticket
 example: 
-Science team is not able to load max or avg projections for ophys
-session #blah. A ITK image cannot be created because input resolution is (0,0).
-It was found through investigation that LIMs was returning a 0 pixel resolution
-for this behavior session.-->
+Science team is not able to load max or avg projections for experiment
+session #blah. A image cannot be created because input pixel
+resolution is (0,0). It was found through investigation that the
+experiment database query was returning a 0 pixel resolution for this
+experiment.-->
 
 # Addresses:
 <!-- Add a link to the issue on Github board
@@ -17,6 +19,7 @@ example:
 Addresses issue [#1234](git_hub_ticket_url)-->
 
 # Type of Fix:
+<!--Chose One-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing
@@ -28,13 +31,13 @@ Addresses issue [#1234](git_hub_ticket_url)-->
 underlying cause. This section should include a brief description of
 your proposed solution and how it addresses the cause of the ticket
 example:
-Solution to this problem is to update the value of the pixel resolution to
-0.78125 (scientifica resolution) if pixel resolution is returned as 0. This 
-will address the underlying problem by providing a fallback value if the data
-is not available from LIMs to query. A downfall is if default resolution is disparate
+Solution to this problem is to update the value of the pixel resolution
+to a default x if pixel resolution is database pixel resolution =0. This
+will address the underlying problem by providing a fallback value if
+the data is not available. A downfall is if default resolution is disparate
 from actual resolution that wasn't saved, images might appear very distorted.
-An alternative solution is to update the LIMs db to have the correct data for 
-all microscope sessions.-->
+An alternative solution is to update the database to cover the missing 
+experiment resolutions.-->
 
 # Adds:
 <!-- Include a bulleted list or check box list of the implemented changes
@@ -42,7 +45,7 @@ in brief, as well as the addition of supplementary materials(unit tests,
 integration tests, etc
 example:
 - Check for 0 pixel resolution coming from LIMs
-- Assignment of default scientifica value of 0.78125 in case of zero return
+- Assignment of default value of x in case of zero return
 - Unit tests for the resolution gettr function to test for various edge cases
 -->
 
@@ -65,11 +68,12 @@ example:
 ### Configuration details:
 
 # Checklist
-- [ ] My code follows [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
-- [ ] My code is unit tested where appropriate and does not decrease
-      test coverage
+- [ ] My code follows
+      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
+- [ ] My code is unit tested and does not decrease test coverage
 - [ ] I have performed a self review of my own code
-- [ ] My code is well-documented, and the docstrings conform to [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
+- [ ] My code is well-documented, and the docstrings conform to
+      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [ ] I have updated the documentation of the repository where
       appropriate
 - [ ] The header on my commit includes the issue number
@@ -78,6 +82,6 @@ example:
 <!-- Use this section to add anything you think worth mentioning to the
 reader of the issue
 example:
-I noticed that values from LIMs query for pixel resolution are returning zero
+I noticed that values from the database query for pixel resolution are returning zero
 I have made a new issue to address this error at #5678. I believe this is an 
-error as all sessions should have a pixel resolution provided by the microscope.-->
+error as all sessions should have a pixel resolution.-->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,10 +5,11 @@ guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CON
 # Overview:
 <!-- Give a brief overview of the issue you are solving. Succinctly
 explain the GitHub issue you are addressing and the underlying problem
-of the ticket
+of the ticket. The commit header and body should also include this
+message, for good commit messages see the full contribution guidelines.
 example: 
 Science team is not able to load max or avg projections for experiment
-session #blah. A image cannot be created because input pixel
+session #x. A image cannot be created because input pixel
 resolution is (0,0). It was found through investigation that the
 experiment database query was returning a 0 pixel resolution for this
 experiment.-->
@@ -77,6 +78,9 @@ example:
 - [ ] I have updated the documentation of the repository where
       appropriate
 - [ ] The header on my commit includes the issue number
+- [ ] My Pull Request has the latest AllenSDK release candidate branch
+      rc/x.y.z as its merge target
+- [ ] My code passes all AllenSDK tests
 
 # Notes:
 <!-- Use this section to add anything you think worth mentioning to the


### PR DESCRIPTION
A pull request template was added to the root directory of the repository. This can be moved in the future if we desire to specify different pull request templates for different situations.

# Template in Action
![isaak-willett-AllenSDK-at-exampl](https://user-images.githubusercontent.com/58192697/82484981-97713100-9a8f-11ea-8198-ff08dced7798.gif)

# Notes:
I had to fork the repo and create the above gif on my own fork as it needs to be in the master branch of the repo for github to recognize the template. This means that if merged into 1.8.0 we will not see the pull request template show up until the next release.