### PR TITLE
Bugfix: Asynchronous Http Engine initialization in EcephysProjectCache

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_lims_api.py
@@ -568,7 +568,7 @@ class EcephysProjectLimsApi(EcephysProjectApi):
 
     @classmethod
     def default(cls, lims_credentials: Optional[DbCredentials] = None, 
-                app_kwargs=None, asynchronous=True):
+                app_kwargs=None, asynchronous=False):
         """ Construct a "straightforward" lims api that can fetch data from 
         lims2.
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_warehouse_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/ecephys_project_warehouse_api.py
@@ -307,7 +307,7 @@ class EcephysProjectWarehouseApi(EcephysProjectApi):
 
 
     @classmethod
-    def default(cls, asynchronous=True, **rma_kwargs):
+    def default(cls, asynchronous=False, **rma_kwargs):
         _rma_kwargs = {"scheme": "http", "host": "api.brain-map.org"}
         _rma_kwargs.update(rma_kwargs)
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/http_engine.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/http_engine.py
@@ -79,6 +79,10 @@ class HttpEngine:
             if elapsed > self.timeout:
                 raise requests.Timeout(f"Download took {elapsed} seconds, but timeout was set to {self.timeout}")
 
+    @staticmethod
+    def write_bytes(path: str, stream: Iterable[bytes]):
+        write_from_stream(path, stream)
+
 
 AsyncStreamCallbackType = Callable[[AsyncIterator[bytes]], Awaitable[None]]
 
@@ -166,7 +170,13 @@ class AsyncHttpEngine(HttpEngine):
             nest_asyncio.apply()
             loop = asyncio.get_event_loop()
             loop.run_until_complete(self.session.close())
-        
+
+    @staticmethod
+    def write_bytes(
+            path: str,
+            coroutine: Callable[[AsyncStreamCallbackType], Awaitable[None]]):
+        write_bytes_from_coroutine(path, coroutine)
+
 
 def write_bytes_from_coroutine(
     path: str, 
@@ -217,7 +227,6 @@ def write_from_stream(path: str, stream: Iterable[bytes]):
         iterable yielding bytes to be written
 
     """
-
     with open(path, "wb") as fil:
         for chunk in stream:
             fil.write(chunk)

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -74,7 +74,7 @@ class EcephysProjectCache(Cache):
             self,
             fetch_api: EcephysProjectApi = EcephysProjectWarehouseApi.default(), 
             fetch_tries: int = 2,
-            stream_writer: Callable = write_from_stream,
+            stream_writer: Optional[Callable] = None,
             manifest: Optional[Union[str, Path]] = None,
             version: Optional[str] = None,
             cache: bool = True):
@@ -82,6 +82,9 @@ class EcephysProjectCache(Cache):
         access to cross-session data (like stimulus templates) and high-level 
         summaries of sessionwise data and provides tools for downloading detailed 
         sessionwise data (such as spike times).
+
+        To ensure correct configuration, it is recommended to use one of the
+        class constructors rather than to initialize this class directly.
 
         Parameters
         ==========
@@ -100,6 +103,14 @@ class EcephysProjectCache(Cache):
         fetch_tries : int
             Maximum number of times to attempt a download before giving up and
             raising an exception. Note that this is total tries, not retries
+        stream_writer: Callable
+            The method used to write from stream. Depends on whether the
+            engine is synchronous or asynchronous. If not set, will use the
+            `write_bytes` method native to the `fetch_api`'s `rma_engine`.
+            If the method is incompatible with the `fetch_api`'s `rma_engine`,
+            will likely encounter errors. For this reason it is recommended
+            to leave this field unspecified, or to use one of the class
+            constructors.
         manifest : str or Path
             full path at which manifest json will be stored (default =
             "ecephys_project_manifest.json" in the local directory.)
@@ -108,6 +119,43 @@ class EcephysProjectCache(Cache):
             recorded in the file at manifest, an error will be raised.
         cache: bool
             Whether to write to the cache (default=True)
+
+        Notes
+        =====
+        It is highly recommended to construct an instance of this class
+        using one of the following constructor methods:
+
+        from_warehouse(scheme: Optional[str] = None,
+                       host: Optional[str] = None,
+                       asynchronous: bool = True,
+                       manifest: Optional[Union[str, Path]] = None,
+                       version: Optional[str] = None,
+                       cache: bool = True,
+                       fetch_tries: int = 2)
+            Create an instance of EcephysProjectCache with an
+            EcephysProjectWarehouseApi. Retrieves released data stored
+            in the warehouse. Suitable for all users downloading
+            published Allen Institute data.
+        from_lims(lims_credentials: Optional[DbCredentials] = None,
+                  scheme: Optional[str] = None,
+                  host: Optional[str] = None,
+                  asynchronous: bool = True,
+                  manifest: Optional[str] = None,
+                  version: Optional[str] = None,
+                  cache: bool = True,
+                  fetch_tries: int = 2)
+            Create an instance of EcephysProjectCache with an
+            EcephysProjectLimsApi. Retrieves bleeding-edge data stored
+            locally on Allen Institute servers. Suitable for internal
+            users on-site at the Allen Institute or using the corporate
+            vpn. Requires Allen Institute database credentials.
+        fixed(manifest: Optional[Union[str, Path]] = None,
+              version: Optional[str] = None)
+            Create an instance of EcephysProjectCache that will only
+            use locally stored data, downloaded previously from LIMS
+            or warehouse using the EcephysProjectCache.
+            Suitable for users who want to analyze a fixed dataset they
+            have previously downloaded using EcephysProjectCache.
         """
         manifest_ = manifest or "ecephys_project_manifest.json"
         version_ = version or self.MANIFEST_VERSION
@@ -117,7 +165,9 @@ class EcephysProjectCache(Cache):
                                                   cache=cache)
         self.fetch_api = fetch_api
         self.fetch_tries = fetch_tries
-        self.stream_writer = stream_writer
+        self.stream_writer = (stream_writer
+                              or self.fetch_api.rma_engine.write_bytes)
+
 
     def _get_sessions(self):
         path = self.get_cache_path(None, self.SESSIONS_KEY)
@@ -532,7 +582,7 @@ class EcephysProjectCache(Cache):
                   scheme: Optional[str] = None,
                   host: Optional[str] = None, 
                   asynchronous: bool = True,
-                  manifest: Optional[str] = None, 
+                  manifest: Optional[Union[str, Path]] = None, 
                   version: Optional[str] = None, 
                   cache: bool = True,
                   fetch_tries: int = 2):
@@ -630,7 +680,8 @@ class EcephysProjectCache(Cache):
         )
 
     @classmethod
-    def fixed(cls, manifest=None, version=None):
+    def fixed(cls, manifest: Optional[Union[str, Path]] = None, 
+              version: Optional[str] = None):
         """
         Creates a EcephysProjectCache that refuses to fetch any data 
         - only the existing local cache is accessible. Useful if you
@@ -702,4 +753,3 @@ def read_nwb(path):
     nwbfile = reader.read()
     nwbfile.identifier  # if the file is corrupt, make sure an exception gets raised during read
     return nwbfile
-

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
@@ -11,7 +11,7 @@ import pynwb
 import allensdk.brain_observatory.ecephys.ecephys_project_cache as epc
 import allensdk.brain_observatory.ecephys.write_nwb.__main__ as write_nwb
 from allensdk.brain_observatory.ecephys.ecephys_project_api.http_engine import (
-    write_from_stream, write_bytes_from_coroutine, AsyncHttpEngine
+    write_from_stream, write_bytes_from_coroutine, AsyncHttpEngine, HttpEngine
 )
 
 
@@ -193,14 +193,6 @@ def tmpdir_cache(shared_tmpdir, mock_api):
         fetch_api=mock_api(),
         manifest=man_path
     )
-
-
-def test_stream_writer_method_default_correct():
-    """Checks that the stream_writer contained in the rma engine is used
-    when one is not supplied to the __init__ method.
-    """
-    cache = epc.EcephysProjectCache(stream_writer=None)
-    assert cache.stream_writer == cache.fetch_api.rma_engine.write_bytes
 
 
 def lazy_cache_test(cache, cache_name, api_name, expected, *args, **kwargs):
@@ -389,5 +381,83 @@ def test_from_lims_default(tmpdir_factory):
     cache = epc.EcephysProjectCache.from_lims(
         manifest=os.path.join(tmpdir, "manifest.json")
     )
-    assert isinstance(cache.fetch_api.app_engine, AsyncHttpEngine)
-    assert cache.stream_writer is epc.write_bytes_from_coroutine
+    assert isinstance(cache.fetch_api.app_engine, HttpEngine)
+    assert cache.stream_writer is write_from_stream
+    assert cache.fetch_api.app_engine.scheme == "http"
+    assert cache.fetch_api.app_engine.host == "lims2"
+
+
+def test_from_warehouse_default(tmpdir_factory):
+    tmpdir = str(tmpdir_factory.mktemp("test_from_warehouse_default"))
+
+    cache = epc.EcephysProjectCache.from_warehouse(
+        manifest=os.path.join(tmpdir, "manifest.json")
+    )
+    assert isinstance(cache.fetch_api.rma_engine, HttpEngine)
+    assert cache.stream_writer is write_from_stream
+    assert cache.fetch_api.rma_engine.scheme == "http"
+    assert cache.fetch_api.rma_engine.host == "api.brain-map.org"
+
+
+def test_init_default(tmpdir_factory):
+    tmpdir = str(tmpdir_factory.mktemp("test_init_default"))
+    cache = epc.EcephysProjectCache(
+        manifest=os.path.join(tmpdir, "manifest.json")
+    )
+    assert isinstance(cache.fetch_api.rma_engine, HttpEngine)
+    assert cache.stream_writer is cache.fetch_api.rma_engine.write_bytes
+    assert cache.fetch_api.rma_engine.scheme == "http"
+    assert cache.fetch_api.rma_engine.host == "api.brain-map.org"
+
+
+@pytest.mark.parametrize(
+    ("cache_constructor, asynchronous, engine_attr, expected_engine,"
+     "expected_scheme, expected_host, expected_stream_writer"), [
+        (
+            epc.EcephysProjectCache.from_lims, True,
+            "app_engine", AsyncHttpEngine, "http", "lims2",
+            write_bytes_from_coroutine
+        ),
+        (
+            epc.EcephysProjectCache.from_warehouse, True,
+            "rma_engine", AsyncHttpEngine, "http", "api.brain-map.org",
+            write_bytes_from_coroutine
+        ),
+        (
+            epc.EcephysProjectCache.from_warehouse, False,
+            "rma_engine", HttpEngine, "http", "api.brain-map.org",
+            write_from_stream
+        ),
+        (
+            epc.EcephysProjectCache.from_lims, False,
+            "app_engine", HttpEngine, "http", "lims2",
+            write_from_stream
+        ),
+    ])
+def test_stream_asynchronous_arg(
+        cache_constructor, asynchronous, engine_attr, expected_engine,
+        expected_scheme, expected_host, expected_stream_writer,
+        tmpdir_factory):
+    """ Ensure the proper stream engine is chosen from the `asynchronous`
+    argument in the EcephysProjectCache constructors (using other default
+    values)."""
+    tmpdir = str(tmpdir_factory.mktemp("test_stream_async_args"))
+    cache = cache_constructor(
+        asynchronous=asynchronous,
+        manifest=os.path.join(tmpdir, "manifest.json")
+    )
+    engine = getattr(cache.fetch_api, engine_attr)
+    assert isinstance(engine, expected_engine)
+    assert cache.stream_writer is expected_stream_writer
+    assert engine.scheme == expected_scheme
+    assert engine.host == expected_host
+
+
+def test_stream_writer_method_default_correct(tmpdir_factory):
+    """Checks that the stream_writer contained in the rma engine is used
+    when one is not supplied to the __init__ method.
+    """
+    tmpdir = str(tmpdir_factory.mktemp("test_from_warehouse_default"))
+    manifest = os.path.join(tmpdir, "manifest.json")
+    cache = epc.EcephysProjectCache(stream_writer=None, manifest=manifest)
+    assert cache.stream_writer == cache.fetch_api.rma_engine.write_bytes

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
@@ -11,7 +11,7 @@ import pynwb
 import allensdk.brain_observatory.ecephys.ecephys_project_cache as epc
 import allensdk.brain_observatory.ecephys.write_nwb.__main__ as write_nwb
 from allensdk.brain_observatory.ecephys.ecephys_project_api.http_engine import (
-    write_bytes_from_coroutine, AsyncHttpEngine
+    write_from_stream, write_bytes_from_coroutine, AsyncHttpEngine
 )
 
 
@@ -109,12 +109,18 @@ def shared_tmpdir(tmpdir_factory):
     return str(tmpdir_factory.mktemp('test_ecephys_project_cache'))
 
 
+class MockEngine:
+    def __init__(self):
+        self.write_bytes = write_from_stream
+
+
 @pytest.fixture
 def mock_api(shared_tmpdir, raw_sessions, units, channels, raw_probes, analysis_metrics):
     class MockApi:
 
         def __init__(self, **kwargs):
             self.accesses = collections.defaultdict(lambda: 1)
+            self.rma_engine = MockEngine()
 
         def __getattr__(self, name):
             self.accesses[name] += 1
@@ -187,6 +193,14 @@ def tmpdir_cache(shared_tmpdir, mock_api):
         fetch_api=mock_api(),
         manifest=man_path
     )
+
+
+def test_stream_writer_method_default_correct():
+    """Checks that the stream_writer contained in the rma engine is used
+    when one is not supplied to the __init__ method.
+    """
+    cache = epc.EcephysProjectCache(stream_writer=None)
+    assert cache.stream_writer == cache.fetch_api.rma_engine.write_bytes
 
 
 def lazy_cache_test(cache, cache_name, api_name, expected, *args, **kwargs):


### PR DESCRIPTION
Resolves #1569 and resolves #1586

Previously the `stream_writer` in the `__init__` method of the `EcephysProjectCache` constructor was always defaulting to `write_from_stream` -- this is not compatible with the default for the default http engine, which required `write_bytes_from_coroutine`. Resulted in the bug reported in #1569. 

This updates `HttpEngine` and `AsyncHttpEngine` to have their own stream-to-file writers in the classs, which is used as the default if `stream_writer` is not passed to `EcephysProjectCache.__init__`. `EcephysProjectCache()` now has the correct default configuration.  I also added a docstring note instructing users to use `EcephysProjectCache.from_lims` or `EcephysProjectCache.from_warehouse` to create the cache, rather than constructing it directly. 

In debugging and testing this method, I also discovered a bug with the `AsyncHttpEngine` interaction with the latest version of jupyter notebooks. Since I believe the majority of users interact with the cache via jupyter notebooks, I didn't think #1569 would be complete as reported unless these defaults were updated. 

Therefore, this PR also updates the default stream engine to `HttpEngine` rather than `AsyncHttpEngine`, so that the default configuration works in jupyter notebooks.  Note that #1585 is not resolved.  Updating the default required a fix for #1586, including additional unit tests to check the configuration (since the actual default-setting done is somewhat complex).