### PR TITLE
GH #1491: Add behavior_session_id to BehaviorOphysSession

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
-from typing import Any
+from typing import Any, Optional
 import logging
 
 
@@ -97,6 +97,13 @@ class BehaviorOphysSession(ParamsMixin):
         :rtype: int
         """
         return self.api.get_ophys_experiment_id()
+
+    @property
+    def behavior_session_id(self) -> Optional[int]:
+        """Returns the unique identifier for the behavior session
+        associated with this experiment, if applicable.
+        """
+        return self.api.get_behavior_session_id()
 
     @property
     def max_projection(self) -> Image:

--- a/allensdk/brain_observatory/behavior/internal/behavior_base.py
+++ b/allensdk/brain_observatory/behavior/internal/behavior_base.py
@@ -15,6 +15,13 @@ class BehaviorBase(abc.ABC):
     methods.
     """
     @abc.abstractmethod
+    def get_behavior_session_id(self) -> int:
+        """Returns the behavior_session_id associated with this experiment,
+        if applicable.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def get_licks(self) -> pd.DataFrame:
         """Get lick data from pkl file.
 

--- a/allensdk/brain_observatory/behavior/internal/behavior_ophys_base.py
+++ b/allensdk/brain_observatory/behavior/internal/behavior_ophys_base.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -12,8 +13,16 @@ class BehaviorOphysBase(BehaviorBase):
     behavior+ophys session data.
 
     Child classes should be instantiated with a fetch API that implements these
-    methods. Both fetch API and session object should inherit from this base.
+    methods.
     """
+
+    @abc.abstractmethod
+    def get_ophys_session_id(self) -> Optional[int]:
+        """Returns the ophys_session_id associated with this experiment,
+        if applicable.
+        """
+        raise NotImplementedError()
+
     @abc.abstractmethod
     def get_average_projection(self) -> Image:
         """Get an image whose values are the average obtained values at

--- a/allensdk/internal/api/ophys_lims_api.py
+++ b/allensdk/internal/api/ophys_lims_api.py
@@ -84,6 +84,26 @@ class OphysLimsApi(CachedInstanceMethodMixin):
             return None
 
     @memoize
+    def get_behavior_session_id(self) -> Optional[int]:
+        """Returns the behavior_session_id associated with this experiment,
+        if applicable.
+        """
+        query = f"""
+            SELECT bs.id
+            FROM ophys_experiments oe
+            -- every ophys_experiment should have an ophys_session
+            JOIN ophys_sessions os ON oe.ophys_session_id = os.id
+            -- but not every ophys_session has a behavior_session
+            LEFT JOIN behavior_sessions bs ON os.id = bs.ophys_session_id
+            WHERE oe.id = {self.get_ophys_experiment_id()}
+        """
+        response = self.lims_db.fetchall(query)     # Can be null
+        if not len(response):
+            return None
+        else:
+            return response[0]
+
+    @memoize
     def get_ophys_experiment_dir(self):
         query = '''
                 SELECT oe.storage_directory


### PR DESCRIPTION
# Overview:
Scientists wanted a public API method to access the behavior_session_id from an instance of BehaviorOphysSession, if applicable.

# Addresses:
Resolves #1491 

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Queries for behavior_session_id based on the ophys_experiment_id and returns if it exists, otherwise `None`.

# Changes:
Queries for behavior_session_id based on the ophys_experiment_id and returns if it exists, otherwise `None`.

# Validation:
This was all SQL, so no unit tests. 
Example from prod data (working as expected):
```
In [1]: exp1 = BehaviorOphysSession.from_lims(471763049)                                                                                                        

In [2]: exp1.behavior_session_id                                                                                                                                

In [3]: exp1.behavior_session_id is None                                                                                                                        
Out[3]: True

In [4]: exp2 = BehaviorOphysSession.from_lims(954311458)                                                                                                        

In [5]: exp2.behavior_session_id                                                                                                                                
Out[5]: 954210875
```

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
~- [] My code is unit tested and does not decrease test coverage~
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
Also updated the abstract base classes
