### PR TITLE
updates Rotation.as_dcm to as_matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.4.1] = 2021-01-04
+-  update deprecated call to scipy.spatial.transform.Rotation.as_dcm() to .as_matrix()
+
 ## [2.4.0] = 2020-12-21
 - When running raster_plot on a spike_times dataframe, the spike times from each unit are plotted twice. (thank you @dgmurx)
 - improvements and fixes to behavior ophys NWB files.

--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -37,7 +37,7 @@ import logging
 
 
 
-__version__ = '2.4.0'
+__version__ = '2.4.1'
 
 
 try:

--- a/allensdk/test/brain_observatory/gaze_mapping/test_gaze_mapping.py
+++ b/allensdk/test/brain_observatory/gaze_mapping/test_gaze_mapping.py
@@ -50,7 +50,7 @@ def rig_component_fixture(request):
 ], indirect=['rig_component_fixture'])
 def test_generate_self_to_eye_frame_xform(rig_component_fixture, expected):
     obtained = rig_component_fixture.generate_self_to_eye_frame_xform()
-    assert np.allclose(obtained.as_dcm(), expected)
+    assert np.allclose(obtained.as_matrix(), expected)
 
 
 # ======== GazeMapper tests ========
@@ -341,4 +341,4 @@ def test_project_to_plane(function_inputs, expected):
 ])
 def test_generate_object_rotation_xform(function_inputs, expected):
     obtained = gm.generate_object_rotation_xform(**function_inputs)
-    assert np.allclose(obtained.as_dcm(), expected)
+    assert np.allclose(obtained.as_matrix(), expected)


### PR DESCRIPTION
Updates a deprecated call from
`scipy.spatial.transform.Rotation.as_dcm()`
to
`scipy.spatial.transform.Rotation.as_matrix()`.

This effects AllenSDK tests only, and the change is compatible with scipy >= v1.4.0. The deprecated `as_dcm()` call is not supported as of v1.6.0 (released in the last few days).