### PR TITLE
GH 1753: Don't truncate mesoscope acquisition frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.3.3] = TODO
+### Bug Fixes
+- (Internal) Fixed a bug in mesoscope processing where the ophys acquisition frames were being truncated
+prior to splitting, resulting in many fewer than expected acquisition frames.
+
 ## [2.3.2] = 2020-10-19
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [2.3.3] = TODO
+## [2.3.3] = 2020-11-12
 ### Bug Fixes
 - (Internal) Fixed a bug in mesoscope processing where the ophys acquisition frames were being truncated
 prior to splitting, resulting in many fewer than expected acquisition frames.

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -107,11 +107,13 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
                 raise RuntimeError('dff_frames is longer than timestamps')
         # Mesoscope data
         # Resample if collecting multiple concurrent planes (e.g. mesoscope)
-        # because the frames are interleaved 
+        # because the frames are interleaved
         else:
-            self.logger.info("Mesoscope data detected. Splitting timestamps "
-                             "over plane group(s).")
             group_count = self.get_plane_group_count()
+            self.logger.info(
+                "Mesoscope data detected. Splitting timestamps "
+                f"(len={len(ophys_timestamps)} over {group_count} "
+                "plane group(s).")
             ophys_timestamps = self._process_ophys_plane_timestamps(
                 ophys_timestamps, plane_group, group_count)
             if number_of_dff_frames != num_of_timestamps:

--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -100,11 +100,14 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
         if plane_group is None:    # non-mesoscope
             if (number_of_dff_frames < num_of_timestamps):
                 self.logger.info(
-                    "Truncating acquisition frames ('ophys_frames') to the "
-                    "number of frames in the df/f trace.")
+                    "Truncating acquisition frames ('ophys_frames') "
+                    f"(len={num_of_timestamps}) to the number of frames "
+                    f"in the df/f trace ({number_of_dff_frames}).")
                 ophys_timestamps = ophys_timestamps[:number_of_dff_frames]
             elif number_of_dff_frames > num_of_timestamps:
-                raise RuntimeError('dff_frames is longer than timestamps')
+                raise RuntimeError(
+                    f"dff_frames (len={number_of_dff_frames}) is longer "
+                    f"than timestamps (len={num_of_timestamps}).")
         # Mesoscope data
         # Resample if collecting multiple concurrent planes (e.g. mesoscope)
         # because the frames are interleaved


### PR DESCRIPTION
# Overview:
Scientifica rigs produce extra acquisition frame pulses
('ophys_frames'), so the number of ophys acquisition frames
are longer than the number of frames in the movie/trace.
A data fix was applied to truncate the length of the acquisition
frames to the length of number of frames in the movie/trace,
to remove these additional sentinel frames (#602).
This caused a problem with mesoscope data. Since the acquisition
frames are interleaved across multiple plane groups, the
length of the acquisition frames is intended to be longer than any
individual plane's movie/trace. Each plane in a given plane group
is acquired simultaneously, and the scope moves between acquiring
plane groups.

We have confirmed with MPE that mesoscope data should not
produce any additional sentinel frames. Once the mesoscope data
is split by plane group, the number of acquisition frames should
align to the number of frames in the movie/trace. This update removes
the data truncation from data produced by mesoscope rigs. If there
is a length mismatch between the split acquisition frames and the
movie/trace frames, raise an error.

# Addresses:
Resolves #1753

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
If the data coming off of the rig contains plane groups (mesoscope data), don't truncate the acquisition frames to the movie/trace since the acquisition frames are interleaved across plane groups and should be longer.

# Changes:
See above.

# Validation:
Unit testing.

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
~- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target~
- [ ] My code passes all AllenSDK tests

# Notes:
This should be a bugfix release to unblock internal users.  I will take care of it.