### PR TITLE
Fix operator for boolean matrix

### DIFF
--- a/allensdk/brain_observatory/demixer.py
+++ b/allensdk/brain_observatory/demixer.py
@@ -215,7 +215,7 @@ def plot_negative_transients(raw_traces, demix_traces, valid_roi, mask_array,
 
     flat_masks = mask_array.reshape(N, x*y)
     overlap = flat_masks.dot(flat_masks.T)
-    overlap -= np.diag(np.diag(overlap))
+    overlap ^= np.diag(np.diag(overlap))
 
     for roi_ind in rois_with_trans:
 


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
Resolves #518

When we migrated from the internal demixing module to
the brain_observatory demixing module (which were
duplicated code), a small update to the internal code
was missed (and therefore not duplicated). 

This resulted in a plotting function returning a TypeError
because we were attempting to use '-=' on a boolean
numpy array. Using the bitwise 'xor' operator '^' solves
this issue. This commit re-implements the internal demixer code update in the
public brain_observatory demixing module.

The rest of the deprecated internal code was checked to ensure that
no other changes were missed, and none were found.

This is a bugfix that affects our internal data pipeline. As soon as this is merged, we should tag a patch version update and deploy.

# Addresses:
#518

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Switch to the bitwise xor operator that was used in the internal module.

# Validation:
Checked demixing methods against one that had already passed (http://lims2.corp.alleninstitute.org/job_logs?id=1028462561&utf8=%E2%9C%93) with truncated traces due to memory constraints. Demixed traces were equal using both the deprecated (from `internal.brain_observatory.demixer`) and public (`brain_observatory.demixer`) demixing method (`demix_time_dep_masks`). The plotting failed initially with the non-deprecated demixer, but passed after re-implementing the internal change to the bitwise xor operator

# Notes:
Should release patch version ASAP.
I didn't add test coverage for this because plotting is hard to test, I think this is only for QC (have no idea what would consume this in downstream processes), and this method has been used for at least a year in the internal module (just wasn't copied over when we switched to the non-internal demixer).