### PR TITLE
Grid data docs page

### DIFF
--- a/doc_template/connectivity.rst
+++ b/doc_template/connectivity.rst
@@ -20,13 +20,8 @@ in more detail on the :doc:`structure unionizes page </unionizes>`.
 Voxel-Level Projection Data
 ---------------------------
 
-The CCF-registered AAV projection signal is also available for download as a set of 3D volumes for each experiment.  The following data volumes
-are available for download:
-
-    - **projection density**: sum of detected projection pixels / sum of all pixels in voxel
-    - **injection_fraction**: fraction of pixels belonging to manually annotated injection site
-    - **injection_density**: density of detected projection pixels within the manually annotated injection site
-    - **data_mask**: binary mask indicating if a voxel contains valid data. Only valid voxels should be used for analysis.
+The CCF-registered AAV projection signal is also available for download as a set of 3D volumes for each experiment. For 
+more information, see the :doc:`grid data page </connectivity_grid_data>`.
 
 
 Code Examples

--- a/doc_template/connectivity_grid_data.rst
+++ b/doc_template/connectivity_grid_data.rst
@@ -1,0 +1,30 @@
+Connectivity Grid Data
+----------------------
+
+Image data from each Allen Mouse Connectivity Atlas experiment is 
+registered to the Common Coordinate Framework (CCF). This produces a series of 
+CCF-space 3D "grid" volumes which describe the location and extent of that experiment's 
+injection site (containing infected cell bodies) as well as the distribution of 
+AAV Projection signal throughout the brain.
+
+You can access these grid volumes either `via the API <http://help.brain-map.org/display/api/Downloading+3-D+Expression+Grid+Data>`_
+or by constructing a :py:class:`allensdk.core.mouse_connectivity_cache.MouseConnectivityCache`.
+
+We produce grid volumes from registered images using the `grid module <https://github.com/AllenInstitute/AllenSDK/tree/master/allensdk/mouse_connectivity/grid>`_. 
+These volumes are then used downstream by the `unionize module <https://github.com/AllenInstitute/AllenSDK/tree/master/allensdk/internal/mouse_connectivity/interval_unionize>`_, which
+summarizes AAV signal within each annotated brain structure, producing :doc:`structure unionizes </unionizes>`.
+
+
+Reference
+---------
+
+========================= ===========================================
+Method                    Description                                
+========================= ===========================================
+projection_density        sum of detected projection pixels / sum of all pixels in voxel
+injection_fraction        fraction of pixels belonging to manually annotated injection site
+injection_density         density of detected projection pixels within the manually annotated injection site
+data_mask                 binary mask indicating if a voxel contains valid data. Only valid voxels should be used for analysis.
+
+
+Note that projection density reports detected AAV signal both within and outside the injection site.

--- a/doc_template/connectivity_grid_data.rst
+++ b/doc_template/connectivity_grid_data.rst
@@ -19,12 +19,12 @@ Reference
 ---------
 
 ========================= ===========================================
-Method                    Description                                
+Volume                    Description                                
 ========================= ===========================================
 projection_density        sum of detected projection pixels / sum of all pixels in voxel
 injection_fraction        fraction of pixels belonging to manually annotated injection site
 injection_density         density of detected projection pixels within the manually annotated injection site
 data_mask                 binary mask indicating if a voxel contains valid data. Only valid voxels should be used for analysis.
-
+========================= ===========================================
 
 Note that projection density reports detected AAV signal both within and outside the injection site.


### PR DESCRIPTION
Adds a standalone documentation page for mouse connecitivty grid data. Includes a few more links and notes than the current documentation. See here: https://allensdk.readthedocs.io/en/1699-grid-data-docs/connectivity_grid_data.html