### PR TITLE
Added 2019 production stimulus files to Stimulus Processing file list

### DIFF
--- a/allensdk/brain_observatory/behavior/__init__.py
+++ b/allensdk/brain_observatory/behavior/__init__.py
@@ -2,7 +2,9 @@
 IMAGE_SETS = {'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl',
               'Natural_Images_Lum_Matched_set_training_2017.07.14': '//allen/programs/braintv/workgroups/nc-ophys/Doug/Stimulus_Code/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl',
               'Natural_Images_Lum_Matched_set_training_2017.07.14_2': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl',
-              'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14_2': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl'}
+              'Natural_Images_Lum_Matched_set_ophys_6_2017.07.14_2': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl',
+              'Natural_Images_Lum_Matched_set_ophys_H_2019.05.26': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_H_2019.05.26.pkl',
+              'Natural_Images_Lum_Matched_set_ophys_G_2019.05.26': '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_G_2019.05.26.pkl'}
 
 
 

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -18,6 +18,10 @@ def convert_filepath_caseinsensitive(filename_in):
         return '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_training_2017.07.14.pkl'
     elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl':
         return '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_6_2017.07.14.pkl'
+    elif filename_in == '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_G_2019.05.26.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_G_2019.05.26.pkl'
+    elif filename_in ==  '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_H_2019.05.26.pkl':
+        return '//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_H_2019.05.26.pkl'
     else:
         raise NotImplementedError(filename_in)
 


### PR DESCRIPTION
# Overview:
Currently sessions that utilize the 2019 stimulus cannot be analyzed as the stimulus files are not defined in a check function in AllenSDK stimulus_processing. To unblock the science team the files have been added. This is a quick change that will get the situation unblocked but purposefully does not present a long term fix as that work has yet to be prioritized and scoped. There are a total of 5 files throwing not implemented errors across the ophys sessions that are raising a NotImplementedError the file names are captured below.
```
NotImplementedError: //allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_H_2019.05.26.pkl

NotImplementedError: //allen/aibs/mpe/Software/stimulus_files/nimages_0_20170714.zip

NotImplementedError: //allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_G_2019.05.26.pkl

NotImplementedError: //allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_3_2017.07.14.pkl

NotImplementedError: //allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_E_viscod_2019.05.26.pkl
```

# Solution:
I talked with Doug and Marina and they concluded they only wanted two of the not implemented files added, as the others were from testing sessions. The files they wanted included are,
```
//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_G_2019.05.26.pkl

//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/image_dictionaries/Natural_Images_Lum_Matched_set_ophys_H_2019.05.26.pkl
```
 I added these to that ugly path check function and then to the dictionary in the init file that was being used to get file name from path, also ugly. The session associated with these two stimulus files now pass successfully for the sessions for which they are the stimuli.

# Validation:

I reran Doug's original session and was able to succesfully get the trials to load and the stimulus files now work properly. I also ran a session associated with the other input stimulus file to verify that one is loaded correctly.

## Validation Script

```python

from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
from allensdk import OneResultExpectedError as OneErr
from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession

ophys_experiment_id = 'Ophys_Experiment_Id'
api = BehaviorOphysLimsApi(ophys_experiment_id)
session = BehaviorOphysSession(api)
session.trials
```

## G_2019
Opyhs Experiment Id: 992619908
Status: Successfully Passes
Image:
![image](https://user-images.githubusercontent.com/58192697/83299920-ee6fb800-a1ab-11ea-8ae3-3979d5b654e2.png)
Notes: This is the original experiment id that Doug provided and links to the G_2019 stimulus file

## H_2019
Opyhs Experiment Id: 964615743
Status: Successfully Passes
Image:
![image](https://user-images.githubusercontent.com/58192697/83300051-2840be80-a1ac-11ea-9853-b091bbb0a9aa.png)
Notes: This is a ophys experiment id that Wayne provided and links to the H_2019 stimulus file

# Notes:
* This is not unit tested and a unit test would not provide much value as this is a function that changes one letter in one path.
* This will be rewritten in the future as we prioritize the work required
* I don't like the implementation of this function but I want minimal changes until we embark on the larger fix.




