### PR TITLE
Add warning if loading outdated Visual Coding Neuropixels nwb files

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -1,7 +1,9 @@
 from typing import Dict, Union, List, Optional, Callable
 import re
 import ast
+import warnings
 
+import h5py
 import pandas as pd
 import numpy as np
 import xarray as xr
@@ -11,6 +13,7 @@ from .ecephys_session_api import EcephysSessionApi
 from allensdk.brain_observatory.nwb.nwb_api import NwbApi
 import allensdk.brain_observatory.ecephys.nwb  # noqa Necessary to import pyNWB namespaces
 from allensdk.brain_observatory.ecephys import get_unit_filter_value
+from allensdk.brain_observatory.nwb import check_nwbfile_version
 
 color_triplet_re = re.compile(r"\[(-{0,1}\d*\.\d*,\s*)*(-{0,1}\d*\.\d*)\]")
 
@@ -54,6 +57,18 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
 
         self.additional_unit_metrics = additional_unit_metrics
         self.external_channel_columns = external_channel_columns
+
+        if hasattr(self, "path") and self.path:
+            check_nwbfile_version(
+                nwbfile_path=self.path,
+                desired_minimum_version="2.2.2",
+                warning_msg=(
+                    f"It looks like the Visual Coding Neuropixels nwbfile "
+                    f"you are trying to access ({self.path})"
+                    f"was created by a previous (and incompatible) version of "
+                    f"AllenSDK and pynwb. You will need to either 1) use "
+                    f"AllenSDK version < 2.0.0 or 2) re-download an updated "
+                    f"version of the nwbfile to access the desired data."))
 
     def test(self):
         """ A minimal test to make sure that this API's NWB file exists and is

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_session_nwb_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_session_nwb_api.py
@@ -1,5 +1,8 @@
 # most of the tests for this functionality are actually in test_write_nwb
 
+import warnings
+
+import h5py
 import pytest
 import pandas as pd
 

--- a/allensdk/test/brain_observatory/nwb/test_nwb.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb.py
@@ -1,0 +1,57 @@
+import warnings
+import h5py
+import pytest
+
+from allensdk.brain_observatory.nwb import check_nwbfile_version
+
+
+@pytest.fixture
+def version_only_nwbfile_fixture(tmp_path, request):
+
+    nwb_version = request.param.get("nwb_version", "2.2.2")
+
+    nwbfile_path = tmp_path / "version_only_nwbfile.nwb"
+    with h5py.File(nwbfile_path, "w") as f:
+        if nwb_version is not None:
+            # pynwb 1.x saves version as a dataset
+            # and in the format "NWB-x.y.z"
+            if tuple(nwb_version.split(".")) < ("2", "0", "0"):
+                f.create_dataset("nwb_version", data=f"NWB-{nwb_version}")
+            # pynwb 2.x saves version as an attribute
+            elif tuple(nwb_version.split(".")) >= ("2", "0", "0"):
+                f.attrs["nwb_version"] = nwb_version
+        else:
+            f.create_dataset("something_completely_unrelated", data="42")
+
+    return str(nwbfile_path)
+
+
+@pytest.mark.parametrize("version_only_nwbfile_fixture, min_desired_version"
+                         ", warns, warn_msg, invalid_nwb", [
+    ({"nwb_version":  None}, "2.2.2" , True, "Warn msg A", True),
+    ({"nwb_version": "0.9.0c"}, "2.2.2" , True, "Warn msg B", False),
+    ({"nwb_version": "2"}, "2.2.2", True, "Warn msg C", False),
+    ({"nwb_version": "2.0b"}, "2.2.2", True, "Warn msg D", False),
+    ({"nwb_version": "2.2.2"}, "2.2.2", False, None, False),
+    ({"nwb_version": "2.2.8"}, "2.2.2", False, None, False),
+    ({"nwb_version": "3.0"}, "2.2.2", False, None, False)
+], indirect=["version_only_nwbfile_fixture"])
+def test_check_nwbfile_version(version_only_nwbfile_fixture,
+                               min_desired_version, warns,
+                               warn_msg, invalid_nwb):
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        check_nwbfile_version(nwbfile_path=version_only_nwbfile_fixture,
+                              desired_minimum_version=min_desired_version,
+                              warning_msg=warn_msg)
+    if warns:
+        if invalid_nwb:
+            assert ("neither a 'nwb_version' field "
+                    "nor dataset could be found"
+                    in str(w[-1].message))
+        else:
+            assert warn_msg in str(w[-1].message)
+    else:
+        assert len(w) == 0


### PR DESCRIPTION
Add a warning when an `EcephysSession` detects an older (and incompatible) version of an nwbfile is trying to be loaded with the new version of AllenSDK.

Relates to: #1635