### PR TITLE
GH-1324: Bugfix: Update behavior sessions time sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [ 1.8.0]
+### Bug Fixes
+- Internal LIMS data served to `BehaviorDataSession` class now all use the same timestamp source
+
 ## [1.7.1] = 2020-05-5
 
 ### Bug Fixes


### PR DESCRIPTION
Resolves #1324
Merging to master because this is a bugfix.

See http://confluence.corp.alleninstitute.org/pages/viewpage.action?pageId=80277925&moved=true
for complete documentation of the different time sources
in the data and how they are used by the APIs that populate
BehaviorDataSession and BehaviorOphysSession attributes
from LIMS data.

This PR aligns all the BehaviorDataSession timestamps to use
what's described in the linked document as 'trial_pkl_frame_times'.
These are the cumulative sum of the offset times between frames
aligned to the (frame, time) data points in the trial event log.
That alignment is done by using a linear regression to compute the
time that elapsed before frame 0 was presented, and then adding it
to the cumulative sum of the offset times.