### PR TITLE
Add function to check for existing column name in list of column names

### DIFF
--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,7 +15,7 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
-from allensdk.brain_observatory.nwb.nwb_utils import (get_stimulus_name_column)
+from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -426,8 +426,8 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
     stimulus_table = stimulus_table.copy()
     ts = nwbfile.modules['stimulus'].get_data_interface('timestamps')
     possible_names = {'stimulus_name', 'image_name'}
-    stimulus_name_column = get_stimulus_name_column(stimulus_table.columns,
-                                                    possible_names)
+    stimulus_name_column = get_column_name(stimulus_table.columns,
+                                           possible_names)
     stimulus_names = stimulus_table[stimulus_name_column].unique()
 
     for stim_name in sorted(stimulus_names):

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,6 +15,7 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
+from allensdk.brain_observatory.nwb.nwb_utils import (get_stimulus_name_column)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -424,10 +425,13 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
     """
     stimulus_table = stimulus_table.copy()
     ts = nwbfile.modules['stimulus'].get_data_interface('timestamps')
-    stimulus_names = stimulus_table['stimulus_name'].unique()
+    possible_names = {'stimulus_name', 'image_name'}
+    stimulus_name_column = get_stimulus_name_column(stimulus_table.columns,
+                                                    possible_names)
+    stimulus_names = stimulus_table[stimulus_name_column].unique()
 
     for stim_name in sorted(stimulus_names):
-        specific_stimulus_table = stimulus_table[stimulus_table['stimulus_name'] == stim_name]
+        specific_stimulus_table = stimulus_table[stimulus_table[stimulus_name_column] == stim_name]
         # Drop columns where all values in column are NaN
         cleaned_table = specific_stimulus_table.dropna(axis=1, how='all')
         # For columns with mixed strings and NaNs, fill NaNs with 'N/A'

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,0 +1,21 @@
+def get_stimulus_name_column(stimulus_table_cols: list,
+                             possible_names: set) -> str:
+    """
+    This function acts a identifier for which column name is present in the
+    dataframe to indict the name of a stimuli. In behavior ophys sessions this
+    is 'image_name' and in eceephys this is 'stimulus_name' as an example
+    where the NWB write functions use the same function with a name change.
+    :param stimulus_table_cols: the table columns to search for the stimulus
+                                name within
+    :param possible_names: the names that could exist within the data columns
+    :return: the first entry of the intersection between the possible names
+             and the names of the columns of the stimulus table
+    """
+
+    stimulus_column_set = set(stimulus_table_cols)
+    stim_column_names = list(stimulus_column_set.intersection(possible_names))
+    if not len(stim_column_names) == 1:
+        raise KeyError("Stimulus table does not have correct names for stimulus"
+                       " name column, expected one name in intersection, found:"
+                       f" {stim_column_names}")
+    return stim_column_names[0]

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,21 +1,19 @@
-def get_stimulus_name_column(stimulus_table_cols: list,
-                             possible_names: set) -> str:
+def get_column_name(table_cols: list,
+                    possible_names: set) -> str:
     """
     This function acts a identifier for which column name is present in the
-    dataframe to indict the name of a stimuli. In behavior ophys sessions this
-    is 'image_name' and in eceephys this is 'stimulus_name' as an example
-    where the NWB write functions use the same function with a name change.
-    :param stimulus_table_cols: the table columns to search for the stimulus
-                                name within
+    dataframe from the provided possibilities. This is used in NWB to identify
+    the correct column name for stimulus_name which differs from Behavior Ophys
+    to Eccephys.
+    :param table_cols: the table columns to search for the possible name within
     :param possible_names: the names that could exist within the data columns
     :return: the first entry of the intersection between the possible names
              and the names of the columns of the stimulus table
     """
 
-    stimulus_column_set = set(stimulus_table_cols)
-    stim_column_names = list(stimulus_column_set.intersection(possible_names))
-    if not len(stim_column_names) == 1:
-        raise KeyError("Stimulus table does not have correct names for stimulus"
-                       " name column, expected one name in intersection, found:"
-                       f" {stim_column_names}")
-    return stim_column_names[0]
+    column_set = set(table_cols)
+    column_names = list(column_set.intersection(possible_names))
+    if not len(column_names) == 1:
+        raise KeyError("Table expected one name column in intersection, found:"
+                       f" {column_names}")
+    return column_names[0]

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,10 +1,10 @@
 def get_column_name(table_cols: list,
                     possible_names: set) -> str:
     """
-    This function acts a identifier for which column name is present in the
-    dataframe from the provided possibilities. This is used in NWB to identify
-    the correct column name for stimulus_name which differs from Behavior Ophys
-    to Eccephys.
+    This function returns a column name, given a table with unknown
+    column names and a set of possible column names which are expected.
+    The table column name returned should be the only name contained in
+    the "expected" possible names.
     :param table_cols: the table columns to search for the possible name within
     :param possible_names: the names that could exist within the data columns
     :return: the first entry of the intersection between the possible names

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -11,7 +11,7 @@ from allensdk.brain_observatory.nwb import nwb_utils
 ])
 def test_get_stimulus_name_column(input_cols, possible_names,
                                   expected_intersection):
-    column_name = nwb_utils.get_stimulus_name_column(input_cols, possible_names)
+    column_name = nwb_utils.get_column_name(input_cols, possible_names)
     assert column_name == expected_intersection
 
 
@@ -25,6 +25,7 @@ def test_get_stimulus_name_column(input_cols, possible_names,
 def test_get_stimulus_name_column_exceptions(input_cols,
                                              possible_names,
                                              expected_excep_cols):
-    regex = ".* \\" + str(expected_excep_cols)
-    with pytest.raises(KeyError, match=regex):
-        nwb_utils.get_stimulus_name_column(input_cols, possible_names)
+    with pytest.raises(KeyError) as error:
+        nwb_utils.get_column_name(input_cols, possible_names)
+    for expected_value in expected_excep_cols:
+        assert expected_value in str(error.value)

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -1,0 +1,30 @@
+import pytest
+
+from allensdk.brain_observatory.nwb import nwb_utils
+
+
+@pytest.mark.parametrize("input_cols, possible_names, expected_intersection", [
+    (['duration', 'end_frame', 'image_index', 'image_name'],
+     {'stimulus_name', 'image_name'}, 'image_name'),
+    (['duration', 'end_frame', 'image_index', 'stimulus_name'],
+     {'stimulus_name', 'image_name'}, 'stimulus_name')
+])
+def test_get_stimulus_name_column(input_cols, possible_names,
+                                  expected_intersection):
+    column_name = nwb_utils.get_stimulus_name_column(input_cols, possible_names)
+    assert column_name == expected_intersection
+
+
+@pytest.mark.parametrize("input_cols, possible_names, expected_excep_cols", [
+    (['duration', 'end_frame', 'image_index'], {'stimulus_name', 'image_name'},
+     []),
+    (['duration', 'end_frame', 'image_index', 'image_name', 'stimulus_name'],
+     {'stimulus_name', 'image_name'},
+     ['stimulus_name', 'image_name'])
+])
+def test_get_stimulus_name_column_exceptions(input_cols,
+                                             possible_names,
+                                             expected_excep_cols):
+    regex = ".* \\" + str(expected_excep_cols)
+    with pytest.raises(KeyError, match=regex):
+        nwb_utils.get_stimulus_name_column(input_cols, possible_names)


### PR DESCRIPTION
# Overview:
This pull request addresses a failure in NWB writing where Behavior Ophys experiments do not have the hard coded `stimulus_name` key available. This has now been rectified by adding in a small function that checks for the existance of equivalent keys in the stimulus table dataframe. 

# Validation:
I've included test cases to test for the existance of the keys in the provided keys, ie: checking for a column name within a set of column names. These cases cover the cases where it finds the eccephys key or the behavior ophys key. It also covers the case where it finds no keys and the case where it finds more than one key.

I have also run the BehaviorOphysNWBAPI.save() function that calls this function and it proceeds past this point, correctly grabbing the names of the stimuli in the stimuli table.
