### PR TITLE
Pull data for summary of experiments/sessions even if there are nulls in join ids

### DIFF
--- a/allensdk/api/caching_utilities.py
+++ b/allensdk/api/caching_utilities.py
@@ -105,6 +105,10 @@ def call_caching(
     except Exception as e:
         if isinstance(e, FileNotFoundError):
             logger.info("No cache file found.")
+        # Pandas throws ValueError rather than FileNotFoundError
+        elif (isinstance(e, ValueError)
+              and str(e) == "Expected object or value"):
+            logger.info("No cache file found.")
         if cleanup is not None and not lazy:
             cleanup()
 

--- a/allensdk/brain_observatory/behavior/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache.py
@@ -18,7 +18,7 @@ BehaviorProjectApi = Type[BehaviorProjectBase]
 
 class BehaviorProjectCache(Cache):
 
-    MANIFEST_VERSION = "0.0.1-alpha.2"
+    MANIFEST_VERSION = "0.0.1-alpha.3"
     OPHYS_SESSIONS_KEY = "ophys_sessions"
     BEHAVIOR_SESSIONS_KEY = "behavior_sessions"
     OPHYS_EXPERIMENTS_KEY = "ophys_experiments"

--- a/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
@@ -211,13 +211,13 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
             FROM behavior_sessions bs
             JOIN donors d on bs.donor_id = d.id
             JOIN genders g on g.id = d.gender_id
-            JOIN (
+            LEFT OUTER JOIN (
                 {self._build_line_from_donor_query("reporter")}
             ) reporter on reporter.donor_id = d.id
-            JOIN (
+            LEFT OUTER JOIN (
                 {self._build_line_from_donor_query("driver")}
             ) driver on driver.donor_id = d.id
-            JOIN equipment ON equipment.id = bs.equipment_id
+            LEFT OUTER JOIN equipment ON equipment.id = bs.equipment_id
             {session_sub_query}
         """
         self.logger.debug(f"get_behavior_session_table query: \n{query}")
@@ -328,19 +328,19 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 ON oec.visual_behavior_experiment_container_id = vbc.id
             JOIN ophys_experiments oe ON oe.id = oec.ophys_experiment_id
             JOIN ophys_sessions os ON os.id = oe.ophys_session_id
-            JOIN behavior_sessions bs ON os.id = bs.ophys_session_id
-            JOIN projects pr ON pr.id = os.project_id
+            LEFT OUTER JOIN behavior_sessions bs ON os.id = bs.ophys_session_id
+            LEFT OUTER JOIN projects pr ON pr.id = os.project_id
             JOIN donors d ON d.id = bs.donor_id
             JOIN genders g ON g.id = d.gender_id
-            JOIN (
+            LEFT OUTER JOIN (
                 {self._build_line_from_donor_query(line="reporter")}
             ) reporter on reporter.donor_id = d.id
-            JOIN (
+            LEFT OUTER JOIN (
                 {self._build_line_from_donor_query(line="driver")}
             ) driver on driver.donor_id = d.id
             LEFT JOIN imaging_depths id ON id.id = oe.imaging_depth_id
             JOIN structures st ON st.id = oe.targeted_structure_id
-            JOIN equipment ON equipment.id = os.equipment_id
+            LEFT OUTER JOIN equipment ON equipment.id = os.equipment_id
             {experiment_query};
         """
         self.logger.debug(f"get_experiment_table query: \n{query}")
@@ -384,20 +384,20 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 reporter.reporter_line,
                 driver.driver_line
             FROM ophys_sessions os
-            JOIN behavior_sessions bs ON os.id = bs.ophys_session_id
-            JOIN projects pr ON pr.id = os.project_id
+            LEFT OUTER JOIN behavior_sessions bs ON os.id = bs.ophys_session_id
+            LEFT OUTER JOIN projects pr ON pr.id = os.project_id
             JOIN donors d ON d.id = bs.donor_id
             JOIN genders g ON g.id = d.gender_id
             JOIN (
                 {self._build_experiment_from_session_query()}
             ) exp_ids ON os.id = exp_ids.id
-            JOIN (
+            LEFT OUTER JOIN (
                 {self._build_line_from_donor_query(line="reporter")}
             ) reporter on reporter.donor_id = d.id
-            JOIN (
+            LEFT OUTER JOIN (
                 {self._build_line_from_donor_query(line="driver")}
             ) driver on driver.donor_id = d.id
-            JOIN equipment ON equipment.id = os.equipment_id
+            LEFT OUTER JOIN equipment ON equipment.id = os.equipment_id
             {session_query};
         """
         self.logger.debug(f"get_session_table query: \n{query}")

--- a/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
@@ -314,6 +314,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 os.date_of_acquisition,
                 os.isi_experiment_id,
                 os.specimen_id,
+                d.id as donor_id,
                 g.name as sex,
                 DATE_PART('day', os.date_of_acquisition - d.date_of_birth)
                     AS age_in_days,
@@ -377,6 +378,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 equipment.name as equipment_name,
                 os.date_of_acquisition,
                 os.specimen_id,
+                d.id as donor_id,
                 g.name as sex,
                 DATE_PART('day', os.date_of_acquisition - d.date_of_birth)
                     AS age_in_days,


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
Previously some sessions/experiments did not show up in the BehaviorProjectCache tables due to null join IDs, resulting in incomplete data. This PR updates the queries to allow null values in certain fields. In addition, using the LIMS "fetch API" no longer caches data on disk by default.

# Addresses:
Resolves #1483

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Changes:
- Use outer joins to allow nulls for the following fields: equipment_name, reporter_line, driver_line, project_code, imaging_depth (Note other fields can be null, but these were null due to missing a join ID in one table)
- No longer cache data coming from LIMS by default
- Write tabular data to json rather than csv to make serialization/deserialization easier when saving to cache
- Add donor_id to the ophys experiment + session summary tables (already present in behavior-only summary table)

# Validation:

Updated unit test coverage.

Example for the donor_id = 756577240; recovered the training sessions where the `equipment_name` is null (due to missing `equipment_id`)

```
from allensdk.brain_observatory.behavior.behavior_project_cache import BehaviorProjectCache
bpc = BehaviorProjectCache.from_lims()
sess[sess["donor_id"] == 756577240].sort_values("date_of_acquisition").drop(["behavior_training_id", "full_genotype", "reporter_line", "driver_line", "sex"], axis=1)
```

Previous result:
![image](https://user-images.githubusercontent.com/34227334/95918941-863c0000-0d61-11eb-8398-ff3f8637dc3f.png)


```
|                     | ophys_session_id | equipment_name |     date_of_acquisition |  donor_id | age_in_days |                          foraging_id |                      session_type |
|--------------------:|-----------------:|---------------:|------------------------:|----------:|------------:|-------------------------------------:|----------------------------------:|
| behavior_session_id |                  |                |                         |           |             |                                      |                                   |
|           769476927 |              NaN |           None | 2018-10-26 15:03:46.461 | 756577240 |        80.0 | ebcfe8a9-a93a-4b4b-94d4-a68ceece67b4 |      0_gratings_autorewards_15min |
|           769983070 |              NaN |           None | 2018-10-29 14:26:17.105 | 756577240 |        83.0 | c8211ddc-8ed7-4e4c-8ce4-52faa2b7a60a |                        1_gratings |
|           770248619 |              NaN |           None | 2018-10-30 14:32:47.666 | 756577240 |        84.0 | 0262b81c-e684-43d5-8753-11ab0edd82d3 |                        1_gratings |
|           771345209 |              NaN |           None | 2018-10-31 14:17:34.280 | 756577240 |        85.0 | 3e4683d2-d4ec-403d-b421-45fef608b99c |               TRAINING_1_gratings |
|           772128781 |              NaN |           None | 2018-11-01 15:07:09.072 | 756577240 |        86.0 | 6361f115-eedc-4262-be42-4a61ee246b35 |       TRAINING_2_gratings_flashed |
|           772682396 |              NaN |           None | 2018-11-02 14:16:22.334 | 756577240 |        87.0 | cdf57463-7500-4ff7-ac7c-cb3ea6a3cc74 |   TRAINING_3_images_A_10uL_reward |
|           773760134 |              NaN |           None | 2018-11-05 14:24:48.311 | 756577240 |        90.0 | 9fd5bece-7104-4595-84dc-1179a4652aeb |   TRAINING_3_images_A_10uL_reward |
|           774364257 |              NaN |           None | 2018-11-06 13:48:47.102 | 756577240 |        91.0 | d7a6ffa9-a8c5-4343-a736-8eb1bbda575f |   TRAINING_3_images_A_10uL_reward |
|           775013029 |              NaN |           None | 2018-11-07 14:06:23.976 | 756577240 |        92.0 | 54e6af61-3944-45a2-94d6-9fcb46b8bbf5 |      TRAINING_4_images_A_training |
|           775465635 |              NaN |           None | 2018-11-08 13:25:53.847 | 756577240 |        93.0 | 7286e519-6963-42aa-8962-a1c12bcf23f4 | TRAINING_4_images_A_handoff_ready |
|           776123405 |              NaN |           None | 2018-11-09 13:52:45.165 | 756577240 |        94.0 | 8bda53e3-4487-42d5-a350-eb803d7d712e | TRAINING_4_images_A_handoff_ready |
|           777317267 |              NaN |           None | 2018-11-12 13:37:55.194 | 756577240 |        97.0 | 3118831c-505c-4ecb-8cc8-3caab1496ed6 | TRAINING_4_images_A_handoff_ready |
|           779094078 |      779027512.0 |        CAM2P.3 | 2018-11-14 14:06:22.817 | 756577240 |        99.0 | a69f4012-3c8a-411b-a9fb-dcae18bc7593 |      OPHYS_0_images_A_habituation |
|           780857956 |      780745632.0 |        CAM2P.3 | 2018-11-16 14:59:49.202 | 756577240 |       101.0 | 18699b1e-88af-41f0-a033-fda1ef55a033 |      OPHYS_0_images_A_habituation |
|           783629024 |      783475910.0 |        CAM2P.4 | 2018-11-20 16:56:46.719 | 756577240 |       105.0 | 4b866d0b-f966-4e11-b35e-c1524245e4ac |                  OPHYS_1_images_A |
|           784320573 |      784219195.0 |        CAM2P.4 | 2018-11-21 13:18:56.947 | 756577240 |       106.0 | 4062948e-a44b-4a2e-9f33-44feca9d9627 |          OPHYS_2_images_A_passive |
|           785568095 |      785540118.0 |        CAM2P.4 | 2018-11-26 16:09:46.840 | 756577240 |       111.0 | 6292a3cb-fd6d-4a07-bb6f-1300495fa797 |                  OPHYS_3_images_A |
|           786335283 |      786235595.0 |        CAM2P.4 | 2018-11-27 15:09:54.573 | 756577240 |       112.0 | 16b74013-389b-4e6b-a89c-1b1b8b0819f4 |                  OPHYS_4_images_B |
|           788447502 |      788418567.0 |        CAM2P.5 | 2018-11-29 16:48:51.136 | 756577240 |       114.0 | b6268330-cc3b-43ae-96cc-a035bd6df47f |          OPHYS_5_images_B_passive |
|           789295700 |      789220000.0 |        CAM2P.5 | 2018-11-30 15:58:50.325 | 756577240 |       115.0 | 69cdbe09-e62b-4b42-aab1-54b5773dfe78 |                  OPHYS_6_images_B |
|           791923868 |      791882988.0 |        CAM2P.5 | 2018-12-07 16:04:16.594 | 756577240 |       122.0 | 1a107827-e92a-4425-8b57-34844b5917e6 |                  OPHYS_3_images_A |
|           793490275 |              NaN |           None | 2018-12-11 15:05:46.997 | 756577240 |       126.0 | 9b038ed6-ad66-42c8-99b6-fe78efa7c3bb |                  OPHYS_3_images_A |
|           794324246 |      794286862.0 |        CAM2P.5 | 2018-12-12 15:11:54.505 | 756577240 |       127.0 | 334b2e30-0479-40a4-bb0b-0fe06ee240ce |                  OPHYS_3_images_A |
|           795025333 |      795009671.0 |        CAM2P.4 | 2018-12-13 17:59:09.915 | 756577240 |       128.0 | ebb72f9b-941a-4587-81ea-9207dd060d92 |                  OPHYS_4_images_B |
|           795903435 |      795866393.0 |        CAM2P.5 | 2018-12-14 16:32:14.278 | 756577240 |       129.0 | 42600851-57b9-40da-8303-0374c31bd6d1 |                  OPHYS_3_images_A |
|           797061548 |      796877845.0 |           None | 2018-12-17 14:05:48.210 | 756577240 |       132.0 | a4408a4b-9917-49c9-97d5-a24a2d05ac68 |                  OPHYS_4_images_B |
|           797806962 |      797611742.0 |        CAM2P.5 | 2018-12-18 11:35:58.994 | 756577240 |       133.0 | 68fbc663-1858-4a99-8aed-821c5e03dc61 |                  OPHYS_4_images_B |
|           799131344 |      799021448.0 |        CAM2P.5 | 2018-12-19 14:21:24.738 | 756577240 |       134.0 | 67a13f9c-3651-454a-a5c9-2358387f05b4 |                  OPHYS_4_images_B |
|           779061249 |              NaN |           None |                     NaT | 756577240 |         NaN | d1d7c6e8-a62d-4775-bb53-c960b3f48f17 |                               NaN |
|           779061254 |              NaN |           None |                     NaT | 756577240 |         NaN | 77e2422b-167a-46e7-b312-3870aca6a8f2 |                               NaN |
|           791381827 |      791355484.0 |        CAM2P.5 |                     NaT | 756577240 |         NaN | 4cc81746-611b-4cd2-9d1b-d6bceb7184af |                               NaN |
```


# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

