### PR TITLE
Update ophys behavior write nwb compatability

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -463,20 +463,20 @@ class BehaviorOphysSession(ParamsMixin):
         for ii, (_, row) in enumerate(table.iterrows()):
             output[ii, :, :] = _translate_roi_mask(row["image_mask"], int(row["y"]), int(row["x"]))
 
-        segmentation_mask_image = self.api.get_segmentation_mask_image()
-        spacing = segmentation_mask_image.GetSpacing()
-        unit = segmentation_mask_image.GetMetaData('unit')
+        pixel_size_um = self.api.get_surface_2p_pixel_size_um()
+        spacing_mm = (pixel_size_um / 1000., pixel_size_um / 1000.)
+        unit = 'mm'
 
         return xr.DataArray(
             data=output,
             dims=("cell_roi_id", "row", "column"),
             coords={
                 "cell_roi_id": cell_roi_ids,
-                "row": np.arange(full_image_shape[0]) * spacing[0],
-                "column": np.arange(full_image_shape[1]) * spacing[1]
+                "row": np.arange(full_image_shape[0]) * spacing_mm[0],
+                "column": np.arange(full_image_shape[1]) * spacing_mm[1]
             },
             attrs={
-                "spacing": spacing,
+                "spacing": spacing_mm,
                 "unit": unit
             }
         ).squeeze(drop=True)

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -29,9 +29,6 @@ class BehaviorOphysJsonApi(BehaviorOphysLimsApi):
     def get_max_projection_file(self):
         return self.data['max_projection_file']
 
-    def get_segmentation_mask_image_file(self):
-        return self.data['segmentation_mask_image_file']
-
     def get_sync_file(self):
         return self.data['sync_file']
 

--- a/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
@@ -29,7 +29,6 @@ class SessionData(RaisingSchema):
     movie_width = Int(required=True, description='width of field-of-view for 2p movie')
     container_id = Int(required=True, description='container that this experiment is in')
     sync_file = String(required=True, description='path to sync file')
-    segmentation_mask_image_file = String(required=True, description='path to segmentation_mask_image file')
     max_projection_file = String(required=True, description='path to max_projection file')
     behavior_stimulus_file = String(required=True, description='path to behavior_stimulus file')
     dff_file = String(required=True, description='path to dff file')

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -346,7 +346,7 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
 
     def get_current_source_density(self, probe_id):
         csd_mod = self._probe_nwbfile(probe_id).get_processing_module("current_source_density")
-        nwb_csd = csd_mod["current_source_density"]
+        nwb_csd = csd_mod["ecephys_csd"]
         csd_data = nwb_csd.time_series.data[:].T  # csd data stored as (timepoints x channels) but we want (channels x timepoints)
 
         csd = xr.DataArray(

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -384,29 +384,6 @@ class OphysLimsApi(CachedInstanceMethodMixin):
         return self.lims_db.fetchone(query, strict=True)
 
     @memoize
-    def get_segmentation_mask_image_file(self):
-        query = '''
-                SELECT obj.storage_directory || obj.filename AS OphysSegmentationMaskImage_filename
-                FROM ophys_experiments oe
-                LEFT JOIN ophys_cell_segmentation_runs ocsr ON ocsr.ophys_experiment_id = oe.id AND ocsr.current = 't'
-                LEFT JOIN well_known_files obj ON obj.attachable_id=ocsr.id AND obj.attachable_type = 'OphysCellSegmentationRun' AND obj.well_known_file_type_id IN (SELECT id FROM well_known_file_types WHERE name = 'OphysSegmentationMaskImage')
-                WHERE oe.id= {};
-                '''.format(self.get_ophys_experiment_id())
-        return safe_system_path(self.lims_db.fetchone(query, strict=True))
-
-
-    @memoize
-    def get_segmentation_mask_image(self, image_api=None):
-
-        if image_api is None:
-            image_api = ImageApi
-
-        segmentation_mask_image_file = self.get_segmentation_mask_image_file()
-        pixel_size = self.get_surface_2p_pixel_size_um()
-        segmentation_mask_image = mpimg.imread(segmentation_mask_image_file)
-        return ImageApi.serialize(segmentation_mask_image, [pixel_size / 1000., pixel_size / 1000.], 'mm')
-
-    @memoize
     def get_sex(self):
         query = '''
                 SELECT g.name as sex

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -196,11 +196,9 @@ def cell_specimen_table_api():
                 }, index=pd.Index(data=[10, 11], name="cell_specimen_id")
             )
 
-        def get_segmentation_mask_image(self):
-            data = roi_1  # useless image data here
-            spacing = (1, 1)
-            unit = 'index'
-            return ImageApi.serialize(data, spacing, unit)
+        def get_surface_2p_pixel_size_um(self):
+            return 1000
+
     return CellSpecimenTableApi()
 
 

--- a/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_ophys_lims_api.py
@@ -248,25 +248,6 @@ def test_get_surface_2p_pixel_size_um(ophys_lims_experiment_id, compare_val):
 
 @pytest.mark.requires_bamboo
 @pytest.mark.parametrize('ophys_lims_experiment_id, compare_val', [
-    pytest.param(511458874, '/allen/programs/braintv/production/neuralcoding/prod6/specimen_503292442/ophys_experiment_511458874/processed/ophys_cell_segmentation_run_572290131/maxInt_masks.tif'),
-    pytest.param(0, None)
-])
-def test_get_segmentation_mask_image_file(ophys_lims_experiment_id, compare_val):
-
-    ophys_lims_api = OphysLimsApi(ophys_lims_experiment_id)
-    if compare_val is None:
-        expected_fail = False
-        try:
-            ophys_lims_api.get_segmentation_mask_image_file()
-        except OneResultExpectedError:
-            expected_fail = True
-        assert expected_fail is True
-    else:
-        assert ophys_lims_api.get_segmentation_mask_image_file() == compare_val
-
-
-@pytest.mark.requires_bamboo
-@pytest.mark.parametrize('ophys_lims_experiment_id, compare_val', [
     pytest.param(842510825, 'M'),
     pytest.param(0, None)
 ])

--- a/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
+++ b/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
@@ -626,7 +626,7 @@ def test_write_probe_lfp_file(tmpdir_factory, lfp_data, probe_data, csd_data):
         else:
             pd.testing.assert_frame_equal(obt_electrodes, exp_electrodes, check_like=True)
 
-        csd_series = obt_f.get_processing_module("current_source_density")["current_source_density"]
+        csd_series = obt_f.get_processing_module("current_source_density")["ecephys_csd"]
 
         assert np.allclose(csd_data["csd"], csd_series.time_series.data[:].T)
         assert np.allclose(csd_data["relative_window"], csd_series.time_series.timestamps[:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ argschema<2.0.0
 marshmallow==3.0.0rc6
 glymur==0.8.19
 xarray<0.16.0
-hdmf>=1.6.3,<2.0.0
 pynwb>=1.3.2,<2.0.0
 tables==3.5.1 # pinning this because updates tend to not include wheels immediately
 seaborn<1.0.0


### PR DESCRIPTION
# Overview:
This PR is aimed at fixing 2 issues:

1) `pynwb` 1.4.0 updated its `hdmf` dependency to `2.2.0`
Because AllenSDK had pinned *both* `pynwb` and `hdmf` to < 2.0.0 this caused problems. The first commit removes the explicit `hdmf` requirement from the requirements.txt so that only `pynwb` will be version bounded. 

2) The new upcoming ophys segmentation pipeline no longer produces a `segmentation mask image file`. This caused problems for the ophys behavior write NWB module which expected this file. The second commit removes the dependency on the `segmentation mask image file`. For details, please see commit message.

# Addresses:
- https://github.com/AllenInstitute/AllenSDK/issues/1690
- https://github.com/AllenInstitute/ophys_etl_pipelines/issues/47

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# TODO:

- [ ] squash commits when things are okay'ed