### PR TITLE
GH #1481 - Add timeout kwarg to 'from_warehouse'

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/http_engine.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/http_engine.py
@@ -11,7 +11,7 @@ import aiohttp
 import nest_asyncio
 from tqdm.auto import tqdm
 
-DEFAULT_TIMEOUT = 10 * 60  # seconds
+DEFAULT_TIMEOUT = 50 * 60  # set timeout to 50 minutes
 DEFAULT_CHUNKSIZE = 1024 * 10  # bytes
 
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_api/http_engine.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_api/http_engine.py
@@ -11,7 +11,7 @@ import aiohttp
 import nest_asyncio
 from tqdm.auto import tqdm
 
-DEFAULT_TIMEOUT = 50 * 60  # set timeout to 50 minutes
+DEFAULT_TIMEOUT = 20 * 60  # seconds
 DEFAULT_CHUNKSIZE = 1024 * 10  # bytes
 
 

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -657,7 +657,7 @@ class EcephysProjectCache(Cache):
                        version: Optional[str] = None,
                        cache: bool = True,
                        fetch_tries: int = 2,
-                       timeout = 3000):
+                       timeout: int = 1200):
         """
         Create an instance of EcephysProjectCache with an
         EcephysProjectWarehouseApi. Retrieves released data stored in
@@ -685,8 +685,10 @@ class EcephysProjectCache(Cache):
         fetch_tries : int
             Maximum number of times to attempt a download before giving up and
             raising an exception. Note that this is total tries, not retries
-        timeout
-            Timeout for the RmaEngine constructor. Defaults to 50 minutes.
+        timeout : int
+            Amount of time (in seconds) to wait on an HTTP request before raising
+            an error. Increase this duration if you find that warehouse servers
+            are not responding quickly. Defaults to 1200 seconds (20 minutes).
         """
         if scheme and host:
             app_kwargs = {"scheme": scheme, "host": host,

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -657,7 +657,7 @@ class EcephysProjectCache(Cache):
                        version: Optional[str] = None,
                        cache: bool = True,
                        fetch_tries: int = 2,
-                       **kwargs):
+                       timeout = 3000):
         """
         Create an instance of EcephysProjectCache with an
         EcephysProjectWarehouseApi. Retrieves released data stored in
@@ -685,15 +685,15 @@ class EcephysProjectCache(Cache):
         fetch_tries : int
             Maximum number of times to attempt a download before giving up and
             raising an exception. Note that this is total tries, not retries
-        **kwargs
-            Arguments that can be passed to the RmaEngine constructor
+        timeout
+            Timeout for the RmaEngine constructor. Defaults to 50 minutes.
         """
         if scheme and host:
             app_kwargs = {"scheme": scheme, "host": host,
                           "asynchronous": asynchronous}
         else:
             app_kwargs = {"asynchronous": asynchronous}
-        app_kwargs.update(kwargs)
+        app_kwargs['timeout'] = timeout
         return cls._from_http_source_default(
             EcephysProjectWarehouseApi, app_kwargs, manifest=manifest,
             version=version, cache=cache, fetch_tries=fetch_tries

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -656,7 +656,8 @@ class EcephysProjectCache(Cache):
                        manifest: Optional[Union[str, Path]] = None,
                        version: Optional[str] = None,
                        cache: bool = True,
-                       fetch_tries: int = 2):
+                       fetch_tries: int = 2,
+                       **kwargs):
         """
         Create an instance of EcephysProjectCache with an
         EcephysProjectWarehouseApi. Retrieves released data stored in
@@ -684,12 +685,15 @@ class EcephysProjectCache(Cache):
         fetch_tries : int
             Maximum number of times to attempt a download before giving up and
             raising an exception. Note that this is total tries, not retries
+        **kwargs
+            Arguments that can be passed to the RmaEngine constructor
         """
         if scheme and host:
             app_kwargs = {"scheme": scheme, "host": host,
                           "asynchronous": asynchronous}
         else:
             app_kwargs = {"asynchronous": asynchronous}
+        app_kwargs.update(kwargs)
         return cls._from_http_source_default(
             EcephysProjectWarehouseApi, app_kwargs, manifest=manifest,
             version=version, cache=cache, fetch_tries=fetch_tries

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_project_cache.py
@@ -12,7 +12,8 @@ import allensdk.brain_observatory.ecephys.ecephys_project_cache as epc
 from allensdk.core.authentication import DbCredentials
 import allensdk.brain_observatory.ecephys.write_nwb.__main__ as write_nwb
 from allensdk.brain_observatory.ecephys.ecephys_project_api.http_engine import (
-    write_from_stream, write_bytes_from_coroutine, AsyncHttpEngine, HttpEngine
+    write_from_stream, write_bytes_from_coroutine, AsyncHttpEngine, HttpEngine,
+    DEFAULT_TIMEOUT as HTTP_ENGINE_DEFAULT_TIMEOUT
 )
 
 mock_lims_credentials = DbCredentials(dbname='mock_lims', user='mock_user',
@@ -493,3 +494,19 @@ def test_stream_writer_method_default_correct(tmpdir_factory):
     manifest = os.path.join(tmpdir, "manifest.json")
     cache = epc.EcephysProjectCache(stream_writer=None, manifest=manifest)
     assert cache.stream_writer == cache.fetch_api.rma_engine.write_bytes
+
+def test_default_timeout_from_warehouse(tmpdir_factory):
+    tmpdir = str(tmpdir_factory.mktemp("test_from_warehouse_default"))
+    cache = epc.EcephysProjectCache.from_warehouse(
+        manifest=os.path.join(tmpdir, "manifest.json")
+    )
+    assert cache.fetch_api.rma_engine.timeout == HTTP_ENGINE_DEFAULT_TIMEOUT
+
+def test_user_provided_timeout_from_warehouse(tmpdir_factory):
+    user_provided_timeout = 3
+    tmpdir = str(tmpdir_factory.mktemp("test_from_warehouse_default"))
+    cache = epc.EcephysProjectCache.from_warehouse(
+        manifest=os.path.join(tmpdir, "manifest.json"),
+        timeout = user_provided_timeout
+    )
+    assert cache.fetch_api.rma_engine.timeout == user_provided_timeout


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->
A timeout error is thrown when downloading files that take longer than 10 minutes when using the 'from_warehouse' constructor of EcephysProjectCache.

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->
Addresses issue #1481 

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change


# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

- This fix adds the **kwargs argument to the 'from_warehouse' constructor of EcephysProjectCache. A user now has the ability to pass kwargs all the way to the RmaEngine including the timeout kwarg from the 'from_warehouse' constructor of EcephysProjectCache.
- The default timeout for the HttpEngine has also been updated from 10 to 50 minutes. 50 minutes was chosen based on this [sample](https://community.brain-map.org/t/failed-to-get-session-data/503/4).

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->
- **kwargs argument added to the 'from_warehouse' constructor of EcephysProjectCache
- Default HttpEngine timeout updated from 10 to 50 minutes
- 2 unit tests added to verify the timeout kwarg is passed into the RmaEngine and verify the default timeout is still intact

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots: 
Successfully setting the timeout from the EcephysProjectCache constructor to 3 seconds
![image](https://user-images.githubusercontent.com/11025905/98627638-aa4c1c00-22e2-11eb-8353-76205b0da704.png)

### Unit Tests: 
![image](https://user-images.githubusercontent.com/11025905/98627648-b20bc080-22e2-11eb-8aa4-6f5adc089809.png)

### Script to reproduce error and fix:


```
import os
from allensdk.brain_observatory.ecephys.ecephys_project_cache import EcephysProjectCache
from allensdk.brain_observatory.ecephys.ecephys_project_api import EcephysProjectWarehouseApi
from allensdk.brain_observatory.ecephys.ecephys_project_api.rma_engine import RmaEngine
from allensdk.config import enable_console_log

data_directory = '/Users/wjones/Projects/brain/allen_sandbox/defects/1481'
manifest_path = os.path.join(data_directory, "manifest.json")
session_id = 721123822
cache = EcephysProjectCache.from_warehouse(
    manifest=manifest_path,
    timeout = 3
)
session = cache.get_session_data(session_id)
```


### Configuration details:

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
