### PR TITLE
Failing tests in AllenSDK caused by no env variables set

### DIFF
--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_lims_api.py
@@ -6,20 +6,28 @@ import pytz
 import math
 
 from allensdk.internal.api.behavior_data_lims_api import BehaviorDataLimsApi
+from allensdk.core.authentication import DbCredentials
 from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.core.exceptions import DataFrameIndexError
 
+mock_db_credentials = DbCredentials(dbname='mock_db', user='mock_user',
+                                      host='mock_host', port='mock_port',
+                                      password='mock')
+
 
 @pytest.fixture
 def MockBehaviorDataLimsApi():
+
     class MockBehaviorDataLimsApi(BehaviorDataLimsApi):
         """
         Mock class that overrides some functions to provide test data and
         initialize without calls to db.
         """
         def __init__(self):
-            super().__init__(behavior_session_id=8675309)
+            super().__init__(behavior_session_id=8675309,
+                             lims_credentials=mock_db_credentials,
+                             mtrain_credentials=mock_db_credentials)
 
         def _get_ids(self):
             return {}
@@ -73,7 +81,9 @@ def MockApiRunSpeedExpectedError():
         initialize without calls to db.
         """
         def __init__(self):
-            super().__init__(behavior_session_id=8675309)
+            super().__init__(behavior_session_id=8675309,
+                             mtrain_credentials=mock_db_credentials,
+                             lims_credentials=mock_db_credentials)
 
         def _get_ids(self):
             return {}

--- a/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
@@ -229,12 +229,12 @@ def test_get_cell_roi_table(ophys_experiment_id):
 
 
 @pytest.mark.requires_bamboo
-@pytest.mark.parametrize('ophys_lims_api, compare_val', [
-    pytest.param(OphysLimsApi(511458874), 0.785203),
-    pytest.param(OphysLimsApi(0), None)
+@pytest.mark.parametrize('ophys_lims_experiment_id, compare_val', [
+    pytest.param(511458874, 0.785203),
+    pytest.param(0, None)
 ])
-def test_get_surface_2p_pixel_size_um(ophys_lims_api, compare_val):
-
+def test_get_surface_2p_pixel_size_um(ophys_lims_experiment_id, compare_val):
+    ophys_lims_api = OphysLimsApi(ophys_lims_experiment_id)
     if compare_val is None:
         expected_fail = False
         try:
@@ -247,12 +247,13 @@ def test_get_surface_2p_pixel_size_um(ophys_lims_api, compare_val):
 
 
 @pytest.mark.requires_bamboo
-@pytest.mark.parametrize('ophys_lims_api, compare_val', [
-    pytest.param(OphysLimsApi(511458874), '/allen/programs/braintv/production/neuralcoding/prod6/specimen_503292442/ophys_experiment_511458874/processed/ophys_cell_segmentation_run_572290131/maxInt_masks.tif'),
-    pytest.param(OphysLimsApi(0), None)
+@pytest.mark.parametrize('ophys_lims_experiment_id, compare_val', [
+    pytest.param(511458874, '/allen/programs/braintv/production/neuralcoding/prod6/specimen_503292442/ophys_experiment_511458874/processed/ophys_cell_segmentation_run_572290131/maxInt_masks.tif'),
+    pytest.param(0, None)
 ])
-def test_get_segmentation_mask_image_file(ophys_lims_api, compare_val):
+def test_get_segmentation_mask_image_file(ophys_lims_experiment_id, compare_val):
 
+    ophys_lims_api = OphysLimsApi(ophys_lims_experiment_id)
     if compare_val is None:
         expected_fail = False
         try:
@@ -265,12 +266,13 @@ def test_get_segmentation_mask_image_file(ophys_lims_api, compare_val):
 
 
 @pytest.mark.requires_bamboo
-@pytest.mark.parametrize('ophys_lims_api, compare_val', [
-    pytest.param(OphysLimsApi(842510825), 'M'),
-    pytest.param(OphysLimsApi(0), None)
+@pytest.mark.parametrize('ophys_lims_experiment_id, compare_val', [
+    pytest.param(842510825, 'M'),
+    pytest.param(0, None)
 ])
-def test_get_sex(ophys_lims_api, compare_val):
+def test_get_sex(ophys_lims_experiment_id, compare_val):
 
+    ophys_lims_api = OphysLimsApi(ophys_lims_experiment_id)
     if compare_val is None:
         expected_fail = False
         try:
@@ -283,12 +285,12 @@ def test_get_sex(ophys_lims_api, compare_val):
 
 
 @pytest.mark.requires_bamboo
-@pytest.mark.parametrize('ophys_lims_api, compare_val', [
-    pytest.param(OphysLimsApi(842510825), 'P157'),
-    pytest.param(OphysLimsApi(0), None)
+@pytest.mark.parametrize('ophys_lims_experiment_id, compare_val', [
+    pytest.param(842510825, 'P157'),
+    pytest.param(0, None)
 ])
-def test_get_age(ophys_lims_api, compare_val):
-
+def test_get_age(ophys_lims_experiment_id, compare_val):
+    ophys_lims_api = OphysLimsApi(ophys_lims_experiment_id)
     if compare_val is None:
         expected_fail = False
         try:

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_lims_api.py
@@ -6,9 +6,14 @@ import pytest
 import pandas as pd
 import numpy as np
 
+from allensdk.core.authentication import DbCredentials
 from allensdk.brain_observatory.ecephys.ecephys_project_api import (
     ecephys_project_lims_api as epla,
 )
+
+mock_lims_credentials = DbCredentials(dbname='mock_lims', user='mock_user',
+                                      host='mock_host', port='mock_port',
+                                      password='mock')
 
 
 class MockSelector:
@@ -18,7 +23,7 @@ class MockSelector:
         self.response = response
 
     def __call__(self, query, *args, **kwargs):
-        self.passed  = {}
+        self.passed = {}
         self.query = query
         for name, check in self.checks.items():
             self.passed[name] = check(query)
@@ -143,12 +148,12 @@ class MockSelector:
         )
     ]
 ])
-def test_pg_query(method_name,kwargs, response, checks, expected):
+def test_pg_query(method_name, kwargs, response, checks, expected):
 
     selector = MockSelector(checks, response)
 
     with mock.patch("allensdk.internal.api.psycopg2_select", new=selector) as ptc:
-        api = epla.EcephysProjectLimsApi.default()
+        api = epla.EcephysProjectLimsApi.default(lims_credentials=mock_lims_credentials)
         obtained = getattr(api, method_name)(**kwargs)
         pd.testing.assert_frame_equal(expected, obtained, check_like=True, check_dtype=False)
 


### PR DESCRIPTION
# Overview:
An external user mentioned failing tests in #1625, claiming that this was the result of a pinned tables dependency. The root cause was fair bit more opaque, the LIMs credentials are not required for api based tests as the LIMs connectivity is mocked out. But the construction still required LIMs credentials to be set in the environment. This caused failures both during collection, why the user claimed tests were never run, as well as in the tests themselves, about 16 were failing because the API object could not be constructed.

# Solution:
I added two small changes that resolve these testing failures so these now work as expected, I moved the api construction from the parameterization tag and I provided mock db credentials where relevant so that the initialization does not fail. This fixes the failing tests as the API creation no longer fails on platforms that do not provide the credentials to the constructor.

# Validation:
I had failures from this error originally and now all the test pass successfully as evidenced below
![image](https://user-images.githubusercontent.com/58192697/86272079-dd3b1200-bb82-11ea-92f9-23aef046985e.png)

For running of the tests:
1. Checkout out branch `failing_pytest_runs`
2. CD to the AllenSDK directory
3. Run `pytest` or `python -m pytest`

# Notes:
* This failure is not persistent to Linux or the online builds