### PR TITLE
GH #1461: Enhancement - demixing modified to load movie stack in blocks

### DIFF
--- a/allensdk/brain_observatory/demixer.py
+++ b/allensdk/brain_observatory/demixer.py
@@ -111,7 +111,8 @@ def _demix_point(source_frame: np.ndarray, mask_traces: np.ndarray,
 
 
 def demix_time_dep_masks(raw_traces: np.ndarray, stack: np.ndarray,
-                         masks: np.ndarray) -> Tuple[np.ndarray, list]:
+                         masks: np.ndarray,
+                         block_size: int = 1000) -> Tuple[np.ndarray, list]:
     """
     Demix traces of potentially overlapping masks extraced from a single
     2p recording.
@@ -120,10 +121,12 @@ def demix_time_dep_masks(raw_traces: np.ndarray, stack: np.ndarray,
         (t, n), where `t` is the number of time points and `n` is the
         number of masks.
     :param stack: 3d array representing a 1p recording movie, of
-        dimensions (t, H, W).
+        dimensions (t, H, W) or corresponding hdf5 dataset.
     :param masks: 3d array of binary roi masks, of shape (n, H, W),
         where `n` is the number of masks, and HW are the dimensions of
         an individual frame in the movie `stack`.
+    :block_size: int representing maximum number of movie frames to read
+        at a time (-1 for full length `t` of `stack`) (the default is 1000)
     :return: Tuple of demixed traces and whether each frame was skipped
         in the demixing calculation.
     """
@@ -131,8 +134,12 @@ def demix_time_dep_masks(raw_traces: np.ndarray, stack: np.ndarray,
     _, x, y = masks.shape
     P = x * y
 
-    if len(stack.shape) == 3:
-        stack = stack.reshape(T, P)
+    if block_size == -1:
+        block_size = T
+    elif block_size < 1:
+        raise ValueError("Invalid block size {}. Block size must be strictly "
+                         "positive (>= 1), or -1 for full length block "
+                         "size.".format(block_size))
 
     num_pixels_in_mask = np.sum(masks, axis=(1, 2))
 
@@ -143,8 +150,15 @@ def demix_time_dep_masks(raw_traces: np.ndarray, stack: np.ndarray,
     demix_traces = np.zeros((N, T))
 
     for t in range(T):
+
+        block_t = t % block_size
+        if block_t == 0:  # load next block into memory and reshape
+            block_T = np.min([(T - t), block_size])
+            stack_block = stack[t : t+block_size].reshape(block_T, P)
+
         demixed_point = _demix_point(
-            stack[t], raw_traces[:, t], flat_masks, num_pixels_in_mask)
+            stack_block[block_t], raw_traces[:, t], flat_masks,
+            num_pixels_in_mask)
         if demixed_point is not None:
             demix_traces[:, t] = demixed_point
             drop_frames.append(False)

--- a/allensdk/test/brain_observatory/test_demixer.py
+++ b/allensdk/test/brain_observatory/test_demixer.py
@@ -62,17 +62,64 @@ def test_demix_raises_warning_for_singular_matrix(
 
 
 @pytest.mark.parametrize(
-    "raw_traces,stack,masks,expected",
+    "raw_traces,stack,masks,max_block_size,expected",
     [
         (
             np.array([[2.0, 0.0], [2.0, 2.0]]),
             np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
             np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            1, # max_block_size < stack length
             (np.array([[0, 0], [2, 0]]), [False, True])
+        ),
+        (
+            np.array([[2.0, 0.0], [2.0, 2.0]]),
+            np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
+            np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            2, # max_block_size = stack length
+            (np.array([[0, 0], [2, 0]]), [False, True])
+        ),
+        (
+            np.array([[2.0, 0.0], [2.0, 2.0]]),
+            np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
+            np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            1000,  # max_block_size > stack length
+            (np.array([[0, 0], [2, 0]]), [False, True])
+        ),
+        (
+            np.array([[2.0, 0.0], [2.0, 2.0]]),
+            np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
+            np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            -1,  # stack processed in one block
+            (np.array([[0, 0], [2, 0]]), [False, True])
+        ),
+        (
+            np.array([[2.0, 0.0, 1.0], [2.0, 2.0, 0.0]]),
+            np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]], [[1., 2.], [1., 2.]]]),
+            np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            2,  # stack length not divisible by max_block_size
+            (np.array([[0, 0, 0], [2, 0, 0]]), [False, True, True])
+        ),
+
+    ],
+)
+def test_demix_time_dep_masks(raw_traces, stack, masks, max_block_size, expected):
+    result = dmx.demix_time_dep_masks(raw_traces, stack, masks, max_block_size)
+    np.testing.assert_equal(result[0], expected[0])
+    assert result[1] == expected[1]
+
+
+@pytest.mark.parametrize(
+    "raw_traces,stack,masks,max_block_size",
+    [
+        (
+            np.array([[2.0, 0.0], [2.0, 2.0]]),
+            np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
+            np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            -2, # invalid max_block_size)
         ),
     ],
 )
-def test_demix_time_dep_masks(raw_traces, stack, masks, expected):
-    result = dmx.demix_time_dep_masks(raw_traces, stack, masks)
-    np.testing.assert_equal(result[0], expected[0])
-    assert result[1] == expected[1]
+def test_demix_invalid_max_block_size(raw_traces, stack, masks, max_block_size):
+    with pytest.raises(ValueError, match="Invalid maximum block size*"):
+        dmx.demix_time_dep_masks(raw_traces, stack, masks, max_block_size)
+

--- a/allensdk/test/brain_observatory/test_demixer.py
+++ b/allensdk/test/brain_observatory/test_demixer.py
@@ -62,17 +62,25 @@ def test_demix_raises_warning_for_singular_matrix(
 
 
 @pytest.mark.parametrize(
-    "raw_traces,stack,masks,expected",
+    "raw_traces,stack,masks,block_size,expected",
     [
         (
             np.array([[2.0, 0.0], [2.0, 2.0]]),
             np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
             np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            1000,
+            (np.array([[0, 0], [2, 0]]), [False, True])
+        ),
+        (
+            np.array([[2.0, 0.0], [2.0, 2.0]]),
+            np.array([[[2., 2.], [2., 1.]], [[2., 2.], [2., 1.]]]),
+            np.array([[[1, 0], [0, 0]], [[1, 1], [0, 0]]]),
+            -1,  # stack processed in one block
             (np.array([[0, 0], [2, 0]]), [False, True])
         ),
     ],
 )
-def test_demix_time_dep_masks(raw_traces, stack, masks, expected):
-    result = dmx.demix_time_dep_masks(raw_traces, stack, masks)
+def test_demix_time_dep_masks(raw_traces, stack, masks, block_size, expected):
+    result = dmx.demix_time_dep_masks(raw_traces, stack, masks, block_size)
     np.testing.assert_equal(result[0], expected[0])
     assert result[1] == expected[1]


### PR DESCRIPTION
# Overview:
`demixer.demix_time_dep_masks()` requires full movie stacks to be loaded,  
which can lead to out-of-memory (OOM) errors for large files.
(This pull request replaces the old, closed pull request #1464.)

# Addresses:
Addresses issue #1461

# Type of Fix:
New feature (non-breaking change which adds functionality)

# Solution:
`demixer.demix_time_dep_masks()` has been modified to accept a `block_size` 
parameter with a default value of 1000. Frames from the movie `stack` are now 
loaded and reshaped in blocks, avoiding OOM errors. 
`stack` can still be passed as an array as before, allowing backward compatibility, 
but now also as an hdf5 dataset. 

# Changes:
- `demixer.demix_time_dep_masks()` docstring updated
- `block_size` argument added with default value 1000
- `block_size` value of -1 loads stack in a single block
- Checks for invalid `block_size` values and raises an error if not -1 or >=1
- Movie stack reshaped within the demixing for loop, in blocks 
- Unit test `test_demixer.py` tests for `block_size` values -1 and 1000

# Validation:
Unit tests passed, as well as tests on local datasets.

# Notes:
This pull request replaces the old, closed pull request #1464.
