### PR TITLE
Issue #1755

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.3.2] = 2020-10-19
+
+### Bug Fixes
+- (Internal) Fixed a running\_processing bug for behavior ophys experiments when the input data would have one more encoder entry than timestamp. The behavior of the code now matches what the warning says.
+
 ## [2.3.1] = 2020-10-13
 
 ### Bug Fixes
-- (Internal) Fixed a write_nwb bug for behavior ophys experiments involving the BehaviorOphysJsonApi expecting a mesoscope-specific method.
+- (Internal) Fixed a write\_nwb bug for behavior ophys experiments involving the BehaviorOphysJsonApi expecting a mesoscope-specific method.
 
 ## [2.3.0] = 2020-10-09
 

--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -37,7 +37,7 @@ import logging
 
 
 
-__version__ = '2.3.1'
+__version__ = '2.3.2'
 
 
 try:

--- a/allensdk/brain_observatory/behavior/running_processing.py
+++ b/allensdk/brain_observatory/behavior/running_processing.py
@@ -55,7 +55,7 @@ def _shift(
         Iterable containing numeric data. If int, will be converted to
         float in returned object.
     periods: int (default=1)
-        The number of elements to shift. 
+        The number of elements to shift.
     fill_value: float (default=np.nan)
         The value to fill at the beginning of the shifted array
     Returns
@@ -364,7 +364,9 @@ def get_running_df(data, time: np.ndarray, lowpass: bool = True):
     if len(v_in) == len(time) + 1:
         warnings.warn(
             "Time array is 1 value shorter than encoder array. Last encoder "
-            "value removed\n", stacklevel=1)
+            "value removed\n", UserWarning, stacklevel=1)
+        v_in = v_in[:-1]
+        v_sig = v_sig[:-1]
 
     # dx = 'd_theta' = angular change
     # There are some issues with angular change in the raw data so we

--- a/allensdk/test/brain_observatory/behavior/test_running_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_running_processing.py
@@ -72,6 +72,43 @@ def test_get_running_df(running_data, timestamps, lowpass):
 
 
 @pytest.mark.parametrize(
+    "lowpass", [True, False]
+)
+def test_get_running_df_one_fewer_timestamp_check_warning(running_data,
+                                                          timestamps,
+                                                          lowpass):
+    with pytest.warns(
+        UserWarning,
+        match="Time array is 1 value shorter than encoder array.*"
+    ):
+        # Call with one fewer timestamp, check for a warning
+        _ = get_running_df(
+            data=running_data,
+            time=timestamps[:-1],
+            lowpass=lowpass
+        )
+
+
+@pytest.mark.parametrize(
+    "lowpass", [True, False]
+)
+def test_get_running_df_one_fewer_timestamp_check_truncation(running_data,
+                                                             timestamps,
+                                                             lowpass):
+    # Call with one fewer timestamp
+    output = get_running_df(
+        data=running_data,
+        time=timestamps[:-1],
+        lowpass=lowpass
+    )
+
+    # Check that the output is actually trimmed, and the values are the same
+    assert len(output) == len(timestamps) - 1
+    np.testing.assert_equal(output["v_sig"], running_data["items"]["behavior"]["encoders"][0]["vsig"][:-1])
+    np.testing.assert_equal(output["v_in"], running_data["items"]["behavior"]["encoders"][0]["vin"][:-1])
+
+
+@pytest.mark.parametrize(
     "arr, periods, fill, expected",
     [
         ([1, 2, 3], 1, None, np.array([np.nan, 1., 2.])),

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -91,11 +91,19 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
 
+What's New - 2.3.2 (October 19, 2020)
+-----------------------------------------------------------------------
+As of the 2.3.2 release:
+
+- (Internal) Fixed a running_processing bug for behavior ophys experiments when the input data would have one more encoder entry than timestamp. The behavior of the code now matches what the warning says.
+
+
 What's New - 2.3.1 (October 13, 2020)
 -----------------------------------------------------------------------
 As of the 2.3.1 release:
 
 - (Internal) Fixed a write_nwb bug for behavior ophys experiments involving the BehaviorOphysJsonApi expecting a mesoscope-specific method.
+
 
 What's New - 2.3.0 (October 9, 2020)
 -----------------------------------------------------------------------


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->
LIMS has been experiencing a number of failures over the past two days related to a small bug. Apparently, during a refactor, a particular warning got carried over, but not the action that it warned about. Doug has added full context to this in a comment on the GitHub issue.

# Addresses:
Addresses issue [#1755](https://github.com/AllenInstitute/AllenSDK/issues/1755)

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->
Just trimming off the last entry of a list. Doug responded to the issue with some context, "Camstim has long had an issue where it generates one extra encoder reading at the end." Apparently this happens every time with mesoscope.

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests