### PR TITLE
GH #1654: Mesoscope time resampling

### DIFF
--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -37,6 +37,53 @@ class OphysLimsApi(CachedInstanceMethodMixin):
         return self.ophys_experiment_id
 
     @memoize
+    def get_plane_group_count(self) -> int:
+        """Gets the total number of plane groups in the session.
+        This is required for resampling ophys timestamps for mesoscope
+        data. Will be 0 if the scope did not capture multiple concurrent
+        frames. See `get_imaging_plane_group` for more info.
+        """
+        query = f"""
+            -- Get the session ID for an experiment
+            WITH sess AS (
+                SELECT os.id from ophys_experiments oe
+                JOIN ophys_sessions os ON os.id = oe.ophys_session_id
+                WHERE oe.id = {self.ophys_experiment_id}
+            )
+            SELECT  COUNT(DISTINCT(pg.group_order)) AS planes
+            FROM  ophys_sessions os
+            JOIN ophys_experiments oe ON os.id = oe.ophys_session_id
+            JOIN  ophys_imaging_plane_groups pg
+                ON pg.id = oe.ophys_imaging_plane_group_id
+            WHERE
+                -- only 1 session for an experiment
+                os.id = (SELECT id from sess limit 1)
+        """
+        return self.lims_db.fetchone(query, strict=True)
+
+    @memoize
+    def get_imaging_plane_group(self) -> Optional[int]:
+        """Get the imaging plane group number. This is a numeric index
+        that indicates the order that the frames were acquired when
+        there is more than one frame acquired concurrently. Relevant for
+        mesoscope data timestamps, as the laser jumps between plane
+        groups during the scan. Will be None for non-mesoscope data.
+        """
+        query = f"""
+            SELECT pg.group_order
+            FROM ophys_experiments oe
+            JOIN ophys_imaging_plane_groups pg
+            ON pg.id = oe.ophys_imaging_plane_group_id
+            WHERE oe.id = {self.ophys_experiment_id}
+        """
+        # Non-mesoscope data will not have results
+        group_order = self.lims_db.fetchall(query)
+        if len(group_order):
+            return group_order[0]
+        else:
+            return None
+
+    @memoize
     def get_ophys_experiment_dir(self):
         query = '''
                 SELECT oe.storage_directory

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+import numpy as np
 
 from allensdk.internal.api import OneResultExpectedError
 from allensdk.internal.api.behavior_ophys_api import BehaviorOphysLimsApi
@@ -55,3 +56,25 @@ def test_get_nwb_filepath(ophys_experiment_id):
 
     api = BehaviorOphysLimsApi(ophys_experiment_id)
     assert api.get_nwb_filepath() == '/allen/programs/braintv/production/visualbehavior/prod0/specimen_823826986/ophys_session_859701393/ophys_experiment_860030092/behavior_ophys_session_860030092.nwb'
+
+
+@pytest.mark.parametrize(
+    "timestamps,plane_group,group_count,expected",
+    [
+        (np.ones(10), 1, 0, np.ones(10)),
+        (np.ones(10), 1, 0, np.ones(10)),
+        # middle
+        (np.array([0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0]), 1, 3, np.ones(4)),
+        # first
+        (np.array([1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]), 0, 4, np.ones(3)),
+        # last
+        (np.array([0, 1, 0, 1, 0, 1, 0, 1]), 1, 2, np.ones(4)),
+        # only one group
+        (np.ones(10), 0, 1, np.ones(10))
+    ]
+)
+def test_process_ophys_plane_timestamps(
+        timestamps, plane_group, group_count, expected):
+    actual = BehaviorOphysLimsApi._process_ophys_plane_timestamps(
+        timestamps, plane_group, group_count)
+    np.testing.assert_array_equal(expected, actual)


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
Resamples the single ophys (2p) frame time stream to
properly distribute across mesoscope plane groups.
The mesoscope jumps between plane groups as it
acquires data, necessitating the resampling of the
combined time stream. Data that does not acquire multiple
planes in parallel is unaffected.

Design doc (internal link): http://confluence.corp.alleninstitute.org/x/JyZNBQ

# Addresses:
#1654 

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Takes every `nth` frame in the sync log, starting at the index of the plane_group (where `n`=total number of plane groups)

# Changes:
See above

# Validation:
Unit tests. Production data validation example in this notebook pdf:
[mesoscope_timestamps.pdf](https://github.com/AllenInstitute/AllenSDK/files/5285639/mesoscope_timestamps.pdf)

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
