### PR TITLE
Omitted stimuli bug

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -61,10 +61,8 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
             nwb.add_stimulus_index(nwbfile, stimulus_index, nwb_template)
 
         # search for omitted rows and add stop_time before writing to NWB file
-        stimulus_table = session_object.stimulus_presentations
-        omitted_row_indexs = stimulus_table.index[stimulus_table['omitted']].tolist()
-        for omitted_row_idx in omitted_row_indexs:
-            set_omitted_stop_time(stimulus_table.iloc[omitted_row_idx])
+        set_omitted_stop_time(stimulus_table=session_object.stimulus_presentations)
+
         # Add stimulus presentations data to NWB in-memory object:
         nwb.add_stimulus_presentations(nwbfile, session_object.stimulus_presentations)
 

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -64,6 +64,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         stimulus_table = session_object.stimulus_presentations
         omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
         for idx, omitted_row in omitted_rows.iterrows():
+            print(idx)
             set_omitted_stop_time(stimulus_table_row=omitted_row)
             print(omitted_row)
         # Add stimulus presentations data to NWB in-memory object:

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -62,11 +62,9 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
 
         # search for omitted rows and add stop_time before writing to NWB file
         stimulus_table = session_object.stimulus_presentations
-        omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
-        for idx, omitted_row in omitted_rows.iterrows():
-            print(idx)
-            set_omitted_stop_time(stimulus_table_row=omitted_row)
-            print(omitted_row)
+        omitted_row_indexs = stimulus_index.index[stimulus_table['omitted']].tolist()
+        for omitted_row_idx in omitted_row_indexs:
+            set_omitted_stop_time(stimulus_table.iloc[omitted_row_idx])
         # Add stimulus presentations data to NWB in-memory object:
         nwb.add_stimulus_presentations(nwbfile, session_object.stimulus_presentations)
 

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -62,7 +62,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
 
         # search for omitted rows and add stop_time before writing to NWB file
         stimulus_table = session_object.stimulus_presentations
-        omitted_row_indexs = stimulus_index.index[stimulus_table['omitted']].tolist()
+        omitted_row_indexs = stimulus_table.index[stimulus_table['omitted']].tolist()
         for omitted_row_idx in omitted_row_indexs:
             set_omitted_stop_time(stimulus_table.iloc[omitted_row_idx])
         # Add stimulus presentations data to NWB in-memory object:

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -63,11 +63,9 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         # search for omitted rows and add stop_time before writing to NWB file
         stimulus_table = session_object.stimulus_presentations
         omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
-        print(omitted_rows)
         for idx, omitted_row in omitted_rows.iterrows():
-            print(omitted_row)
+            print(type(omitted_row))
             set_omitted_stop_time(stimulus_table_row=omitted_row)
-        print(omitted_rows)
         # Add stimulus presentations data to NWB in-memory object:
         nwb.add_stimulus_presentations(nwbfile, session_object.stimulus_presentations)
 

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -65,6 +65,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
         print(omitted_rows)
         for omitted_row in omitted_rows:
+            print(omitted_row)
             set_omitted_stop_time(stimulus_table_row=omitted_row)
         print(omitted_rows)
         # Add stimulus presentations data to NWB in-memory object:

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 from allensdk.core.lazy_property import LazyProperty
 from allensdk.brain_observatory.nwb.nwb_api import NwbApi
+from allensdk.brain_observatory.nwb.nwb_utils import set_omitted_stop_time
 from allensdk.brain_observatory.behavior.trials_processing import TRIAL_COLUMN_DESCRIPTION_DICT
 from allensdk.brain_observatory.behavior.schemas import OphysBehaviorMetaDataSchema, OphysBehaviorTaskParametersSchema
 from allensdk.brain_observatory.nwb.metadata import load_LabMetaData_extension
@@ -59,6 +60,13 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
             stimulus_index = session_object.stimulus_presentations[session_object.stimulus_presentations['image_set'] == nwb_template.name]
             nwb.add_stimulus_index(nwbfile, stimulus_index, nwb_template)
 
+        # search for omitted rows and add stop_time before writing to NWB file
+        stimulus_table = session_object.stimulus_presentations
+        omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
+        print(omitted_rows)
+        for omitted_row in omitted_rows:
+            set_omitted_stop_time(stimulus_table_row=omitted_row)
+        print(omitted_rows)
         # Add stimulus presentations data to NWB in-memory object:
         nwb.add_stimulus_presentations(nwbfile, session_object.stimulus_presentations)
 

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -64,7 +64,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         stimulus_table = session_object.stimulus_presentations
         omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
         print(omitted_rows)
-        for omitted_row in omitted_rows:
+        for idx, omitted_row in omitted_rows.iterrows():
             print(omitted_row)
             set_omitted_stop_time(stimulus_table_row=omitted_row)
         print(omitted_rows)

--- a/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_api/behavior_ophys_nwb_api.py
@@ -64,8 +64,8 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysApiBase):
         stimulus_table = session_object.stimulus_presentations
         omitted_rows = stimulus_table[stimulus_table['omitted'] == True]
         for idx, omitted_row in omitted_rows.iterrows():
-            print(type(omitted_row))
             set_omitted_stop_time(stimulus_table_row=omitted_row)
+            print(omitted_row)
         # Add stimulus presentations data to NWB in-memory object:
         nwb.add_stimulus_presentations(nwbfile, session_object.stimulus_presentations)
 

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -30,8 +30,17 @@ def load_pickle(pstream):
     return pickle.load(pstream, encoding="bytes")
 
 
-def get_stimulus_presentations(data, stimulus_timestamps):
-
+def get_stimulus_presentations(data, stimulus_timestamps) -> pd.DataFrame:
+    """
+    This function retrieves the stimulus presentation dataframe and
+    renames the columns, adds a stop_time column, and set's index to
+    stimulus_presentation_id before sorting and returning the dataframe.
+    :param data: stimulus file associated with experiment id
+    :param stimulus_timestamps: timestamps indicating when stimuli switched
+                                during experiment
+    :return: stimulus_table: dataframe containing the stimuli metadata as well
+                             as what stimuli was presented
+    """
     stimulus_table = get_visual_stimuli_df(data, stimulus_timestamps)
     # workaround to rename columns to harmonize with visual coding and rebase timestamps to sync time
     stimulus_table.insert(loc=0, column='flash_number', value=np.arange(0, len(stimulus_table)))
@@ -159,7 +168,22 @@ def unpack_change_log(change):
         to_name=to_name,
     )
 
-def get_visual_stimuli_df(data, time):
+
+def get_visual_stimuli_df(data, time) -> pd.DataFrame:
+    """
+    This function loads the stimuli and the omitted stimuli into a dataframe.
+    These stimuli are loaded from the input data, where the set_log and
+    draw_log contained within are used to calculate the epochs. These epochs
+    are used as start_frame and end_frame and converted to times by input
+    stimulus timestamps. The omitted stimuli do not have a end_frame by design
+    though there duration is always 250ms.
+    :param data: the behavior data file
+    :param time: the stimulus timestamps indicating when each stimuli is
+                 displayed
+    :return: df: a pandas dataframe containing the stimuli and omitted stimuli
+                 that were displayed with their frame, end_frame, start_time,
+                 and duration
+    """
 
     stimuli = data['items']['behavior']['stimuli']
     n_frames = len(time)

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,7 +15,7 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
-from allensdk.brain_observatory.nwb.nwb_utils import (get_stimulus_name_column)
+from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -426,8 +426,8 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
     stimulus_table = stimulus_table.copy()
     ts = nwbfile.modules['stimulus'].get_data_interface('timestamps')
     possible_names = {'stimulus_name', 'image_name'}
-    stimulus_name_column = get_stimulus_name_column(stimulus_table.columns,
-                                                    possible_names)
+    stimulus_name_column = get_column_name(stimulus_table.columns,
+                                           possible_names)
     stimulus_names = stimulus_table[stimulus_name_column].unique()
 
     for stim_name in sorted(stimulus_names):

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,6 +15,7 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
+from allensdk.brain_observatory.nwb.nwb_utils import (get_stimulus_name_column)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -424,10 +425,13 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
     """
     stimulus_table = stimulus_table.copy()
     ts = nwbfile.modules['stimulus'].get_data_interface('timestamps')
-    stimulus_names = stimulus_table['stimulus_name'].unique()
+    possible_names = {'stimulus_name', 'image_name'}
+    stimulus_name_column = get_stimulus_name_column(stimulus_table.columns,
+                                                    possible_names)
+    stimulus_names = stimulus_table[stimulus_name_column].unique()
 
     for stim_name in sorted(stimulus_names):
-        specific_stimulus_table = stimulus_table[stimulus_table['stimulus_name'] == stim_name]
+        specific_stimulus_table = stimulus_table[stimulus_table[stimulus_name_column] == stim_name]
         # Drop columns where all values in column are NaN
         cleaned_table = specific_stimulus_table.dropna(axis=1, how='all')
         # For columns with mixed strings and NaNs, fill NaNs with 'N/A'

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,7 +15,7 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
-from allensdk.brain_observatory.nwb.nwb_utils import (get_stimulus_name_column,
+from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name,
                                                       set_omitted_stop_time)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,7 +15,8 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
-from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
+from allensdk.brain_observatory.nwb.nwb_utils import (get_stimulus_name_column,
+                                                      set_omitted_stop_time)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -451,6 +452,12 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
 
         for row in cleaned_table.itertuples(index=False):
             row = row._asdict()
+
+            # if there is no stop time in the stimuli it is an 'omitted' stimuli
+            # row and therefore by design has no stop_time, we must add this in.
+            if 'stop_time' not in row.keys():
+                set_omitted_stop_time(row)
+
             presentation_interval.add_interval(**row, tags=tag, timeseries=ts)
 
         nwbfile.add_time_intervals(presentation_interval)

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,8 +15,7 @@ from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
 import allensdk.brain_observatory.roi_masks as roi
-from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name,
-                                                      set_omitted_stop_time)
+from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -452,11 +451,6 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
 
         for row in cleaned_table.itertuples(index=False):
             row = row._asdict()
-
-            # if there is no stop time in the stimuli it is an 'omitted' stimuli
-            # row and therefore by design has no stop_time, we must add this in.
-            if 'stop_time' not in row.keys():
-                set_omitted_stop_time(row)
 
             presentation_interval.add_interval(**row, tags=tag, timeseries=ts)
 

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,0 +1,21 @@
+def get_stimulus_name_column(stimulus_table_cols: list,
+                             possible_names: set) -> str:
+    """
+    This function acts a identifier for which column name is present in the
+    dataframe to indict the name of a stimuli. In behavior ophys sessions this
+    is 'image_name' and in eceephys this is 'stimulus_name' as an example
+    where the NWB write functions use the same function with a name change.
+    :param stimulus_table_cols: the table columns to search for the stimulus
+                                name within
+    :param possible_names: the names that could exist within the data columns
+    :return: the first entry of the intersection between the possible names
+             and the names of the columns of the stimulus table
+    """
+
+    stimulus_column_set = set(stimulus_table_cols)
+    stim_column_names = list(stimulus_column_set.intersection(possible_names))
+    if not len(stim_column_names) == 1:
+        raise KeyError("Stimulus table does not have correct names for stimulus"
+                       " name column, expected one name in intersection, found:"
+                       f" {stim_column_names}")
+    return stim_column_names[0]

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -44,7 +44,6 @@ def set_omitted_stop_time(stimulus_table_row: dict) -> None:
             end_time = start_time + omitted_stimuli_duration
             stimulus_table_row['stop_time'] = end_time
             stimulus_table_row['duration'] = omitted_stimuli_duration
-            print(stimulus_table_row)
     else:
         raise ValueError("Row does not have omitted or omitted is False, this"
                          "is not an omitted row and cannot have it's stop_time"

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -2,7 +2,6 @@ import pandas as pd
 # All of the omitted stimuli have a duration of 250ms as defined
 # by the Visual Behavior team. For questions about duration contact that
 # team.
-omitted_stimuli_duration = 0.250
 
 
 def get_column_name(table_cols: list,
@@ -26,7 +25,8 @@ def get_column_name(table_cols: list,
     return column_names[0]
 
 
-def set_omitted_stop_time(stimulus_table: pd.DataFrame) -> None:
+def set_omitted_stop_time(stimulus_table: pd.DataFrame,
+                          omitted_time_duration: float=0.25) -> None:
     """
     This function sets the stop time for a row that of a stimuli table that
     is a omitted stimuli. A omitted stimuli is a stimuli where a mouse is
@@ -36,6 +36,8 @@ def set_omitted_stop_time(stimulus_table: pd.DataFrame) -> None:
     stop_time calculated and put into the row as data before writing to NWB.
     :param stimulus_table: pd.DataFrame that contains the stimuli presented to
                            an experiment subject
+    :param omitted_time_duration: The duration in seconds of the expected length
+                                  of the omitted stimuli
     :return:
           stimulus_table_row: returns the same dictionary as inputted but with
                               an additional entry for stop_time.
@@ -44,7 +46,7 @@ def set_omitted_stop_time(stimulus_table: pd.DataFrame) -> None:
     for omitted_row_idx in omitted_row_indexs:
         row = stimulus_table.iloc[omitted_row_idx]
         start_time = row['start_time']
-        end_time = start_time + omitted_stimuli_duration
+        end_time = start_time + omitted_time_duration
         row['stop_time'] = end_time
-        row['duration'] = omitted_stimuli_duration
+        row['duration'] = omitted_time_duration
         stimulus_table.iloc[omitted_row_idx] = row

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -39,11 +39,12 @@ def set_omitted_stop_time(stimulus_table_row: dict) -> None:
           stimulus_table_row: returns the same dictionary as inputted but with
                               an additional entry for stop_time.
     """
-    print(stimulus_table_row)
     if 'omitted' in stimulus_table_row.keys() and stimulus_table_row['omitted']:
             start_time = stimulus_table_row['start_time']
             end_time = start_time + omitted_stimuli_duration
             stimulus_table_row['stop_time'] = end_time
+            stimulus_table_row['duration'] = omitted_stimuli_duration
+            print(stimulus_table_row)
     else:
         raise ValueError("Row does not have omitted or omitted is False, this"
                          "is not an omitted row and cannot have it's stop_time"

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,3 +1,4 @@
+import pandas as pd
 # All of the omitted stimuli have a duration of 250ms as defined
 # by the Visual Behavior team. For questions about duration contact that
 # team.
@@ -25,7 +26,7 @@ def get_column_name(table_cols: list,
     return column_names[0]
 
 
-def set_omitted_stop_time(stimulus_table_row: dict) -> None:
+def set_omitted_stop_time(stimulus_table: pd.DataFrame) -> None:
     """
     This function sets the stop time for a row that of a stimuli table that
     is a omitted stimuli. A omitted stimuli is a stimuli where a mouse is
@@ -33,18 +34,17 @@ def set_omitted_stop_time(stimulus_table_row: dict) -> None:
     include a stop_time or end_frame as other stimuli in the stimulus table due
     to design choices. For these stimuli to be added they must have the
     stop_time calculated and put into the row as data before writing to NWB.
-    :param stimulus_table_row: dictionary representing the contents of the
-                               row in the stimuli table.
+    :param stimulus_table: pd.DataFrame that contains the stimuli presented to
+                           an experiment subject
     :return:
           stimulus_table_row: returns the same dictionary as inputted but with
                               an additional entry for stop_time.
     """
-    if 'omitted' in stimulus_table_row.keys() and stimulus_table_row['omitted']:
-            start_time = stimulus_table_row['start_time']
-            end_time = start_time + omitted_stimuli_duration
-            stimulus_table_row['stop_time'] = end_time
-            stimulus_table_row['duration'] = omitted_stimuli_duration
-    else:
-        raise ValueError("Row does not have omitted or omitted is False, this"
-                         "is not an omitted row and cannot have it's stop_time"
-                         f"set to omitted value. Row: {stimulus_table_row}")
+    omitted_row_indexs = stimulus_table.index[stimulus_table['omitted']].tolist()
+    for omitted_row_idx in omitted_row_indexs:
+        row = stimulus_table.iloc[omitted_row_idx]
+        start_time = row['start_time']
+        end_time = start_time + omitted_stimuli_duration
+        row['stop_time'] = end_time
+        row['duration'] = omitted_stimuli_duration
+        stimulus_table.iloc[omitted_row_idx] = row

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,21 +1,19 @@
-def get_stimulus_name_column(stimulus_table_cols: list,
-                             possible_names: set) -> str:
+def get_column_name(table_cols: list,
+                    possible_names: set) -> str:
     """
     This function acts a identifier for which column name is present in the
-    dataframe to indict the name of a stimuli. In behavior ophys sessions this
-    is 'image_name' and in eceephys this is 'stimulus_name' as an example
-    where the NWB write functions use the same function with a name change.
-    :param stimulus_table_cols: the table columns to search for the stimulus
-                                name within
+    dataframe from the provided possibilities. This is used in NWB to identify
+    the correct column name for stimulus_name which differs from Behavior Ophys
+    to Eccephys.
+    :param table_cols: the table columns to search for the possible name within
     :param possible_names: the names that could exist within the data columns
     :return: the first entry of the intersection between the possible names
              and the names of the columns of the stimulus table
     """
 
-    stimulus_column_set = set(stimulus_table_cols)
-    stim_column_names = list(stimulus_column_set.intersection(possible_names))
-    if not len(stim_column_names) == 1:
-        raise KeyError("Stimulus table does not have correct names for stimulus"
-                       " name column, expected one name in intersection, found:"
-                       f" {stim_column_names}")
-    return stim_column_names[0]
+    column_set = set(table_cols)
+    column_names = list(column_set.intersection(possible_names))
+    if not len(column_names) == 1:
+        raise KeyError("Table expected one name column in intersection, found:"
+                       f" {column_names}")
+    return column_names[0]

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -39,6 +39,7 @@ def set_omitted_stop_time(stimulus_table_row: dict) -> None:
           stimulus_table_row: returns the same dictionary as inputted but with
                               an additional entry for stop_time.
     """
+    print(stimulus_table_row)
     if 'omitted' in stimulus_table_row.keys() and stimulus_table_row['omitted']:
             start_time = stimulus_table_row['start_time']
             end_time = start_time + omitted_stimuli_duration

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -1,3 +1,9 @@
+# All of the omitted stimuli have a duration of 250ms as defined
+# by the Visual Behavior team. For questions about duration contact that
+# team.
+omitted_stimuli_duration = 0.250
+
+
 def get_column_name(table_cols: list,
                     possible_names: set) -> str:
     """
@@ -17,3 +23,27 @@ def get_column_name(table_cols: list,
         raise KeyError("Table expected one name column in intersection, found:"
                        f" {column_names}")
     return column_names[0]
+
+
+def set_omitted_stop_time(stimulus_table_row: dict) -> None:
+    """
+    This function sets the stop time for a row that of a stimuli table that
+    is a omitted stimuli. A omitted stimuli is a stimuli where a mouse is
+    shown only a grey screen and these last for 250 milliseconds. These do not
+    include a stop_time or end_frame as other stimuli in the stimulus table due
+    to design choices. For these stimuli to be added they must have the
+    stop_time calculated and put into the row as data before writing to NWB.
+    :param stimulus_table_row: dictionary representing the contents of the
+                               row in the stimuli table.
+    :return:
+          stimulus_table_row: returns the same dictionary as inputted but with
+                              an additional entry for stop_time.
+    """
+    if 'omitted' in stimulus_table_row.keys() and stimulus_table_row['omitted']:
+            start_time = stimulus_table_row['start_time']
+            end_time = start_time + omitted_stimuli_duration
+            stimulus_table_row['stop_time'] = end_time
+    else:
+        raise ValueError("Row does not have omitted or omitted is False, this"
+                         "is not an omitted row and cannot have it's stop_time"
+                         f"set to omitted value. Row: {stimulus_table_row}")

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -11,7 +11,7 @@ from allensdk.brain_observatory.nwb import nwb_utils
 ])
 def test_get_stimulus_name_column(input_cols, possible_names,
                                   expected_intersection):
-    column_name = nwb_utils.get_stimulus_name_column(input_cols, possible_names)
+    column_name = nwb_utils.get_column_name(input_cols, possible_names)
     assert column_name == expected_intersection
 
 
@@ -25,6 +25,7 @@ def test_get_stimulus_name_column(input_cols, possible_names,
 def test_get_stimulus_name_column_exceptions(input_cols,
                                              possible_names,
                                              expected_excep_cols):
-    regex = ".* \\" + str(expected_excep_cols)
-    with pytest.raises(KeyError, match=regex):
-        nwb_utils.get_stimulus_name_column(input_cols, possible_names)
+    with pytest.raises(KeyError) as error:
+        nwb_utils.get_column_name(input_cols, possible_names)
+    for expected_value in expected_excep_cols:
+        assert expected_value in str(error.value)

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 
 from allensdk.brain_observatory.nwb import nwb_utils
 
@@ -31,36 +32,17 @@ def test_get_stimulus_name_column_exceptions(input_cols,
         assert expected_value in str(error.value)
 
 
-@pytest.mark.parametrize("stimulus_row, expected_stop_time", [
-    ({'image_index': 8,
-      'image_name': 'omitted',
-      'image_set': 'omitted',
-      'index': 201,
-      'omitted': True,
-      'start_frame': 231060,
-      'start_time': 0}, 0.250)
+@pytest.mark.parametrize("stimulus_table, expected_stop_time", [
+    ({'image_index': [8, 9],
+      'image_name': ['omitted', 'not_omitted'],
+      'image_set': ['omitted', 'not_omitted'],
+      'index': [201, 202],
+      'omitted': [True, False],
+      'start_frame': [231060, 232340],
+      'start_time': [0, 250],
+      'stop_time': [None, 1340509]}, 0.250)
 ])
-def test_set_omitted_stop_time(stimulus_row, expected_stop_time):
-    nwb_utils.set_omitted_stop_time(stimulus_row)
-    assert stimulus_row['stop_time'] == expected_stop_time
-
-
-@pytest.mark.parametrize("stimulus_row", [
-    ({'image_index': 8,
-      'image_name': 'omitted',
-      'image_set': 'omitted',
-      'index': 201,
-      'omitted': False,
-      'start_frame': 231060,
-      'start_time': 0}),
-    ({'image_index': 8,
-      'image_name': 'omitted',
-      'image_set': 'omitted',
-      'index': 201,
-      'start_frame': 231060,
-      'start_time': 0})
-])
-def test_set_omitted_stop_time_exceptions(stimulus_row):
-    regex = f".* \\{stimulus_row}"
-    with pytest.raises(ValueError, match=regex):
-        nwb_utils.set_omitted_stop_time(stimulus_row)
+def test_set_omitted_stop_time(stimulus_table, expected_stop_time):
+    stimulus_table = pd.DataFrame.from_dict(data=stimulus_table)
+    nwb_utils.set_omitted_stop_time(stimulus_table)
+    assert stimulus_table.iloc[0]['stop_time'] == expected_stop_time

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -1,0 +1,30 @@
+import pytest
+
+from allensdk.brain_observatory.nwb import nwb_utils
+
+
+@pytest.mark.parametrize("input_cols, possible_names, expected_intersection", [
+    (['duration', 'end_frame', 'image_index', 'image_name'],
+     {'stimulus_name', 'image_name'}, 'image_name'),
+    (['duration', 'end_frame', 'image_index', 'stimulus_name'],
+     {'stimulus_name', 'image_name'}, 'stimulus_name')
+])
+def test_get_stimulus_name_column(input_cols, possible_names,
+                                  expected_intersection):
+    column_name = nwb_utils.get_stimulus_name_column(input_cols, possible_names)
+    assert column_name == expected_intersection
+
+
+@pytest.mark.parametrize("input_cols, possible_names, expected_excep_cols", [
+    (['duration', 'end_frame', 'image_index'], {'stimulus_name', 'image_name'},
+     []),
+    (['duration', 'end_frame', 'image_index', 'image_name', 'stimulus_name'],
+     {'stimulus_name', 'image_name'},
+     ['stimulus_name', 'image_name'])
+])
+def test_get_stimulus_name_column_exceptions(input_cols,
+                                             possible_names,
+                                             expected_excep_cols):
+    regex = ".* \\" + str(expected_excep_cols)
+    with pytest.raises(KeyError, match=regex):
+        nwb_utils.get_stimulus_name_column(input_cols, possible_names)

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -32,7 +32,7 @@ def test_get_stimulus_name_column_exceptions(input_cols,
         assert expected_value in str(error.value)
 
 
-@pytest.mark.parametrize("stimulus_table, expected_stop_time", [
+@pytest.mark.parametrize("stimulus_table, expected_table_data", [
     ({'image_index': [8, 9],
       'image_name': ['omitted', 'not_omitted'],
       'image_set': ['omitted', 'not_omitted'],
@@ -40,9 +40,19 @@ def test_get_stimulus_name_column_exceptions(input_cols,
       'omitted': [True, False],
       'start_frame': [231060, 232340],
       'start_time': [0, 250],
-      'stop_time': [None, 1340509]}, 0.250)
+      'stop_time': [None, 1340509]},
+     {'image_index': [8, 9],
+      'image_name': ['omitted', 'not_omitted'],
+      'image_set': ['omitted', 'not_omitted'],
+      'index': [201, 202],
+      'omitted': [True, False],
+      'start_frame': [231060, 232340],
+      'start_time': [0, 250],
+      'stop_time': [0.25, 1340509]}
+     )
 ])
-def test_set_omitted_stop_time(stimulus_table, expected_stop_time):
+def test_set_omitted_stop_time(stimulus_table, expected_table_data):
     stimulus_table = pd.DataFrame.from_dict(data=stimulus_table)
+    expected_table = pd.DataFrame.from_dict(data=expected_table_data)
     nwb_utils.set_omitted_stop_time(stimulus_table)
-    assert stimulus_table.iloc[0]['stop_time'] == expected_stop_time
+    assert stimulus_table.equals(expected_table)

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -29,3 +29,38 @@ def test_get_stimulus_name_column_exceptions(input_cols,
         nwb_utils.get_column_name(input_cols, possible_names)
     for expected_value in expected_excep_cols:
         assert expected_value in str(error.value)
+
+
+@pytest.mark.parametrize("stimulus_row, expected_stop_time", [
+    ({'image_index': 8,
+      'image_name': 'omitted',
+      'image_set': 'omitted',
+      'index': 201,
+      'omitted': True,
+      'start_frame': 231060,
+      'start_time': 0}, 0.250)
+])
+def test_set_omitted_stop_time(stimulus_row, expected_stop_time):
+    nwb_utils.set_omitted_stop_time(stimulus_row)
+    assert stimulus_row['stop_time'] == expected_stop_time
+
+
+@pytest.mark.parametrize("stimulus_row", [
+    ({'image_index': 8,
+      'image_name': 'omitted',
+      'image_set': 'omitted',
+      'index': 201,
+      'omitted': False,
+      'start_frame': 231060,
+      'start_time': 0}),
+    ({'image_index': 8,
+      'image_name': 'omitted',
+      'image_set': 'omitted',
+      'index': 201,
+      'start_frame': 231060,
+      'start_time': 0})
+])
+def test_set_omitted_stop_time_exceptions(stimulus_row):
+    regex = f".* \\{stimulus_row}"
+    with pytest.raises(ValueError, match=regex):
+        nwb_utils.set_omitted_stop_time(stimulus_row)


### PR DESCRIPTION
# Overview:
Currently Omitted Stimuli exist in Behavior Ophys experiments, these stimuli represent when a experiment subject is being shown a gray screen. These stimuli by design have no ending frame or ending timestamp, they always last for 750ms however. Currently these cannot be written as an NWB interval because the datatype requires an ending timestamp, leaving this information out is not a good idea.

# Solution:
The proposed solution that the Visual Behavior team agrees with is to take the starting timestamp, which is present in the omitted stimuli data, and add the standard duration time to get the stop time. This fixes the error where NWB intervals require a stop time, the stop_time is now created and saved in the stimulus table row. 

# Validation:
The solution has been validated by running through four Behavior Ophys experiments and successfully running the function `add_stimulus_presentations`, with the inclusion of #1619. The test cases cover the cases where stop_time is not found in a row, any additional testing coverage suggestions would be much appreciated.

# Notes:
* This does not fully fix the writing of Behavior Ophys NWB files but contributes to eliminating the errors in writing those files!
* This PR also adds some documentation to `stimulus_processing.py` as work was done in this file understanding the omitted stimuli data.