### PR TITLE
Update pynwb and hdmf minimum required version

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -36,7 +36,7 @@
 import logging
 
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ argschema<2.0.0
 marshmallow==3.0.0rc6
 glymur==0.8.19
 xarray<0.16.0
-hdmf>=1.0.2,<2.0.0
-pynwb>=1.0.2,<2.0.0
+hdmf>=1.6.3,<2.0.0
+pynwb>=1.3.2,<2.0.0
 tables==3.5.1 # pinning this because updates tend to not include wheels immediately
 seaborn<1.0.0
 aiohttp==3.6.2


### PR DESCRIPTION
# Overview:
Some users are encountering errors using AllenSDK 2.0 because it allows for outdated versions of hdmf and pynwb dependencies.

# Addresses:
Relates to: #1620

# Solution:
Increase the minimum required version for hdmf and pynwb.
