### PR TITLE
Adds unfiltered running speed as new data stream

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/abcs/behavior_base.py
+++ b/allensdk/brain_observatory/behavior/session_apis/abcs/behavior_base.py
@@ -44,8 +44,13 @@ class BehaviorBase(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_running_data_df(self) -> pd.DataFrame:
+    def get_running_data_df(self, lowpass=True) -> pd.DataFrame:
         """Get running speed data.
+
+        Parameters
+        ----------
+        lowpass: bool
+            Whether to return running speed with low pass filter applied or without
 
         Returns
         -------

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -61,9 +61,10 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
         # Add running data to NWB in-memory object:
         unit_dict = {'v_sig': 'V', 'v_in': 'V',
                      'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
-        nwb.add_running_data_df_to_nwbfile(nwbfile,
-                                           session_object.running_data_df,
-                                           unit_dict)
+        nwb.add_running_data_dfs_to_nwbfile(nwbfile,
+                                            session_object.running_data_df,
+                                            session_object.raw_running_data_df,
+                                            unit_dict)
 
         # Add stimulus template data to NWB in-memory object:
         for name, image_data in session_object.stimulus_templates.items():
@@ -148,9 +149,22 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
     def get_eye_tracking(self) -> int:
         raise NotImplementedError()
 
-    def get_running_data_df(self, **kwargs) -> pd.DataFrame:
+    def get_running_data_df(self, lowpass=True) -> pd.DataFrame:
+        """
+        Gets the running data df
+        Parameters
+        ----------
+        lowpass: bool
+            Whether to return running speed with or without low pass filter applied
 
-        running_speed = self.get_running_speed()
+        Returns
+        -------
+            pd.DataFrame:
+                Dataframe containing various signals used to compute running
+                speed, and the filtered or unfiltered speed.
+        """
+
+        running_speed = self.get_running_speed(lowpass=lowpass)
 
         running_data_df = pd.DataFrame({'speed': running_speed.values},
                                        index=pd.Index(running_speed.timestamps,

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -333,37 +333,48 @@ def add_running_speed_to_nwbfile(nwbfile, running_speed, name='speed', unit='cm/
         unit=unit
     )
 
-    running_mod = ProcessingModule('running', 'Running speed processing module')
-    nwbfile.add_processing_module(running_mod)
+    if 'running' in nwbfile.processing:
+        running_mod = nwbfile.processing['running']
+    else:
+        running_mod = ProcessingModule('running', 'Running speed processing module')
+        nwbfile.add_processing_module(running_mod)
 
     running_mod.add_data_interface(running_speed_series)
 
     return nwbfile
 
 
-def add_running_data_df_to_nwbfile(nwbfile, running_data_df, unit_dict, index_key='timestamps'):
-    ''' Adds running speed data to an NWBFile as timeseries in acquisition and processing
+def add_running_data_dfs_to_nwbfile(nwbfile, running_data_df, running_data_df_unfiltered, unit_dict):
+    """Adds both unfiltered (raw) and filtered running speed data to an NWBFile as timeseries in acquisition and processing
 
     Parameters
     ----------
     nwbfile : pynwb.NWBFile
-        File to which runnign speeds will be written
-    running_speed : pandas.DataFrame
-        Contains 'speed' and 'times', 'v_in', 'vsig', 'dx'
-    unit : str, optional
+        File to which running speeds will be written
+    running_data_df : pandas.DataFrame
+        Filtered running data
+        Contains 'speed', 'v_in', 'vsig', 'dx'
+        Note that 'v_in', 'vsig', 'dx' are expected to be the same as in running_data_df_unfiltered
+    running_data_df_unfiltered : pandas.DataFrame
+        Unfiltered (raw) Running data
+        Contains 'speed', 'v_in', 'vsig', 'dx'
+        Note that 'v_in', 'vsig', 'dx' are expected to be the same as in running_data_df
+    unit_dict : dict, optional
         SI units of running speed values
 
     Returns
     -------
     nwbfile : pynwb.NWBFile
 
-    '''
-    assert running_data_df.index.name == index_key
-
+    """
     running_speed = RunningSpeed(timestamps=running_data_df.index.values,
                                  values=running_data_df['speed'].values)
 
+    running_speed_unfiltered = RunningSpeed(timestamps=running_data_df_unfiltered.index.values,
+                                            values=running_data_df_unfiltered['speed'].values)
+
     add_running_speed_to_nwbfile(nwbfile, running_speed, name='speed', unit=unit_dict['speed'])
+    add_running_speed_to_nwbfile(nwbfile, running_speed_unfiltered, name='speed_unfiltered', unit=unit_dict['speed'])
 
     running_mod = nwbfile.processing['running']
     timestamps_ts = running_mod.get_data_interface('speed').timestamps

--- a/allensdk/brain_observatory/nwb/nwb_api.py
+++ b/allensdk/brain_observatory/nwb/nwb_api.py
@@ -45,10 +45,23 @@ class NwbApi:
 
         return cls(path=path, **kwargs)
 
-    def get_running_speed(self) -> RunningSpeed:
+    def get_running_speed(self, lowpass=True) -> RunningSpeed:
+        """
+        Gets the running speed
+        Parameters
+        ----------
+        lowpass: bool
+            Whether to return the running speed with lowpass filter applied or without
 
-        values = self.nwbfile.modules['running'].get_data_interface('speed').data[:]
-        timestamps = self.nwbfile.modules['running'].get_data_interface('speed').timestamps[:]
+        Returns
+        -------
+        RunningSpeed:
+            The running speed
+        """
+
+        interface_name = 'speed' if lowpass else 'speed_unfiltered'
+        values = self.nwbfile.modules['running'].get_data_interface(interface_name).data[:]
+        timestamps = self.nwbfile.modules['running'].get_data_interface(interface_name).timestamps[:]
 
         return RunningSpeed(
             timestamps=timestamps,

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -13,10 +13,13 @@ from allensdk.brain_observatory.behavior.session_apis.data_io import (
 
 @pytest.mark.parametrize('roundtrip', [True, False])
 def test_add_running_data_df_to_nwbfile(nwbfile, running_data_df, roundtrip, roundtripper):
+    # Just make it different from running_data_df
+    running_data_df_unfiltered = running_data_df.copy()
+    running_data_df_unfiltered['speed'] = running_data_df['speed'] * 2
 
     unit_dict = {'v_sig': 'V', 'v_in': 'V', 'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
     nwbfile = nwb.add_running_data_dfs_to_nwbfile(nwbfile, running_data_df=running_data_df,
-                                                  running_data_df_unfiltered=running_data_df, unit_dict=unit_dict)
+                                                  running_data_df_unfiltered=running_data_df_unfiltered, unit_dict=unit_dict)
 
     if roundtrip:
         obt = roundtripper(nwbfile, BehaviorOphysNwbApi)
@@ -24,7 +27,7 @@ def test_add_running_data_df_to_nwbfile(nwbfile, running_data_df, roundtrip, rou
         obt = BehaviorOphysNwbApi.from_nwbfile(nwbfile)
 
     pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df(lowpass=True))
-    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df(lowpass=False))
+    pd.testing.assert_frame_equal(running_data_df_unfiltered, obt.get_running_data_df(lowpass=False))
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -9,37 +9,22 @@ import pytest
 import allensdk.brain_observatory.nwb as nwb
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
     BehaviorOphysNwbApi)
-from allensdk.brain_observatory.behavior.schemas import (
-    BehaviorTaskParametersSchema, OphysBehaviorMetadataSchema)
-
-
-@pytest.mark.parametrize('roundtrip', [True, False])
-def test_add_running_speed_to_nwbfile(nwbfile, running_speed, roundtrip, roundtripper):
-
-    nwbfile = nwb.add_running_speed_to_nwbfile(nwbfile, running_speed)
-
-    if roundtrip:
-        obt = roundtripper(nwbfile, BehaviorOphysNwbApi)
-    else:
-        obt = BehaviorOphysNwbApi.from_nwbfile(nwbfile)
-
-    running_speed_obt = obt.get_running_speed()
-    assert np.allclose(running_speed.timestamps, running_speed_obt.timestamps)
-    assert np.allclose(running_speed.values, running_speed_obt.values)
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])
 def test_add_running_data_df_to_nwbfile(nwbfile, running_data_df, roundtrip, roundtripper):
 
     unit_dict = {'v_sig': 'V', 'v_in': 'V', 'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
-    nwbfile = nwb.add_running_data_df_to_nwbfile(nwbfile, running_data_df, unit_dict)
+    nwbfile = nwb.add_running_data_dfs_to_nwbfile(nwbfile, running_data_df=running_data_df,
+                                                  running_data_df_unfiltered=running_data_df, unit_dict=unit_dict)
 
     if roundtrip:
         obt = roundtripper(nwbfile, BehaviorOphysNwbApi)
     else:
         obt = BehaviorOphysNwbApi.from_nwbfile(nwbfile)
 
-    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df())
+    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df(lowpass=True))
+    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df(lowpass=False))
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
Adds unfiltered running speed as new data stream to NWB

# Addresses:
[#1676 ](https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/allensdk/1676)

# Validation:
- Passes round trip tests
- Passes DANDI validator and pynwb validator

# Notes:
- There was an existing filtered running speed data stream
- This just adds a new DataInterface for the unfiltered running speed
