### PR TITLE
Image mask in cell specimen table

### DIFF
--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -32,7 +32,8 @@ cell_specimen_col_descriptions = {
                         ' cell matching)',
     'height': 'Height of ROI in pixels',
     'width': 'Width of ROI in pixels',
-    'mask_image_plane': 'Image Plane of the ROI mask',
+    'mask_image_plane': 'Which image plane an ROI resides on. Overlapping ROIs '
+                        'are stored on different mask image planes.',
     'max_correction_down': 'Max motion correction in down direction in pixels',
     'max_correction_left': 'Max motion correction in left direction in pixels',
     'max_correction_up': 'Max motion correction in up direction in pixels',

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -10,7 +10,7 @@ import SimpleITK as sitk
 import pynwb
 from pynwb.base import TimeSeries, Images
 from pynwb.behavior import BehavioralEvents
-from pynwb import ProcessingModule
+from pynwb import ProcessingModule, NWBFile
 from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
 
@@ -714,7 +714,28 @@ def add_task_parameters(nwbfile, task_parameters):
     nwbfile.add_lab_meta_data(nwb_task_parameters)
 
 
-def add_cell_specimen_table(nwbfile, cell_specimen_table):
+def add_cell_specimen_table(nwbfile: NWBFile,
+                            cell_specimen_table: pd.DataFrame):
+    """
+    This function takes the cell specimen table and writes the ROIs
+    contained within. It writes these to a new NWB imaging plane
+    based off the previously supplied metadata
+    Parameters
+    ----------
+    nwbfile: NWBFile
+        this is the in memory NWBFile currently being written to which ROI data
+        is added
+    cell_specimen_table: pd.DataFrame
+        this is the DataFrame containing the cells segmented from a ophys
+        experiment, stored in json file and loaded.
+        example: /home/nicholasc/projects/allensdk/allensdk/test/
+                 brain_observatory/behavior/cell_specimen_table_789359614.json
+
+    Returns
+    -------
+    nwbfile: NWBFile
+        The altered in memory NWBFile object that now has a specimen table
+    """
     cell_roi_table = cell_specimen_table.reset_index().set_index('cell_roi_id')
 
     # Device:
@@ -774,12 +795,19 @@ def add_cell_specimen_table(nwbfile, cell_specimen_table):
         description="Segmented rois",
         imaging_plane=imaging_plane)
 
-    for c in [c for c in cell_roi_table.columns if c not in ['id', 'mask_matrix']]:
-        plane_segmentation.add_column(c, c)
+    for col_name in cell_roi_table.columns:
+        # the columns 'image_mask', 'pixel_mask', and 'voxel_mask' are already defined
+        # in the nwb.ophys::PlaneSegmentation Object
+        if col_name not in ['id', 'mask_matrix', 'image_mask', 'pixel_mask', 'voxel_mask']:
+            # This builds the columns with name of column and description of column
+            # both equal to the column name in the cell_roi_table
+            plane_segmentation.add_column(col_name, col_name)
 
+    # go through each roi and add it to the plan segmentation object
     for cell_roi_id, row in cell_roi_table.iterrows():
         sub_mask = np.array(row.pop('image_mask'))
-        curr_roi = roi.create_roi_mask(fov_width, fov_height, [(fov_width - 1), 0, (fov_height - 1), 0], roi_mask=sub_mask)
+        curr_roi = roi.create_roi_mask(fov_width, fov_height, [(fov_width - 1), 0, (fov_height - 1), 0],
+                                       roi_mask=sub_mask)
         mask = curr_roi.get_mask_plane()
         csid = row.pop('cell_specimen_id')
         row['cell_specimen_id'] = -1 if csid is None else csid

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -28,7 +28,8 @@ log = logging.getLogger("allensdk.brain_observatory.nwb")
 
 
 cell_specimen_col_descriptions = {
-    'cell_specimen_id': 'Id of segmented cell',
+    'cell_specimen_id': 'Unified id of segmented cell across experiments (after'
+                        ' cell matching)',
     'height': 'Height of ROI',
     'width': 'Width of ROI',
     'mask_image_plane': 'Image Plane of the ROI mask',
@@ -36,7 +37,8 @@ cell_specimen_col_descriptions = {
     'max_correction_left': 'Max motion correction in left direction',
     'max_correction_up': 'Max motion correction in up direction',
     'max_correction_right': 'Max motion correction in right direction',
-    'valid_roi': 'Indicates if classifier found to be true or false',
+    'valid_roi': 'Indicates if cell classification found the ROI to be a cell '
+                 'or not',
     'x': 'x position of ROI in Image Plane',
     'y': 'y position of ROI in Image Plane'
 }

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -795,6 +795,8 @@ def add_cell_specimen_table(nwbfile: NWBFile,
         description="Segmented rois",
         imaging_plane=imaging_plane)
 
+    print(cell_roi_table.columns)
+
     for col_name in cell_roi_table.columns:
         # the columns 'image_mask', 'pixel_mask', and 'voxel_mask' are already defined
         # in the nwb.ophys::PlaneSegmentation Object

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -27,7 +27,7 @@ from allensdk.brain_observatory.nwb.metadata import load_LabMetaData_extension
 log = logging.getLogger("allensdk.brain_observatory.nwb")
 
 
-cell_specimen_col_descriptions = {
+CELL_SPECIMEN_COL_DESCRIPTIONS = {
     'cell_specimen_id': 'Unified id of segmented cell across experiments (after'
                         ' cell matching)',
     'height': 'Height of ROI in pixels',
@@ -821,8 +821,8 @@ def add_cell_specimen_table(nwbfile: NWBFile,
             # This builds the columns with name of column and description of column
             # both equal to the column name in the cell_roi_table
             plane_segmentation.add_column(col_name,
-                                          cell_specimen_col_descriptions[
-                                              col_name])
+                                          CELL_SPECIMEN_COL_DESCRIPTIONS.get(col_name,
+                                                                             "No Description Available"))
 
     # go through each roi and add it to the plan segmentation object
     for cell_roi_id, row in cell_roi_table.iterrows():

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -30,17 +30,18 @@ log = logging.getLogger("allensdk.brain_observatory.nwb")
 cell_specimen_col_descriptions = {
     'cell_specimen_id': 'Unified id of segmented cell across experiments (after'
                         ' cell matching)',
-    'height': 'Height of ROI',
-    'width': 'Width of ROI',
+    'height': 'Height of ROI in pixels',
+    'width': 'Width of ROI in pixels',
     'mask_image_plane': 'Image Plane of the ROI mask',
-    'max_correction_down': 'Max motion correction in down direction',
-    'max_correction_left': 'Max motion correction in left direction',
-    'max_correction_up': 'Max motion correction in up direction',
-    'max_correction_right': 'Max motion correction in right direction',
+    'max_correction_down': 'Max motion correction in down direction in pixels',
+    'max_correction_left': 'Max motion correction in left direction in pixels',
+    'max_correction_up': 'Max motion correction in up direction in pixels',
+    'max_correction_right': 'Max motion correction in right direction in '
+                            'pixels',
     'valid_roi': 'Indicates if cell classification found the ROI to be a cell '
                  'or not',
-    'x': 'x position of ROI in Image Plane',
-    'y': 'y position of ROI in Image Plane'
+    'x': 'x position of ROI in Image Plane in pixels (top left corner)',
+    'y': 'y position of ROI in Image Plane in pixels (top left corner)'
 }
 
 

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -27,6 +27,21 @@ from allensdk.brain_observatory.nwb.metadata import load_LabMetaData_extension
 log = logging.getLogger("allensdk.brain_observatory.nwb")
 
 
+cell_specimen_col_descriptions = {
+    'cell_specimen_id': 'Id of segmented cell',
+    'height': 'Height of ROI',
+    'width': 'Width of ROI',
+    'mask_image_plane': 'Image Plane of the ROI mask',
+    'max_correction_down': 'Max motion correction in down direction',
+    'max_correction_left': 'Max motion correction in left direction',
+    'max_correction_up': 'Max motion correction in up direction',
+    'max_correction_right': 'Max motion correction in right direction',
+    'valid_roi': 'Indicates if classifier found to be true or false',
+    'x': 'x position of ROI in Image Plane',
+    'y': 'y position of ROI in Image Plane'
+}
+
+
 def read_eye_dlc_tracking_ellipses(input_path: Path) -> dict:
     """Reads eye tracking ellipse fit data from an h5 file.
 
@@ -795,15 +810,15 @@ def add_cell_specimen_table(nwbfile: NWBFile,
         description="Segmented rois",
         imaging_plane=imaging_plane)
 
-    print(cell_roi_table.columns)
-
     for col_name in cell_roi_table.columns:
         # the columns 'image_mask', 'pixel_mask', and 'voxel_mask' are already defined
         # in the nwb.ophys::PlaneSegmentation Object
         if col_name not in ['id', 'mask_matrix', 'image_mask', 'pixel_mask', 'voxel_mask']:
             # This builds the columns with name of column and description of column
             # both equal to the column name in the cell_roi_table
-            plane_segmentation.add_column(col_name, col_name)
+            plane_segmentation.add_column(col_name,
+                                          cell_specimen_col_descriptions[
+                                              col_name])
 
     # go through each roi and add it to the plan segmentation object
     for cell_roi_id, row in cell_roi_table.iterrows():

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -41,7 +41,6 @@ def test_session_from_json(tmpdir_factory, session_data, get_expected, get_from_
     compare_fields(expected, obtained)
 
 
-@pytest.mark.xfail
 @pytest.mark.requires_bamboo
 def test_nwb_end_to_end(tmpdir_factory):
     oeid = 789359614


### PR DESCRIPTION
# Story:
As a scientists I want to be able to write Behavior Ophys Experiments to the latest NWB file format so that I can share my research and data with other neuroscientists to provide open data to accelerate science.

# Error Overview:
NWB files for behavior ophys were not able to be written as the CellSpecimenTable could not be added to the NWB in memory object. This was occurring because the column 'image_mask' was already included in the PlaneSegmentation NWB object created to store the data. This column is created at initialization and therefore an error was thrown when it was attempted to be created again. Upon investigation there are three columns automatically created in PlaneSegmentation NWB objects (image_mask, pixel_mask, and voxel_mask). These are given pre-defined descriptions and created with no data stored. The loop that processes the CellSpecimenTable attempts to add all columns within as columns in the PlaneSegmentation NWB object, and it fails when it goes over the column 'image_mask'

# Solution:
To rectify this problem the three pre-defined columns were added to the list of column names that are not created when looping through the CellSpecimenTable columns. This does not effect the data stored as this error only occurred creating the columns so they are not absent when data is written.

# Validation:
Previously a nightly test was turned off to write behavior ophys nwb files (see #1597). This test has been run and it now successfully passes. This validates that NWB files can be written for Behavior Ophys Experiments and that the data matches the experiment objects from LIMs. As such the expected fail for this test has been removed.
![image](https://user-images.githubusercontent.com/58192697/85901653-2112cd80-b7b7-11ea-9f40-6387cd071d9c.png)

There is also a separate script attached below that demonstrates writing Behavior Ophys NWB files, this produces a file called test.nwb from a Behavior Ophys Experiment. You will need to install this branch into a conda environment in order for this to produce a file.

```
from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession
from allensdk.brain_observatory.behavior.behavior_ophys_api.behavior_ophys_nwb_api import BehaviorOphysNwbApi

nwb_filepath = '/home/isaak.willett/Projects/AllenTickets/UnpinPyNWBBehaviorOphys/test.nwb'

ophys_experiment_id = 994051952
api = BehaviorOphysLimsApi(ophys_experiment_id)
session = BehaviorOphysSession(api)
BehaviorOphysNwbApi(nwb_filepath).save(session)
```
 