### PR TITLE
GH #1739 - Fix ecephys raster_plot plotting units twice

### DIFF
--- a/allensdk/brain_observatory/ecephys/visualization/__init__.py
+++ b/allensdk/brain_observatory/ecephys/visualization/__init__.py
@@ -97,7 +97,9 @@ def raster_plot(spike_times, figsize=(8,8), cmap=plt.cm.tab20, title='spike rast
 
     fig, ax = plt.subplots(figsize=figsize)
     plotter = _VlPlotter(ax, num_objects=len(spike_times['unit_id'].unique()), cmap=cmap, cycle_colors=cycle_colors)
-    spike_times.groupby('unit_id').agg(plotter)
+    # aggregate is called on each column, so pass only one (eg the stimulus_presentation_id)
+    # to plot each unit once
+    spike_times[['stimulus_presentation_id', 'unit_id']].groupby('unit_id').agg(plotter)
     
     ax.set_xlabel('time (s)', fontsize=16)
     ax.set_ylabel('unit', fontsize=16)

--- a/allensdk/test/brain_observatory/ecephys/test_visualization.py
+++ b/allensdk/test/brain_observatory/ecephys/test_visualization.py
@@ -1,0 +1,14 @@
+import allensdk.brain_observatory.ecephys.visualization.__init__ as vis
+import pandas as pd
+
+def test_raster_plot():
+    spike_times = pd.DataFrame({
+        'unit_id': [2, 1, 2],
+        'stimulus_presentation_id': [2, 2, 2, ],
+        'time_since_stimulus_presentation_onset': [0.01, 0.02, 0.03]
+    }, index=pd.Index(name='spike_time', data=[1.01, 1.02, 1.03]))
+    
+    fig = vis.raster_plot(spike_times)
+    ax = fig.get_axes()[0]
+
+    assert len(spike_times['unit_id'].unique()) == len(ax.collections)


### PR DESCRIPTION
raster_plot now correctly plots each unit once.  A unit
test checks that the number of plotted lines equals the
number of units passed to the raster_plot function.

# Overview:
When running raster_plot on a spike_times dataframe, the spike 
times from each unit are plotted twice.

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->

# Type of Fix:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
The function passed to pandas's aggregate (here, the call on the 
_VlPlotter object) is called on each column, thus once on the 
'stimulus_presentation_id' and once on the 
'time_since_stimulus_presentation_onset' column.

This was fixed by passing only one column to the aggregate 
function, namely the 'stimulus_presentation_id' column.

# Changes:
- Pass only the 'stimulus_presentation_id' columns to the plotter
- Unit tests for the number of plotted units

# Validation:
### Screenshots:
### Unit Tests:
test_visualization.py creates a spike_times data frame with two
units and tests that the figure contains two rows (more precisely,
two matplotlib collections) representing the spike times of the 
units.
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [X] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [X] My code is unit tested and does not decrease test coverage
- [X] I have performed a self review of my own code
- [X] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [X] I have updated the documentation of the repository where
      appropriate
- [X] The header on my commit includes the issue number
- [X] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [X] My code passes all AllenSDK tests

# Notes:
