### PR TITLE
Update regression test affected by updated scipy ks_2samp function

### DIFF
--- a/allensdk/test/brain_observatory/test_session_analysis_regression_data.json
+++ b/allensdk/test/brain_observatory/test_session_analysis_regression_data.json
@@ -8,9 +8,9 @@
                "nwb_c": "/allen/aibs/informatics/module_test_data/observatory/py2_analysis/569494121.nwb"
         }, 
         "3": {
-               "analysis_a": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp/510859641_three_session_A_analysis.h5",
-               "analysis_b": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp/510698988_three_session_B_analysis.h5",
-               "analysis_c": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp/510532780_three_session_C_analysis.h5",
+               "analysis_a": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp-2020-07-07/510859641_three_session_A_analysis.h5",
+               "analysis_b": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp-2020-07-07/510698988_three_session_B_analysis.h5",
+               "analysis_c": "/allen/aibs/informatics/module_test_data/observatory/py3_analysis/new_ks_2samp-2020-07-07/510532780_three_session_C_analysis.h5",
                "nwb_a": "/allen/aibs/informatics/module_test_data/observatory//plots/510859641.nwb",
                "nwb_b": "/allen/aibs/informatics/module_test_data/observatory/plots/510698988.nwb",
                "nwb_c": "/allen/aibs/informatics/module_test_data/observatory/plots/510532780.nwb"


### PR DESCRIPTION
# Overview:

Scipy 1.5.0 fixed a ks_2samp bug that resulted in incorrect p-values
being reported. This change was picked up by our nightly brain observatory analysis
regression tests.

The specific tests that failed were:
`test_session_a`,
`test_session_b`,
`test_session_c`

Located in:
https://github.com/AllenInstitute/AllenSDK/blob/master/allensdk/test/brain_observatory/test_session_analysis_regression.py

The reason for the test failures was due to the new p-values being reported by the `scipy.stats.ks_2samp` function not matching up with 'expected' p-values that were produced by the scipy < 1.5.0 version of `ks_2samp`.

# Addresses:

Issue: https://github.com/AllenInstitute/AllenSDK/issues/1631

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
This commit updates the expected output file's Kolmogorov Smirnov
test p-values so that they reflect the correct values returned by
the most up to date ks_2samp implementation.

# Validation:

See: http://bamboo.corp.alleninstitute.org/browse/IFR-ANG23-2 (when it finishes)
