### PR TITLE
GH-1327 - Queries now return external_donor_id as mouse_id

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
@@ -108,9 +108,9 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
 
         if mtrain_credentials:
             mtrain_engine = PostgresQueryMixin(
-                dbname=lims_credentials.dbname, user=lims_credentials.user,
-                host=lims_credentials.host, password=lims_credentials.password,
-                port=lims_credentials.port)
+                dbname=mtrain_credentials.dbname, user=mtrain_credentials.user,
+                host=mtrain_credentials.host, password=mtrain_credentials.password,
+                port=mtrain_credentials.port)
         else:
             # Currying is equivalent to decorator syntactic sugar
             mtrain_engine = (

--- a/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_lims_api.py
@@ -202,6 +202,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 bs.date_of_acquisition,
                 d.id as donor_id,
                 d.full_genotype,
+                d.external_donor_name AS mouse_id,
                 reporter.reporter_line,
                 driver.driver_line,
                 g.name AS sex,
@@ -288,7 +289,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                         ophys_experiment_id, project_code, session_name,
                         session_type, equipment_name, date_of_acquisition,
                         specimen_id, full_genotype, sex, age_in_days,
-                        reporter_line, driver_line
+                        reporter_line, driver_line, mouse_id
 
         :param ophys_experiment_ids: optional list of ophys_experiment_ids
             to include
@@ -318,6 +319,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 DATE_PART('day', os.date_of_acquisition - d.date_of_birth)
                     AS age_in_days,
                 d.full_genotype,
+                d.external_donor_name AS mouse_id,
                 reporter.reporter_line,
                 driver.driver_line,
                 id.depth as imaging_depth,
@@ -356,7 +358,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                         ophys_experiment_id, project_code, session_name,
                         session_type, equipment_name, date_of_acquisition,
                         specimen_id, full_genotype, sex, age_in_days,
-                        reporter_line, driver_line
+                        reporter_line, driver_line, mouse_id
 
         :param ophys_session_ids: optional list of ophys_session_ids to include
         :rtype: pd.DataFrame
@@ -381,6 +383,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 DATE_PART('day', os.date_of_acquisition - d.date_of_birth)
                     AS age_in_days,
                 d.full_genotype,
+                d.external_donor_name AS mouse_id,
                 reporter.reporter_line,
                 driver.driver_line
             FROM ophys_sessions os


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

`_get_behavior_summary_table`, `_get_experiment_table`, and `_get_session_table` now all return `external_donor_id` as `mouse_id`

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1327](https://github.com/AllenInstitute/AllenSDK/issues/1327)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

Edited the query to return this.

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

In pgAdmin I ran all three queries selecting for a null id and the queries came up empty.

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
