### PR TITLE
Fix for Issue #1682

### DIFF
--- a/allensdk/brain_observatory/sync_utilities/__init__.py
+++ b/allensdk/brain_observatory/sync_utilities/__init__.py
@@ -23,7 +23,8 @@ def trim_discontiguous_times(times, threshold=100):
 
 
 def get_synchronized_frame_times(session_sync_file: Path,
-                                 sync_line_label_keys: Tuple[str, ...]) -> pd.Series:
+                                 sync_line_label_keys: Tuple[str, ...],
+                                 trim_after_spike: bool = True) -> pd.Series:
     """Get experimental frame times from an experiment session sync file.
 
     Parameters
@@ -37,6 +38,10 @@ def get_synchronized_frame_times(session_sync_file: Path,
         Line label keys to get times for. See class attributes of
         allensdk.brain_observatory.sync_dataset.Dataset for a listing of
         possible keys.
+    trim_after_spike : bool = True
+        If True, will calll trim_discontiguous_times on the frame times
+        before returning them, which will detect any spikes in the data
+        and remove all elements for the list which come after the spike.
 
     Returns
     -------
@@ -51,6 +56,6 @@ def get_synchronized_frame_times(session_sync_file: Path,
 
     # Occasionally an extra set of frame times are acquired after the rest of
     # the signals. We detect and remove these.
-    frame_times = trim_discontiguous_times(frame_times)
+    frame_times = trim_discontiguous_times(frame_times) if trim_after_spike else frame_times
 
     return pd.Series(frame_times)

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -299,7 +299,8 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
         eye_tracking_data = load_eye_tracking_hdf(filepath)
         frame_times = sync_utilities.get_synchronized_frame_times(
             session_sync_file=sync_path,
-            sync_line_label_keys=Dataset.EYE_TRACKING_KEYS)
+            sync_line_label_keys=Dataset.EYE_TRACKING_KEYS,
+            trim_after_spike=False)
 
         eye_tracking_data = process_eye_tracking_data(eye_tracking_data,
                                                       frame_times,

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_utilities.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_utilities.py
@@ -54,3 +54,17 @@ def test_get_synchronized_frame_times(monkeypatch, mock_dataset_fixture,
 
     obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys)
     assert np.allclose(obtained, expected)
+
+@pytest.mark.parametrize("mock_dataset_fixture,sync_line_label_keys,expected", [
+    ({"eye_tracking_timings": [0.020, 0.030, 0.040, 0.050, 3.0]},
+     Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 0.040, 0.050, 3.0]),
+
+    ({"behavior_tracking_timings": [0.080, 0.090, 0.100, 0.110, 8.0]},
+     Dataset.BEHAVIOR_TRACKING_KEYS, [0.08, 0.090, 0.100, 0.110, 8.0])
+], indirect=["mock_dataset_fixture"])
+def test_get_synchronized_frame_times_no_trim(monkeypatch, mock_dataset_fixture,
+                                      sync_line_label_keys, expected):
+    monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
+
+    obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys, trim_after_spike=False)
+    assert np.allclose(obtained, expected)


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

This is a fix for the problem of the mismatch between the count returned by sync counts on load, and in eye_tracking file. @kschelonka and I Discovered that there were some outlier values in the frame time lists, and an internal method was clipping off all data after the outlier, assuming (in this case, wrongly) that it must be part of another experiment.

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1682 ](https://github.com/AllenInstitute/AllenSDK/issues/1682)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

To fix this, I added an opt out to the trimming that occurs in get_synchronized_frame_times.

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

- Added a bool argument to get_synchronized_frame_times, default set to True
- If this argument is True, the function acts identically to before
- If this argument is False, it will skip the step where it clips off data after an outlier
- Copied the existing unit test for get_synchronized_frame_times, and changed the expected outputs
- I updated the docstring to include this new argument

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
I ran all unit tests for AllenSDK
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
