### PR TITLE
GH #1323: Bugfix - Response time logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
+## [2.2.0]
+## Bug Fixes
+- `response_time` of a trial in behavior-only or behavior + ophys sessions is now the first lick of the trial (for non-"aborted" trials). If no lick occurred or if the trial is "aborted", `repsonse_time` is `NaN`.
 
 ## [2.1.0] = 2020-07-16
 

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -1,3 +1,4 @@
+from typing import List
 import numpy as np
 import datetime
 import pandas as pd
@@ -9,7 +10,6 @@ import dateutil
 from scipy.stats import norm
 
 from allensdk import one
-
 
 # TODO: add trial column descriptions
 TRIAL_COLUMN_DESCRIPTION_DICT = {}
@@ -215,37 +215,121 @@ def get_trial_reward_time(rebased_reward_times, start_time, stop_time):
         rebased_reward_times <= stop_time
     ))]
     return float('nan') if len(reward_times) == 0 else one(reward_times)
-        
 
-def get_trial_timing(event_dict, stimulus_presentations_df, licks, go, catch, auto_rewarded, hit, false_alarm):
-    '''
-    extract trial timing data
-    
-    content of trial log depends on trial type depends on trial type and response type
-    go, catch, auto_rewarded, hit, false_alarm must be passed as booleans to disambiguate trial and response type
 
-    on `go` or `auto_rewarded` trials, extract the stimulus_changed time
-    on `catch` trials, extract the sham_change time
+def _get_response_time(licks: List[float], aborted: bool) -> float:
+    """
+    Return the time the first lick occurred in a non-"aborted" trial.
+    A response time is not returned for on an "aborted trial", since by
+    definition, the animal licked before the change stimulus.
 
-    on `hit` trials, extract the response time from the `hit` entry in event_dict
-    on `false_alarm` trials, extract the response time from the `false_alarm` entry in event_dict
-    '''
+    Parameters
+    ==========
+    licks: List[float]
+        List of timestamps that a lick occurred during this trial.
+        The list should contain all licks that occurred while the trial
+        was active (between 'trial_start' and 'trial_end' events)
+    aborted: bool
+        Whether or not the trial was "aborted". This means that the
+        response occurred before the stimulus change and should not be
+        a valid response.
+    Returns
+    =======
+    float
+        Time of first lick if there was a valid response, otherwise
+        NaN. See rules above.
+    """
+    if aborted:
+        return float("nan")
+    if len(licks):
+        return licks[0]
+    else:
+        return float("nan")
 
-    assert not (hit==True and false_alarm==True), "both `hit` and `false_alarm` cannot be True, they are mutually exclusive categories"
-    assert not (go==True and catch==True), "both `go` and `catch` cannot be True, they are mutually exclusive categories"
-    assert not (go==True and auto_rewarded==True), "both `go` and `auto_rewarded` cannot be True, they are mutually exclusive categories"
+
+def get_trial_timing(
+        event_dict: dict, stimulus_presentations_df: pd.DataFrame,
+        licks: List[float], go: bool, catch: bool, auto_rewarded: bool,
+        hit: bool, false_alarm: bool, aborted: bool):
+    """
+    Extract a dictionary of trial timing data.
+    See trial_data_from_log for a description of the trial types.
+
+    Parameters
+    ==========
+    event_dict: dict
+        Dictionary of trial events in the well-known `pkl` file
+    stimulus_presentations_df: pd.DataFrame
+        pandas dataframe of stimulus presentations, from the
+        `get_stimulus_presentations` response for the
+        BehaviorOphysSession.api.
+    licks: List[float]
+        list of lick timestamps, from the `get_licks` response for
+        the BehaviorOphysSession.api.
+    go: bool
+        True if "go" trial, False otherwise. Mutually exclusive with
+        `catch`.
+    catch: bool
+        True if "catch" trial, False otherwise. Mutually exclusive
+        with `go.`
+    auto_rewarded: bool
+        True if "auto_rewarded" trial, False otherwise.
+    hit: bool
+        True if "hit" trial, False otherwise
+    false_alarm: bool
+        True if "false_alarm" trial, False otherwise
+    aborted: bool
+        True if "aborted" trial, False otherwise
+
+    Returns
+    =======
+    dict
+        start_time: float
+            The time the trial started (in seconds elapsed from
+            recording start)
+        stop_time: float
+            The time the trial ended (in seconds elapsed from
+            recording start)
+        trial_length: float
+            Duration of the trial in seconds
+        response_time: float
+            The response time, for non-aborted trials. This is equal
+            to the first lick in the trial. For aborted trials or trials
+            without licks, `response_time` is NaN.
+        change_frame: int
+            The frame number that the stimulus changed
+        change_time: float
+            The time in seconds that the stimulus changed
+        response_latency: float or None
+            The time in seconds between the stimulus change and the
+            animal's lick response, if the trial is a "go", "catch", or
+            "auto_rewarded" type. If the animal did not respond,
+            return `float("inf")`. In all other cases, return None.
+
+    Notes
+    =====
+    The following parameters are mutually exclusive (exactly one can
+    be true):
+        hit, miss, false_alarm, aborted, auto_rewarded
+    """
+    assert not (aborted and (hit or false_alarm or auto_rewarded)), (
+        "'aborted' trials cannot be 'hit', 'false_alarm', or 'auto_rewarded'")
+    assert not (hit and false_alarm), (
+        "both `hit` and `false_alarm` cannot be True, they are mutually "
+        "exclusive categories")
+    assert not (go and catch), (
+        "both `go` and `catch` cannot be True, they are mutually exclusive "
+        "categories")
+    assert not (go and auto_rewarded), (
+        "both `go` and `auto_rewarded` cannot be True, they are mutually "
+        "exclusive categories")
 
     start_time = event_dict["trial_start", ""]['rebased_time']
     stop_time = event_dict["trial_end", ""]['rebased_time']
 
-    if hit:
-        response_time = event_dict.get(("hit", ""))['rebased_time']
-    elif false_alarm:
-        response_time = event_dict.get(("false_alarm", ""))['rebased_time']
-    else:
-        response_time = float("nan")
+    response_time = _get_response_time(licks, aborted)
 
-    def get_change_time(change_frame,stimulus_presentations_df):
+    def get_change_time(change_frame, stimulus_presentations_df):
         # get the first stimulus in the log after the current change frame:
         query = stimulus_presentations_df.query('start_frame >= @change_frame')
         if len(query) > 0:
@@ -256,10 +340,10 @@ def get_trial_timing(event_dict, stimulus_presentations_df, licks, go, catch, au
 
     if go or auto_rewarded:
         change_frame = event_dict.get(('stimulus_changed', ''))['frame']
-        change_time = get_change_time(change_frame,stimulus_presentations_df)
+        change_time = get_change_time(change_frame, stimulus_presentations_df)
     elif catch:
         change_frame = event_dict.get(('sham_change', ''))['frame']
-        change_time = get_change_time(change_frame,stimulus_presentations_df)
+        change_time = get_change_time(change_frame, stimulus_presentations_df)
     else:
         change_time = float("nan")
         change_frame = float("nan")
@@ -279,7 +363,7 @@ def get_trial_timing(event_dict, stimulus_presentations_df, licks, go, catch, au
         "change_frame": change_frame,
         "change_time": change_time,
         "response_latency": response_latency,
-    }       
+    }
 
 
 def get_trial_image_names(trial, stimuli):
@@ -332,6 +416,7 @@ def get_trials(data, licks_df, rewards_df, stimulus_presentations_df, rebase):
             tr_data['auto_rewarded'],
             tr_data['hit'],
             tr_data['false_alarm'],
+            tr_data["aborted"]
         ))
         tr_data.update(get_trial_image_names(trial, stimuli))
 


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
For a given trial, the `response_time` now equals the
time of the first lick event for non-'aborted' trials.
If the trial is 'aborted' (lick occurs prior to the
stimulus change), or no licks occurred in the trial,
'response_time' is 'NaN' instead.

This differs from the previous implementation,
where 'response_time' was extracted from 'hit'
or 'false_alarm' events in the trial event log,
(which were triggered by licks) and null for
all other trial types.


# Addresses:
Resolves #1323 

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
For a given trial, the `response_time` now equals the
time of the first lick event for non-'aborted' trials.

## Validation
Added unit-testing for the extraction function.
Updated existing integration test to assert that response time is equal to the first lick.
Confirmed all tests pass.

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests