### PR TITLE
Fixes a bug where the length of an array did not get updated in get_ophys_timestamps

### DIFF
--- a/allensdk/internal/api/behavior_ophys_api.py
+++ b/allensdk/internal/api/behavior_ophys_api.py
@@ -91,13 +91,13 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
         plane_group = self.get_imaging_plane_group()
 
         number_of_cells, number_of_dff_frames = dff_traces.shape
-        num_of_timestamps = len(ophys_timestamps)
         # Scientifica data has extra frames in the sync file relative
         # to the number of frames in the video. These sentinel frames
         # should be removed.
         # NOTE: This fix does not apply to mesoscope data.
         # See http://confluence.corp.alleninstitute.org/x/9DVnAg
         if plane_group is None:    # non-mesoscope
+            num_of_timestamps = len(ophys_timestamps)
             if (number_of_dff_frames < num_of_timestamps):
                 self.logger.info(
                     "Truncating acquisition frames ('ophys_frames') "
@@ -119,6 +119,7 @@ class BehaviorOphysLimsApi(OphysLimsApi, BehaviorOphysApiBase):
                 "plane group(s).")
             ophys_timestamps = self._process_ophys_plane_timestamps(
                 ophys_timestamps, plane_group, group_count)
+            num_of_timestamps = len(ophys_timestamps)
             if number_of_dff_frames != num_of_timestamps:
                 raise RuntimeError(
                     f"dff_frames (len={number_of_dff_frames}) is not equal to "

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
@@ -98,9 +98,9 @@ def test_process_ophys_plane_timestamps(
          np.arange(5), does_not_raise()),
         (None, np.arange(10), np.arange(20).reshape(1, 20),
          None, pytest.raises(RuntimeError)),
-        (2, np.arange(10), np.arange(10).reshape(1, 10),
-         np.arange(10), does_not_raise()),
-        (2, np.arange(10), np.arange(5).reshape(1, 5),
+        (0, np.arange(10), np.arange(5).reshape(1, 5),
+         np.arange(0, 10, 2), does_not_raise()),
+        (0, np.arange(20), np.arange(5).reshape(1, 5),
          None, pytest.raises(RuntimeError))
     ],
     ids=["scientifica-trunate", "scientifica-raise", "mesoscope-good",
@@ -117,9 +117,7 @@ def test_get_ophys_timestamps(monkeypatch, plane_group, ophys_timestamps,
                         lambda: {"ophys_frames": ophys_timestamps})
     monkeypatch.setattr(api, "get_raw_dff_data", lambda: dff_traces)
     monkeypatch.setattr(api, "get_imaging_plane_group", lambda: plane_group)
-    monkeypatch.setattr(api, "_process_ophys_plane_timestamps",
-                        lambda *x: ophys_timestamps)
-    monkeypatch.setattr(api, "get_plane_group_count", lambda: 4)
+    monkeypatch.setattr(api, "get_plane_group_count", lambda: 2)
     with context:
         actual = api.get_ophys_timestamps()
         if expected is not None:


### PR DESCRIPTION
Properly compute the number of timestamps in
in BehaviorOphysLimsApi.get_ophys_timestamps. This value was computed at the beginning and not recomputed after splitting the timestamps.

I updated tests to remove the mock on _process_ophys_timestamps so that
the behavior is properly tested on mesoscope data.

This was reported by @dougollerenshaw on the VBA slack channel.

Note I also updated some of the test params (plane group count and plane group) just to make the expected cases easier.