### PR TITLE
fixes incorrect assert statement

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -340,7 +340,7 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         ophys_timestamps = self.get_ophys_timestamps()
 
         num_trace_timepoints = corrected_fluorescence_traces.shape[1]
-        assert num_trace_timepoints, ophys_timestamps.shape[0]
+        assert num_trace_timepoints == ophys_timestamps.shape[0]
         df = pd.DataFrame(
             {'corrected_fluorescence': list(corrected_fluorescence_traces)},
             index=pd.Index(cell_roi_id_list, name='cell_roi_id'))


### PR DESCRIPTION
sort of resolves #1751.
the reported behavior of mismatched lengths from that issue is no longer present in the master branch, likely due to the extensive refactor in #1769. Nonetheless, the misuse of that assert was propagated through.