### PR TITLE
Fixes breaking regression test between data api and lims api

### DIFF
--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -155,7 +155,8 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
         idx_name = stimulus_presentations_df_pre.index.name
         stimulus_index_df = stimulus_presentations_df_pre.reset_index().merge(stimulus_metadata_df.reset_index(), on=['image_name']).set_index(idx_name)
         stimulus_index_df.sort_index(inplace=True)
-        stimulus_index_df = stimulus_index_df[['image_set', 'image_index', 'start_time']].rename(columns={'start_time': 'timestamps'})
+        stimulus_index_df = stimulus_index_df[['image_set', 'image_index', 'start_time',
+                                               'phase', 'spatial_frequency']].rename(columns={'start_time': 'timestamps'})
         stimulus_index_df.set_index('timestamps', inplace=True, drop=True)
         stimulus_presentations_df = stimulus_presentations_df_pre.merge(stimulus_index_df, left_on='start_time', right_index=True, how='left')
         assert len(stimulus_presentations_df_pre) == len(stimulus_presentations_df)


### PR DESCRIPTION
Adds columns for spatial frequency and phase to the lims api call for get_stimulus_presentations that fixes the breaking regression test. This makes the data between the two api's congruent.

## Validation:
The failing regression test now passes when I run the test on my computer with network access.
![image](https://user-images.githubusercontent.com/58192697/93798277-45354d80-fbf2-11ea-8662-12a76485c988.png)

#### Test Instructions:
1. Checkout this branch on a computer with network access
2. Cd into `Allensdk/allensdk/test/brain_observatory/behavior`
3. Remove nightly and requires_bamboo tag from TestBehaviorRegression in `test_behavior_data_lims_api.py` (or use requires_bamboo=True nightly=True)
4. Run `pytest test_behavior_data_lims_api.py::TestBehaviorRegression::test_get_stimulus_presentations_regression`