### PR TITLE
Fixes 2 errors in allensdk.brain_observatory.extract_running_speed.__…

### DIFF
--- a/allensdk/brain_observatory/extract_running_speed/__main__.py
+++ b/allensdk/brain_observatory/extract_running_speed/__main__.py
@@ -60,9 +60,9 @@ def extract_running_speeds(
 
     durations = end_times - start_times
     if use_median_duration:
-        angular_velocity = dx_rad / durations
+        angular_velocity = dx_rad / np.median(durations)
     else:
-        angular_velocity = dx_rad = np.median(durations)
+        angular_velocity = dx_rad / durations
 
     radius = wheel_radius * subject_position
     linear_velocity = angular_to_linear_velocity(angular_velocity, radius)


### PR DESCRIPTION
# Overview:
There are 2 errors in `extract_running_speeds()` in `allensdk/brain_observatory/extract_running_speed/__main__.py`. 
1) The if/else statements at lines 61-65 are switched.
2) There is a typo where a `/` (divide) is replaced by a second `=`. 
As a result, when `use_median_duration` is true, median duration is *not* used to calculate running speed. When it is False (else statement), the entire running speed array is accidentally set to the value of the median frame duration.  

# Addresses:
Addresses issue #1741 

# Type of Fix:
- [x] Bug fix (non-breaking change which fixes an issue)

# Solution:
The solution is to switch the contents of the if/else statements and replace the 
incorrect `=` by `/` (divide).

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
The code is not currently docstringed and the existing unit tests do not seem to test for actual running values extracted.