### PR TITLE
Fix internal Bamboo CI test failures

### DIFF
--- a/docker/anaconda3/Dockerfile
+++ b/docker/anaconda3/Dockerfile
@@ -1,17 +1,26 @@
-# DOCKER-VERSION 1.11.1
-#
 # docker build --tag alleninstitute/allensdk:anaconda3 .
 # docker run -it alleninstitute/allensdk:anaconda3 /bin/bash
 #
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:4.8.2
 
-MAINTAINER David Feng <davidf@alleninstitute.org>
+LABEL maintainer="nicholas.mei@alleninstitute.org"
 
-# neuron installation
-WORKDIR root
-COPY shared/apt_get_dependencies.sh ./shared/
-RUN /bin/bash shared/apt_get_dependencies.sh
-COPY shared/conda_27.sh ./shared/
-RUN /bin/bash shared/conda_27.sh
-COPY shared/conda_36.sh ./shared/
-RUN /bin/bash shared/conda_36.sh
+RUN apt-get update \
+    && apt-get install -y \
+        automake \
+        libopenjp2-7 \
+        make \
+        pkg-config \
+        rsync \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN conda update -y conda
+
+RUN conda create -y --name py36 python=3.6 ipykernel \
+    && conda clean --index-cache --tarballs
+
+RUN conda create -y --name py37 python=3.7 ipykernel \
+    && conda clean --index-cache --tarballs
+
+RUN conda create -y --name py38 python=3.8 ipykernel \
+    && conda clean --index-cache --tarballs

--- a/docker/anaconda3/shared/apt_get_dependencies.sh
+++ b/docker/anaconda3/shared/apt_get_dependencies.sh
@@ -1,3 +1,0 @@
-apt-get update
-apt-get -yq install pkg-config make automake
-apt-get -yq install libopenjp2-7

--- a/docker/anaconda3/shared/conda_27.sh
+++ b/docker/anaconda3/shared/conda_27.sh
@@ -1,5 +1,0 @@
-conda update -y conda
-source activate base
-conda create -n py27 python=2.7 anaconda
-source activate base
-/opt/conda/envs/py27/bin/python -m ipykernel install

--- a/docker/anaconda3/shared/conda_36.sh
+++ b/docker/anaconda3/shared/conda_36.sh
@@ -1,5 +1,0 @@
-conda update -y conda
-source activate base
-conda create -n py36 python=3.6 anaconda
-source activate base
-/opt/conda/envs/py36/bin/python -m ipykernel install

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,6 +6,7 @@ pytest-xdist>=1.14,<2.0.0
 pytest-mock>=1.5.0,<3.0.0
 mock>=1.0.1,<5.0.0
 coverage>=3.7.1,<6.0.0
+scikit-learn<1.0.0
 # these overlap with requirements specified in doc_requirements. As long as they are needed, these specifications must be kept in sync
 # TODO: see if we can avoid duplicating these requirements - this will involved surveying CI
 pep8==1.7.0,<2.0.0


### PR DESCRIPTION
This PR aims to fix errors occurring with our
internal Bamboo CI infrastructure. The root cause
appears to be an extremely out of date base docker image
which causing problems when trying to install/test AllenSDK.

The new dockerfile spec also generates a drastically smaller
image (~6.5 GB -> ~1.5 GB).

Because the new docker image is very minimal it was discovered
that a particular internal test has a dependency on scikit-learn
which is why it has been added as a test-requirement.