### PR TITLE
Fix typing.Protocol import in Python 3.8

### DIFF
--- a/allensdk/core/typing.py
+++ b/allensdk/core/typing.py
@@ -1,8 +1,12 @@
 import sys
-if sys.version_info.minor <= 7:  
+try:
+    # for Python 3.8 and greater
+    from typing import Protocol
+except ImportError:
+    # for Python 3.7 and before
     from typing import _Protocol as Protocol
 else:
-    from typing import Protocol
+    
 from abc import abstractmethod
 
 

--- a/allensdk/core/typing.py
+++ b/allensdk/core/typing.py
@@ -1,8 +1,12 @@
-from typing import _Protocol
+import sys
+if sys.version_info.minor <= 7:  
+    from typing import _Protocol as Protocol
+else:
+    from typing import Protocol
 from abc import abstractmethod
 
 
-class SupportsStr(_Protocol):
+class SupportsStr(Protocol):
     """Classes that support the __str__ method"""
     @abstractmethod
     def __str__(self) -> str:

--- a/allensdk/core/typing.py
+++ b/allensdk/core/typing.py
@@ -5,7 +5,6 @@ try:
 except ImportError:
     # for Python 3.7 and before
     from typing import _Protocol as Protocol
-else:
     
 from abc import abstractmethod
 


### PR DESCRIPTION
This addresses issue #1610. This solves the import issue on my system, but I am not completely sure that all functionality in typing._Protocol in v3.7 is maintained in typing.Protocol in 3.8.