### PR TITLE
1356 behavior nwb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.6.0] = TBD
+- Adds ability to write and read behavior only NWB files
+
 ## [2.5.0] = 2021-01-29
 -  Adds unfiltered running speed as new data stream
 -  run_demixing gracefully ignores any ROIs that are not in the input trace file

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -5,7 +5,7 @@ import numpy as np
 import inspect
 
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
-    BehaviorLimsApi)
+    BehaviorLimsApi, BehaviorNwbApi)
 from allensdk.brain_observatory.behavior.session_apis.abcs import BehaviorBase
 from allensdk.brain_observatory.running_speed import RunningSpeed
 
@@ -36,14 +36,14 @@ class BehaviorSession(object):
     @classmethod
     def from_nwb_path(
             cls, nwb_path: str, **api_kwargs: Any) -> "BehaviorSession":
-        return NotImplementedError
+        return cls(api=BehaviorNwbApi.from_path(path=nwb_path, **api_kwargs))
 
     @property
     def behavior_session_id(self) -> int:
         """Unique identifier for this experimental session.
         :rtype: int
         """
-        return self.api.behavior_session_id
+        return self.api.get_behavior_session_id
 
     @property
     def ophys_session_id(self) -> Optional[int]:
@@ -51,7 +51,7 @@ class BehaviorSession(object):
         with this behavior session (if one exists)
         :rtype: int
         """
-        return self.api.ophys_session_id
+        return self.api.get_ophys_session_id
 
     @property
     def ophys_experiment_ids(self) -> Optional[List[int]]:
@@ -59,7 +59,7 @@ class BehaviorSession(object):
         with this behavior session (if one exists)
         :rtype: int
         """
-        return self.api.ophys_experiment_ids
+        return self.api.get_ophys_experiment_ids
 
     @property
     def licks(self) -> pd.DataFrame:

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -43,7 +43,7 @@ class BehaviorSession(object):
         """Unique identifier for this experimental session.
         :rtype: int
         """
-        return self.api.get_behavior_session_id
+        return self.api.get_behavior_session_id()
 
     @property
     def ophys_session_id(self) -> Optional[int]:
@@ -51,7 +51,7 @@ class BehaviorSession(object):
         with this behavior session (if one exists)
         :rtype: int
         """
-        return self.api.get_ophys_session_id
+        return self.api.get_ophys_session_id()
 
     @property
     def ophys_experiment_ids(self) -> Optional[List[int]]:
@@ -59,7 +59,7 @@ class BehaviorSession(object):
         with this behavior session (if one exists)
         :rtype: int
         """
-        return self.api.get_ophys_experiment_ids
+        return self.api.get_ophys_experiment_ids()
 
     @property
     def licks(self) -> pd.DataFrame:

--- a/allensdk/brain_observatory/behavior/metadata_processing.py
+++ b/allensdk/brain_observatory/behavior/metadata_processing.py
@@ -26,6 +26,11 @@ OPHYS_5_DESCRIPTION = (
     "previously trained, but with the lick-response "
     "sensor withdrawn (passive/open loop mode)."
 )
+TRAINING_DESCRIPTION = (
+    "A training session where a mouse performs a visual change detection task "
+    "with a set of natural scenes. Successfully completing the task delivers "
+    "a water reward via a lick spout."
+)
 
 
 def get_expt_description(session_type: str) -> str:
@@ -55,8 +60,11 @@ def get_expt_description(session_type: str) -> str:
     ophys_4_6 = dict.fromkeys(["OPHYS_4", "OPHYS_6"], OPHYS_4_6_DESCRIPTION)
     ophys_2_5 = {"OPHYS_2": OPHYS_2_DESCRIPTION,
                  "OPHYS_5": OPHYS_5_DESCRIPTION}
+    training = dict.fromkeys(
+        ["TRAINING_1", "TRAINING_2", "TRAINING_3", "TRAINING_4", "TRAINING_5"],
+        TRAINING_DESCRIPTION)
 
-    expt_description_dict = {**ophys_1_3, **ophys_2_5, **ophys_4_6}
+    expt_description_dict = {**ophys_1_3, **ophys_2_5, **ophys_4_6, **training}
 
     # Session type string will look something like: OPHYS_4_images_A
     truncated_session_type = "_".join(session_type.split("_")[:2])

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
@@ -184,7 +184,6 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
             SELECT
                 bs.id AS behavior_session_id,
                 bs.ophys_session_id,
-                bs.behavior_training_id,
                 equipment.name as equipment_name,
                 bs.date_of_acquisition,
                 d.id as donor_id,

--- a/allensdk/brain_observatory/behavior/schemas.py
+++ b/allensdk/brain_observatory/behavior/schemas.py
@@ -61,6 +61,10 @@ class SubjectMetadataSchema(RaisingSchema):
 class BehaviorMetadataSchema(RaisingSchema):
     """This schema contains metadata pertaining to behavior.
     """
+    neurodata_type = 'BehaviorMetadata'
+    neurodata_type_inc = 'LabMetaData'
+    neurodata_doc = "Metadata for behavior and behavior + ophys experiments"
+    neurodata_skip = {"experiment_datetime"}
 
     behavior_session_uuid = fields.UUID(
         doc='MTrain record for session, also called foraging_id',
@@ -69,6 +73,21 @@ class BehaviorMetadataSchema(RaisingSchema):
     stimulus_frame_rate = fields.Float(
         doc=('Frame rate (frames/second) of the '
              'visual_stimulus from the monitor'),
+        required=True,
+    )
+    session_type = fields.String(
+        doc='Experimental session description',
+        allow_none=True,
+        required=True,
+    )
+    # 'experiment_datetime' will be stored in
+    # pynwb NWBFile 'session_start_time' attr
+    experiment_datetime = fields.DateTime(
+        doc='Date of the experiment (UTC, as string)',
+        required=True,
+    )
+    rig_name = fields.String(
+        doc='Name of behavior or optical physiology experiment rig',
         required=True,
     )
 
@@ -123,10 +142,6 @@ class OphysMetadataSchema(NwbOphysMetadataSchema):
         doc='Id for this ophys session',
         required=True,
     )
-    rig_name = fields.String(
-        doc='Name of optical physiology experiment rig',
-        required=True,
-    )
     field_of_view_width = fields.Int(
         doc='Width of optical physiology imaging plane in pixels',
         required=True,
@@ -143,7 +158,7 @@ class OphysBehaviorMetadataSchema(BehaviorMetadataSchema, OphysMetadataSchema):
     """
 
     neurodata_type = 'OphysBehaviorMetadata'
-    neurodata_type_inc = 'LabMetaData'
+    neurodata_type_inc = 'BehaviorMetadata'
     neurodata_doc = "Metadata for behavior + ophys experiments"
     # Fields to skip converting to extension
     # They already exist as attributes for the following pyNWB classes:
@@ -151,18 +166,6 @@ class OphysBehaviorMetadataSchema(BehaviorMetadataSchema, OphysMetadataSchema):
     neurodata_skip = {"emission_lambda", "excitation_lambda", "indicator",
                       "targeted_structure", "experiment_datetime",
                       "ophys_frame_rate"}
-
-    session_type = fields.String(
-        doc='Experimental session description',
-        allow_none=True,
-        required=True,
-    )
-    # 'experiment_datetime' will be stored in
-    # pynwb NWBFile 'session_start_time' attr
-    experiment_datetime = fields.DateTime(
-        doc='Date of the experiment (UTC, as string)',
-        required=True,
-    )
 
 
 class CompleteOphysBehaviorMetadataSchema(OphysBehaviorMetadataSchema,

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/__init__.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/__init__.py
@@ -1,5 +1,7 @@
 # data_io classes for behavior only
+from allensdk.brain_observatory.behavior.session_apis.data_io.behavior_nwb_api import BehaviorNwbApi  # noqa: F401, E501
 from allensdk.brain_observatory.behavior.session_apis.data_io.behavior_lims_api import BehaviorLimsApi  # noqa: F401, E501
+from allensdk.brain_observatory.behavior.session_apis.data_io.behavior_json_api import BehaviorJsonApi  # noqa: F401, E501
 
 # data_io classes for behavior + ophys
 from allensdk.brain_observatory.behavior.session_apis.data_io.behavior_ophys_nwb_api import BehaviorOphysNwbApi  # noqa: F401, E501

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_json_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_json_api.py
@@ -1,0 +1,75 @@
+import logging
+from datetime import datetime
+import pytz
+
+from allensdk.brain_observatory.behavior.session_apis.data_transforms import (
+    BehaviorDataXforms)
+
+
+class BehaviorJsonApi(BehaviorDataXforms):
+    """A data fetching class that serves as an API for fetching 'raw'
+    data from a json file necessary (but not sufficient) for filling
+    a 'BehaviorSession'.
+
+    Most 'raw' data provided by this API needs to be processed by
+    BehaviorDataXforms methods in order to usable by 'BehaviorSession's.
+
+    This class is used by the write_nwb module for behavior sessions.
+    """
+
+    def __init__(self, data):
+        self.data = data
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def get_behavior_session_id(self) -> int:
+        return self.data['behavior_session_id']
+
+    def get_foraging_id(self) -> int:
+        return self.data['foraging_id']
+
+    def get_rig_name(self) -> str:
+        """Get the name of the experiment rig (ex: CAM2P.3)"""
+        return self.data['rig_name']
+
+    def get_sex(self) -> str:
+        """Get the sex of the subject (ex: 'M', 'F', or 'unknown')"""
+        return self.data['sex']
+
+    def get_age(self) -> str:
+        """Get the age of the subject (ex: 'P15', 'Adult', etc...)"""
+        return self.data['age']
+
+    def get_stimulus_name(self) -> str:
+        """Get the name of the stimulus presented for a behavior or
+        behavior + ophys experiment"""
+        return self.data['stimulus_name']
+
+    def get_experiment_date(self) -> datetime:
+        """Get the acquisition date of an ophys experiment"""
+        return pytz.utc.localize(
+            datetime.strptime(self.data['date_of_acquisition'],
+                              "%Y-%m-%d %H:%M:%S"))
+
+    def get_reporter_line(self) -> str:
+        """Get the (gene) reporter line for the subject associated with a
+        behavior or behavior + ophys experiment"""
+        return self.data['reporter_line']
+
+    def get_driver_line(self) -> str:
+        """Get the (gene) driver line for the subject associated with a
+        behavior or behavior + ophys experiment"""
+        return self.data['driver_line']
+
+    def get_full_genotype(self) -> str:
+        """Get the full genotype of the subject associated with a
+        behavior or behavior + ophys experiment"""
+        return self.data['full_genotype']
+
+    def get_behavior_stimulus_file(self) -> str:
+        """Get the filepath to the StimulusPickle file for the session"""
+        return self.data['behavior_stimulus_file']
+
+    def get_external_specimen_name(self) -> int:
+        """Get the external specimen id (LabTracks ID) for the subject
+        associated with a behavior experiment"""
+        return int(self.data['external_specimen_name'])

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
@@ -43,7 +43,6 @@ class BehaviorLimsApi(BehaviorDataXforms, CachedInstanceMethodMixin):
         ids = self._get_ids()
         self.ophys_experiment_ids = ids.get("ophys_experiment_ids")
         self.ophys_session_id = ids.get("ophys_session_id")
-        self.behavior_training_id = ids.get("behavior_training_id")
         self.foraging_id = ids.get("foraging_id")
         self.ophys_container_id = ids.get("ophys_container_id")
 
@@ -82,8 +81,7 @@ class BehaviorLimsApi(BehaviorDataXforms, CachedInstanceMethodMixin):
         """Fetch ids associated with this behavior_session_id. If there is no
         id, return None.
         :returns: Dictionary of ids with the following keys:
-            behavior_training_id: int -- Only if was a training session
-            ophys_session_id: int -- None if have behavior_training_id
+            ophys_session_id: int
             ophys_experiment_ids: List[int] -- only if have ophys_session_id
             foraging_id: int
         :rtype: dict
@@ -91,7 +89,7 @@ class BehaviorLimsApi(BehaviorDataXforms, CachedInstanceMethodMixin):
         # Get all ids from the behavior_sessions table
         query = f"""
             SELECT
-                ophys_session_id, behavior_training_id, foraging_id
+                ophys_session_id, foraging_id
             FROM
                 behavior_sessions
             WHERE
@@ -146,10 +144,6 @@ class BehaviorLimsApi(BehaviorDataXforms, CachedInstanceMethodMixin):
 
     def get_ophys_session_id(self) -> Optional[int]:
         return self.ophys_session_id
-
-    def get_behavior_training_id(self) -> int:
-        """Getter to be consistent with BehaviorDataXforms."""
-        return self.behavior_training_id
 
     def get_foraging_id(self) -> int:
         return self.foraging_id

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
@@ -141,6 +141,22 @@ class BehaviorLimsApi(BehaviorDataXforms, CachedInstanceMethodMixin):
         """Getter to be consistent with BehaviorOphysLimsApi."""
         return self.behavior_session_id
 
+    def get_ophys_experiment_ids(self) -> Optional[List[int]]:
+        return self.ophys_experiment_ids
+
+    def get_ophys_session_id(self) -> Optional[int]:
+        return self.ophys_session_id
+
+    def get_behavior_training_id(self) -> int:
+        """Getter to be consistent with BehaviorDataXforms."""
+        return self.behavior_training_id
+
+    def get_foraging_id(self) -> int:
+        return self.foraging_id
+
+    def get_ophys_container_id(self) -> Optional[int]:
+        return self.ophys_container_id
+
     def get_behavior_stimulus_file(self) -> str:
         """Return the path to the StimulusPickle file for a session.
         :rtype: str

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
@@ -1,0 +1,195 @@
+import datetime
+import uuid
+
+import numpy as np
+import pandas as pd
+import pytz
+
+from pynwb import NWBHDF5IO, NWBFile
+
+import allensdk.brain_observatory.nwb as nwb
+from allensdk.brain_observatory.behavior.metadata_processing import (
+    get_expt_description
+)
+from allensdk.brain_observatory.behavior.session_apis.abcs import (
+    BehaviorBase
+)
+from allensdk.brain_observatory.behavior.schemas import (
+    BehaviorTaskParametersSchema, OphysBehaviorMetadataSchema)
+from allensdk.brain_observatory.behavior.trials_processing import (
+    TRIAL_COLUMN_DESCRIPTION_DICT
+)
+from allensdk.brain_observatory.nwb.metadata import load_pynwb_extension
+from allensdk.brain_observatory.nwb.nwb_api import NwbApi
+from allensdk.brain_observatory.nwb.nwb_utils import set_omitted_stop_time
+
+load_pynwb_extension(OphysBehaviorMetadataSchema, 'ndx-aibs-behavior-ophys')
+load_pynwb_extension(BehaviorTaskParametersSchema, 'ndx-aibs-behavior-ophys')
+
+
+class BehaviorNwbApi(NwbApi, BehaviorBase):
+    """A data fetching class that serves as an API for fetching 'raw'
+    data from an NWB file that is both necessary and sufficient for filling
+    a 'BehaviorOphysSession'.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.filter_invalid_rois = kwargs.pop("filter_invalid_rois", False)
+        super(BehaviorNwbApi, self).__init__(*args, **kwargs)
+
+    def save(self, session_object):
+
+        session_type = str(session_object.metadata['session_type'])
+
+        nwbfile = NWBFile(
+            session_description=session_type,
+            identifier=str(session_object.behavior_session_id),
+            session_start_time=session_object.metadata['experiment_datetime'],
+            file_create_date=pytz.utc.localize(datetime.datetime.now()),
+            institution="Allen Institute for Brain Science",
+            keywords=["visual", "behavior", "task"],
+            experiment_description=get_expt_description(session_type)
+        )
+
+        # Add stimulus_timestamps to NWB in-memory object:
+        nwb.add_stimulus_timestamps(nwbfile,
+                                    session_object.stimulus_timestamps)
+
+        # Add running data to NWB in-memory object:
+        unit_dict = {'v_sig': 'V', 'v_in': 'V',
+                     'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
+        nwb.add_running_data_df_to_nwbfile(nwbfile,
+                                           session_object.running_data_df,
+                                           unit_dict)
+
+        # Add stimulus template data to NWB in-memory object:
+        for name, image_data in session_object.stimulus_templates.items():
+            nwb.add_stimulus_template(nwbfile, image_data, name)
+
+            # Add index for this template to NWB in-memory object:
+            nwb_template = nwbfile.stimulus_template[name]
+            stimulus_index = session_object.stimulus_presentations[
+                session_object.stimulus_presentations[
+                    'image_set'] == nwb_template.name]
+            nwb.add_stimulus_index(nwbfile, stimulus_index, nwb_template)
+
+        # search for omitted rows and add stop_time before writing to NWB file
+        set_omitted_stop_time(
+            stimulus_table=session_object.stimulus_presentations)
+
+        # Add stimulus presentations data to NWB in-memory object:
+        nwb.add_stimulus_presentations(nwbfile,
+                                       session_object.stimulus_presentations)
+
+        # Add trials data to NWB in-memory object:
+        nwb.add_trials(nwbfile, session_object.trials,
+                       TRIAL_COLUMN_DESCRIPTION_DICT)
+
+        # Add licks data to NWB in-memory object:
+        if len(session_object.licks) > 0:
+            nwb.add_licks(nwbfile, session_object.licks)
+
+        # Add rewards data to NWB in-memory object:
+        if len(session_object.rewards) > 0:
+            nwb.add_rewards(nwbfile, session_object.rewards)
+
+        # Add metadata to NWB in-memory object:
+        nwb.add_metadata(nwbfile, session_object.metadata,
+                         behavior_only=True)
+
+        # Add task parameters to NWB in-memory object:
+        nwb.add_task_parameters(nwbfile, session_object.task_parameters)
+
+        # Write the file:
+        with NWBHDF5IO(self.path, 'w') as nwb_file_writer:
+            nwb_file_writer.write(nwbfile)
+
+        return nwbfile
+
+    def get_behavior_session_id(self) -> int:
+        return int(self.nwbfile.identifier)
+
+    def get_running_data_df(self, **kwargs) -> pd.DataFrame:
+
+        running_speed = self.get_running_speed()
+
+        running_data_df = pd.DataFrame({'speed': running_speed.values},
+                                       index=pd.Index(running_speed.timestamps,
+                                                      name='timestamps'))
+
+        for key in ['v_in', 'v_sig']:
+            if key in self.nwbfile.acquisition:
+                running_data_df[key] = self.nwbfile.get_acquisition(key).data
+
+        if 'running' in self.nwbfile.processing:
+            running = self.nwbfile.processing['running']
+            for key in ['dx']:
+                if key in running.fields['data_interfaces']:
+                    running_data_df[key] = running.get_data_interface(key).data
+
+        return running_data_df[['speed', 'dx', 'v_sig', 'v_in']]
+
+    def get_stimulus_templates(self, **kwargs):
+        return {key: val.data[:]
+                for key, val in self.nwbfile.stimulus_template.items()}
+
+    def get_stimulus_timestamps(self) -> np.ndarray:
+        stim_module = self.nwbfile.processing['stimulus']
+        return stim_module.get_data_interface('timestamps').timestamps[:]
+
+    def get_trials(self) -> pd.DataFrame:
+        trials = self.nwbfile.trials.to_dataframe()
+        if 'lick_events' in trials.columns:
+            trials.drop('lick_events', inplace=True, axis=1)
+        trials.index = trials.index.rename('trials_id')
+        return trials
+
+    def get_licks(self) -> np.ndarray:
+        if 'licking' in self.nwbfile.processing:
+            licks = (
+                self.nwbfile.processing['licking'].get_data_interface('licks'))
+            lick_timestamps = licks['timestamps'].timestamps[:]
+            return pd.DataFrame({'time': lick_timestamps})
+        else:
+            return pd.DataFrame({'time': []})
+
+    def get_rewards(self) -> np.ndarray:
+        if 'rewards' in self.nwbfile.processing:
+            rewards = self.nwbfile.processing['rewards']
+            time = rewards.get_data_interface('autorewarded').timestamps[:]
+            autorewarded = rewards.get_data_interface('autorewarded').data[:]
+            volume = rewards.get_data_interface('volume').data[:]
+            return pd.DataFrame({
+                'volume': volume, 'timestamps': time,
+                'autorewarded': autorewarded}).set_index('timestamps')
+        else:
+            return pd.DataFrame({
+                'volume': [], 'timestamps': [],
+                'autorewarded': []}).set_index('timestamps')
+
+    def get_metadata(self) -> dict:
+
+        metadata_nwb_obj = self.nwbfile.lab_meta_data['metadata']
+        data = OphysBehaviorMetadataSchema(
+            exclude=['experiment_datetime']).dump(metadata_nwb_obj)
+
+        # Add pyNWB Subject metadata to behavior ophys session metadata
+        nwb_subject = self.nwbfile.subject
+        data['LabTracks_ID'] = int(nwb_subject.subject_id)
+        data['sex'] = nwb_subject.sex
+        data['age'] = nwb_subject.age
+        data['full_genotype'] = nwb_subject.genotype
+        data['reporter_line'] = list(nwb_subject.reporter_line)
+        data['driver_line'] = list(nwb_subject.driver_line)
+
+        # Add other metadata stored in nwb file to behavior ophys session meta
+        data['experiment_datetime'] = self.nwbfile.session_start_time
+        data['behavior_session_uuid'] = uuid.UUID(
+            data['behavior_session_uuid'])
+        return data
+
+    def get_task_parameters(self) -> dict:
+
+        metadata_nwb_obj = self.nwbfile.lab_meta_data['task_parameters']
+        data = BehaviorTaskParametersSchema().dump(metadata_nwb_obj)
+        return data

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_json_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_json_api.py
@@ -1,13 +1,13 @@
 import logging
-from datetime import datetime
-import pytz
 from typing import Optional
 
+from allensdk.brain_observatory.behavior.session_apis.data_io import (
+    BehaviorJsonApi)
 from allensdk.brain_observatory.behavior.session_apis.data_transforms import (
     BehaviorOphysDataXforms)
 
 
-class BehaviorOphysJsonApi(BehaviorOphysDataXforms):
+class BehaviorOphysJsonApi(BehaviorOphysDataXforms, BehaviorJsonApi):
     """A data fetching class that serves as an API for fetching 'raw'
     data from a json file necessary (but not sufficient) for filling
     a 'BehaviorOphysSession'.
@@ -50,18 +50,6 @@ class BehaviorOphysJsonApi(BehaviorOphysDataXforms):
         ophys experiment"""
         return self.data['sync_file']
 
-    def get_rig_name(self) -> str:
-        """Get the name of the experiment rig (ex: CAM2P.3)"""
-        return self.data['rig_name']
-
-    def get_sex(self) -> str:
-        """Get the sex of the subject (ex: 'M', 'F', or 'unknown')"""
-        return self.data['sex']
-
-    def get_age(self) -> str:
-        """Get the age of the subject (ex: 'P15', 'Adult', etc...)"""
-        return self.data['age']
-
     def get_field_of_view_shape(self) -> dict:
         """Get a field of view dictionary for a given ophys experiment.
            ex: {"width": int, "height": int}
@@ -83,41 +71,6 @@ class BehaviorOphysJsonApi(BehaviorOphysDataXforms):
         """Get the imaging depth for an ophys experiment
         (ex: 400, 500, etc.)"""
         return self.data['targeted_depth']
-
-    def get_stimulus_name(self) -> str:
-        """Get the name of the stimulus presented for an ophys experiment"""
-        return self.data['stimulus_name']
-
-    def get_experiment_date(self) -> datetime:
-        """Get the acquisition date of an ophys experiment"""
-        return pytz.utc.localize(
-            datetime.strptime(self.data['date_of_acquisition'],
-                              "%Y-%m-%d %H:%M:%S"))
-
-    def get_reporter_line(self) -> str:
-        """Get the (gene) reporter line for the subject associated with an
-        ophys experiment
-        """
-        return self.data['reporter_line']
-
-    def get_driver_line(self) -> str:
-        """Get the (gene) driver line for the subject associated with an ophys
-        experiment"""
-        return self.data['driver_line']
-
-    def external_specimen_name(self) -> int:
-        """Get the external specimen id (LabTracks ID) for the subject
-        associated with an ophys experiment"""
-        return self.data['external_specimen_name']
-
-    def get_full_genotype(self) -> str:
-        """Get the full genotype of the subject associated with an ophys
-        experiment"""
-        return self.data['full_genotype']
-
-    def get_behavior_stimulus_file(self) -> str:
-        """Get the filepath to the StimulusPickle file for the session"""
-        return self.data['behavior_stimulus_file']
 
     def get_dff_file(self) -> str:
         """Get the filepath of the dff trace file associated with an ophys
@@ -147,11 +100,6 @@ class BehaviorOphysJsonApi(BehaviorOphysDataXforms):
         """Get the filepath for the motion transform file (.csv) associated
         with an ophys experiment"""
         return self.data['rigid_motion_transform_file']
-
-    def get_external_specimen_name(self) -> int:
-        """Get the external specimen id for the subject associated with an
-        ophys experiment"""
-        return int(self.data['external_specimen_name'])
 
     def get_imaging_plane_group(self) -> Optional[int]:
         """Get the imaging plane group number. This is a numeric index

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -106,7 +106,8 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
                                         session_object.segmentation_mask_image)
 
         # Add metadata to NWB in-memory object:
-        nwb.add_metadata(nwbfile, session_object.metadata)
+        nwb.add_metadata(nwbfile, session_object.metadata,
+                         behavior_only=False)
 
         # Add task parameters to NWB in-memory object:
         nwb.add_task_parameters(nwbfile, session_object.task_parameters)

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -22,14 +22,16 @@ from allensdk.brain_observatory.behavior.trials_processing import (
     TRIAL_COLUMN_DESCRIPTION_DICT
 )
 from allensdk.brain_observatory.nwb.metadata import load_pynwb_extension
-from allensdk.brain_observatory.nwb.nwb_api import NwbApi
+from allensdk.brain_observatory.behavior.session_apis.data_io import (
+    BehaviorNwbApi
+)
 from allensdk.brain_observatory.nwb.nwb_utils import set_omitted_stop_time
 
 load_pynwb_extension(OphysBehaviorMetadataSchema, 'ndx-aibs-behavior-ophys')
 load_pynwb_extension(BehaviorTaskParametersSchema, 'ndx-aibs-behavior-ophys')
 
 
-class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
+class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
     """A data fetching class that serves as an API for fetching 'raw'
     data from an NWB file that is both necessary and sufficient for filling
     a 'BehaviorOphysSession'.
@@ -37,7 +39,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
 
     def __init__(self, *args, **kwargs):
         self.filter_invalid_rois = kwargs.pop("filter_invalid_rois", False)
-        super(BehaviorOphysNwbApi, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def save(self, session_object):
 
@@ -72,7 +74,9 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
 
             # Add index for this template to NWB in-memory object:
             nwb_template = nwbfile.stimulus_template[name]
-            stimulus_index = session_object.stimulus_presentations[session_object.stimulus_presentations['image_set'] == nwb_template.name]
+            stimulus_index = session_object.stimulus_presentations[
+                session_object.stimulus_presentations[
+                    'image_set'] == nwb_template.name]
             nwb.add_stimulus_index(nwbfile, stimulus_index, nwb_template)
 
         # search for omitted rows and add stop_time before writing to NWB file
@@ -138,10 +142,6 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
     def get_ophys_experiment_id(self) -> int:
         return int(self.nwbfile.identifier)
 
-    # TODO: Implement save and load of behavior_session_id to/from NWB file
-    def get_behavior_session_id(self) -> int:
-        raise NotImplementedError()
-
     # TODO: Implement save and load of ophys_session_id to/from NWB file
     def get_ophys_session_id(self) -> int:
         raise NotImplementedError()
@@ -150,72 +150,10 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
     def get_eye_tracking(self) -> int:
         raise NotImplementedError()
 
-    def get_running_data_df(self, lowpass=True) -> pd.DataFrame:
-        """
-        Gets the running data df
-        Parameters
-        ----------
-        lowpass: bool
-            Whether to return running speed with or without low pass filter applied
-
-        Returns
-        -------
-            pd.DataFrame:
-                Dataframe containing various signals used to compute running
-                speed, and the filtered or unfiltered speed.
-        """
-
-        running_speed = self.get_running_speed(lowpass=lowpass)
-
-        running_data_df = pd.DataFrame({'speed': running_speed.values},
-                                       index=pd.Index(running_speed.timestamps,
-                                                      name='timestamps'))
-
-        for key in ['v_in', 'v_sig']:
-            if key in self.nwbfile.acquisition:
-                running_data_df[key] = self.nwbfile.get_acquisition(key).data
-
-        for key in ['dx']:
-            if ('running' in self.nwbfile.processing) and (key in self.nwbfile.processing['running'].fields['data_interfaces']):
-                running_data_df[key] = self.nwbfile.processing['running'].get_data_interface(key).data
-
-        return running_data_df[['speed', 'dx', 'v_sig', 'v_in']]
-
     def get_ophys_timestamps(self) -> np.ndarray:
-        return self.nwbfile.processing['ophys'].get_data_interface('dff').roi_response_series['traces'].timestamps[:]
-
-    def get_stimulus_templates(self, **kwargs):
-        return {key: val.data[:]
-                for key, val in self.nwbfile.stimulus_template.items()}
-
-    def get_stimulus_timestamps(self) -> np.ndarray:
-        return self.nwbfile.processing['stimulus'].get_data_interface('timestamps').timestamps[:]
-
-    def get_trials(self) -> pd.DataFrame:
-        trials = self.nwbfile.trials.to_dataframe()
-        if 'lick_events' in trials.columns:
-            trials.drop('lick_events', inplace=True, axis=1)
-        trials.index = trials.index.rename('trials_id')
-        return trials
-
-    def get_licks(self) -> pd.DataFrame:
-        if 'licking' in self.nwbfile.processing:
-            return pd.DataFrame({'time': self.nwbfile.processing['licking'].get_data_interface('licks').timestamps[:]})
-        else:
-            return pd.DataFrame({'time': []})
-
-    def get_rewards(self) -> np.ndarray:
-        if 'rewards' in self.nwbfile.processing:
-            time = self.nwbfile.processing['rewards'].get_data_interface('autorewarded').timestamps[:]
-            autorewarded = self.nwbfile.processing['rewards'].get_data_interface('autorewarded').data[:]
-            volume = self.nwbfile.processing['rewards'].get_data_interface('volume').data[:]
-            return pd.DataFrame({
-                'volume': volume, 'timestamps': time,
-                'autorewarded': autorewarded}).set_index('timestamps')
-        else:
-            return pd.DataFrame({
-                'volume': [], 'timestamps': [], 
-                'autorewarded': []}).set_index('timestamps')
+        return self.nwbfile.processing[
+            'ophys'].get_data_interface('dff').roi_response_series[
+                'traces'].timestamps[:]
 
     def get_max_projection(self, image_api=None) -> sitk.Image:
         return self.get_image('max_projection', 'ophys', image_api=image_api)
@@ -254,7 +192,8 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
                           "'emission_lambda'")
         else:
             image_seg = ophys_module.data_interfaces['image_segmentation']
-            imaging_plane = image_seg.plane_segmentations['cell_specimen_table'].imaging_plane
+            imaging_plane = image_seg.plane_segmentations[
+                'cell_specimen_table'].imaging_plane
             optical_channel = imaging_plane.optical_channel[0]
 
             data['ophys_frame_rate'] = imaging_plane.imaging_rate
@@ -269,21 +208,19 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
             data['behavior_session_uuid'])
         return data
 
-    def get_task_parameters(self) -> dict:
-
-        metadata_nwb_obj = self.nwbfile.lab_meta_data['task_parameters']
-        data = BehaviorTaskParametersSchema().dump(metadata_nwb_obj)
-        return data
-
     def get_cell_specimen_table(self) -> pd.DataFrame:
         # NOTE: ROI masks are stored in full frame width and height arrays
-        df = self.nwbfile.processing['ophys'].data_interfaces['image_segmentation'].plane_segmentations['cell_specimen_table'].to_dataframe()
+        df = self.nwbfile.processing[
+            'ophys'].data_interfaces[
+                'image_segmentation'].plane_segmentations[
+                    'cell_specimen_table'].to_dataframe()
 
         # Because pynwb stores this field as "image_mask", it is renamed here
         df = df.rename(columns={'image_mask': 'roi_mask'})
 
         df.index.rename('cell_roi_id', inplace=True)
-        df['cell_specimen_id'] = [None if csid == -1 else csid for csid in df['cell_specimen_id'].values]
+        df['cell_specimen_id'] = [None if csid == -1 else csid
+                                  for csid in df['cell_specimen_id'].values]
 
         df.reset_index(inplace=True)
         df.set_index('cell_specimen_id', inplace=True)
@@ -294,7 +231,8 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
         return df
 
     def get_dff_traces(self) -> pd.DataFrame:
-        dff_nwb = self.nwbfile.processing['ophys'].data_interfaces['dff'].roi_response_series['traces']
+        dff_nwb = self.nwbfile.processing[
+            'ophys'].data_interfaces['dff'].roi_response_series['traces']
         # dff traces stored as timepoints x rois in NWB
         # We want rois x timepoints, hence the transpose
         dff_traces = dff_nwb.data[:].T
@@ -310,13 +248,16 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
         return df
 
     def get_corrected_fluorescence_traces(self) -> pd.DataFrame:
-        corrected_fluorescence_nwb = self.nwbfile.processing['ophys'].data_interfaces['corrected_fluorescence'].roi_response_series['traces']
+        corr_fluorescence_nwb = self.nwbfile.processing[
+            'ophys'].data_interfaces[
+                'corrected_fluorescence'].roi_response_series['traces']
         # f traces stored as timepoints x rois in NWB
         # We want rois x timepoints, hence the transpose
-        f_traces = corrected_fluorescence_nwb.data[:].T
+        f_traces = corr_fluorescence_nwb.data[:].T
         df = pd.DataFrame({'corrected_fluorescence': f_traces.tolist()},
-                          index=pd.Index(data=corrected_fluorescence_nwb.rois.table.id[:],
-                                         name='cell_roi_id'))
+                          index=pd.Index(
+                                data=corr_fluorescence_nwb.rois.table.id[:],
+                                name='cell_roi_id'))
 
         cell_specimen_table = self.get_cell_specimen_table()
         df = cell_specimen_table[['cell_roi_id']].join(df, on='cell_roi_id')
@@ -326,7 +267,9 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
         ophys_module = self.nwbfile.processing['ophys']
 
         motion_correction_data = {}
-        motion_correction_data['x'] = ophys_module.get_data_interface('ophys_motion_correction_x').data[:]
-        motion_correction_data['y'] = ophys_module.get_data_interface('ophys_motion_correction_y').data[:]
+        motion_correction_data['x'] = ophys_module.get_data_interface(
+            'ophys_motion_correction_x').data[:]
+        motion_correction_data['y'] = ophys_module.get_data_interface(
+            'ophys_motion_correction_y').data[:]
 
         return pd.DataFrame(motion_correction_data)

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_xforms.py
@@ -249,8 +249,7 @@ class BehaviorDataXforms(BehaviorBase):
         pd.DataFrame
             A dataframe containing extended behavior trial information.
         """
-        filename = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(filename)
+        data = self._behavior_stimulus_file()
         return get_extended_trials(data)
 
     @memoize

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_xforms.py
@@ -285,8 +285,4 @@ class BehaviorDataXforms(BehaviorBase):
             "foraging_id": self.get_foraging_id(),
             "behavior_session_id": self.get_behavior_session_id()
         }
-        if hasattr(self, "ophys_experiment_ids"):
-            metadata["ophys_experiment_id"] = self.ophys_experiment_ids
-        if hasattr(self, "ophys_container_id"):
-            metadata["experiment_container_id"] = self.ophys_container_id
         return metadata

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_xforms.py
@@ -41,14 +41,20 @@ class BehaviorDataXforms(BehaviorBase):
         """
         data = self._behavior_stimulus_file()
         behavior_pkl_uuid = data.get("session_uuid")
+
+        behavior_session_id = self.get_behavior_session_id()
+        foraging_id = self.get_foraging_id()
+
         # Sanity check to ensure that pkl file data matches up with
         # the behavior session that the pkl file has been associated with.
         assert_err_msg = (
-            f"The behavior session UUID ({behavior_pkl_uuid}) in the behavior "
-            f"stimulus *.pkl file ({self.get_behavior_stimulus_file()}) does "
-            f"does not match the LIMS UUID ({self.foraging_id}) for "
-            f"behavior session: {self.behavior_session_id}")
-        assert behavior_pkl_uuid == self.foraging_id, assert_err_msg
+            f"The behavior session UUID ({behavior_pkl_uuid}) in the "
+            f"behavior stimulus *.pkl file "
+            f"({self.get_behavior_stimulus_file()}) does "
+            f"does not match the foraging UUID ({foraging_id}) for "
+            f"behavior session: {behavior_session_id}")
+        assert behavior_pkl_uuid == foraging_id, assert_err_msg
+
         return behavior_pkl_uuid
 
     def get_licks(self) -> pd.DataFrame:
@@ -269,8 +275,6 @@ class BehaviorDataXforms(BehaviorBase):
             "rig_name": self.get_rig_name(),
             "sex": self.get_sex(),
             "age": self.get_age(),
-            "ophys_experiment_id": self.ophys_experiment_ids,
-            "experiment_container_id": self.ophys_container_id,
             "stimulus_frame_rate": self.get_stimulus_frame_rate(),
             "session_type": self.get_stimulus_name(),
             "experiment_datetime": self.get_experiment_date(),
@@ -279,8 +283,11 @@ class BehaviorDataXforms(BehaviorBase):
             "LabTracks_ID": self.get_external_specimen_name(),
             "full_genotype": self.get_full_genotype(),
             "behavior_session_uuid": bs_uuid,
-            "foraging_id": self.foraging_id,
-            "behavior_session_id": self.behavior_session_id,
-            "behavior_training_id": self.behavior_training_id,
+            "foraging_id": self.get_foraging_id(),
+            "behavior_session_id": self.get_behavior_session_id()
         }
+        if hasattr(self, "ophys_experiment_ids"):
+            metadata["ophys_experiment_id"] = self.ophys_experiment_ids
+        if hasattr(self, "ophys_container_id"):
+            metadata["experiment_container_id"] = self.ophys_container_id
         return metadata

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -12,36 +12,33 @@ from allensdk.api.cache import memoize
 from allensdk.brain_observatory.behavior.session_apis.abcs import (
     BehaviorOphysBase)
 
-from allensdk.brain_observatory.behavior.trials_processing import (
-    get_extended_trials)
+
 from allensdk.brain_observatory.behavior.sync import (
     get_sync_data, get_stimulus_rebase_function, frame_time_offset)
 from allensdk.brain_observatory.sync_dataset import Dataset
 from allensdk.brain_observatory import sync_utilities
 from allensdk.internal.brain_observatory.time_sync import OphysTimeAligner
-from allensdk.brain_observatory.behavior.stimulus_processing import (
-    get_stimulus_presentations, get_stimulus_templates, get_stimulus_metadata)
-from allensdk.brain_observatory.behavior.metadata_processing import (
-    get_task_parameters)
-from allensdk.brain_observatory.behavior.running_processing import (
-    get_running_df)
 from allensdk.brain_observatory.behavior.rewards_processing import get_rewards
 from allensdk.brain_observatory.behavior.trials_processing import get_trials
 from allensdk.brain_observatory.behavior.eye_tracking_processing import (
     load_eye_tracking_hdf, process_eye_tracking_data)
-from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory.behavior.image_api import ImageApi
 import allensdk.brain_observatory.roi_masks as roi
+from allensdk.brain_observatory.behavior.session_apis.data_transforms import (
+    BehaviorDataXforms
+)
 
 
-class BehaviorOphysDataXforms(BehaviorOphysBase):
+class BehaviorOphysDataXforms(BehaviorDataXforms, BehaviorOphysBase):
     """This class provides methods that transform (xform) 'raw' data provided
     by LIMS data APIs to fill a BehaviorOphysSession.
     """
 
     @memoize
     def get_cell_specimen_table(self):
-        cell_specimen_table = pd.DataFrame.from_dict(self.get_raw_cell_specimen_table_dict()).set_index('cell_roi_id').sort_index()
+        cell_specimen_table = pd.DataFrame.from_dict(
+            self.get_raw_cell_specimen_table_dict()).set_index(
+                'cell_roi_id').sort_index()
         fov_width = self.get_field_of_view_shape()['width']
         fov_height = self.get_field_of_view_shape()['height']
 
@@ -59,7 +56,8 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
             roi_mask_list.append(curr_roi.get_mask_plane().astype(np.bool))
 
         cell_specimen_table['roi_mask'] = roi_mask_list
-        cell_specimen_table = cell_specimen_table[sorted(cell_specimen_table.columns)]
+        cell_specimen_table = cell_specimen_table[
+            sorted(cell_specimen_table.columns)]
 
         cell_specimen_table.index.rename('cell_roi_id', inplace=True)
         cell_specimen_table.reset_index(inplace=True)
@@ -154,14 +152,8 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         return resampled
 
     def get_behavior_session_uuid(self):
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
+        data = self._behavior_stimulus_file()
         return data['session_uuid']
-
-    @memoize
-    def get_stimulus_frame_rate(self):
-        stimulus_timestamps = self.get_stimulus_timestamps()
-        return np.round(1 / np.mean(np.diff(stimulus_timestamps)), 0)
 
     @memoize
     def get_ophys_frame_rate(self):
@@ -193,7 +185,8 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         mdata['emission_lambda'] = 520.
         mdata['indicator'] = 'GCAMP6f'
         mdata['field_of_view_width'] = self.get_field_of_view_shape()['width']
-        mdata['field_of_view_height'] = self.get_field_of_view_shape()['height']
+        mdata['field_of_view_height'] = (
+            self.get_field_of_view_shape()['height'])
 
         return mdata
 
@@ -222,69 +215,13 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         return df
 
     @memoize
-    def get_running_data_df(self, lowpass=True):
-        stimulus_timestamps = self.get_stimulus_timestamps()
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
-        return get_running_df(data, stimulus_timestamps, lowpass=lowpass)
-
-    @memoize
-    def get_running_speed(self, lowpass=True):
-        running_data_df = self.get_running_data_df(lowpass=lowpass)
-        assert running_data_df.index.name == 'timestamps'
-        return RunningSpeed(timestamps=running_data_df.index.values,
-                            values=running_data_df.speed.values)
-
-    @memoize
-    def get_stimulus_presentations(self):
-        stimulus_timestamps = self.get_stimulus_timestamps()
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
-        stim_presentations_df_pre = get_stimulus_presentations(
-            data, stimulus_timestamps)
-        stimulus_metadata_df = get_stimulus_metadata(data)
-        idx_name = stim_presentations_df_pre.index.name
-
-        stimulus_index_df = (
-            stim_presentations_df_pre.reset_index().merge(
-                stimulus_metadata_df.reset_index(),
-                on=['image_name']).set_index(idx_name))
-
-        stimulus_index_df.sort_index(inplace=True)
-
-        columns_to_select = ['image_set', 'image_index', 'start_time',
-                             'phase', 'spatial_frequency']
-
-        stimulus_index_df = (
-            stimulus_index_df[columns_to_select].rename(
-                columns={'start_time': 'timestamps'}))
-
-        stimulus_index_df.set_index('timestamps', inplace=True, drop=True)
-        stim_presentations_df = (
-            stim_presentations_df_pre.merge(stimulus_index_df,
-                                            left_on='start_time',
-                                            right_index=True, how='left'))
-
-        assert len(stim_presentations_df_pre) == len(stim_presentations_df)
-
-        sorted_column_names = sorted(stim_presentations_df.columns)
-        return stim_presentations_df[sorted_column_names]
-
-    @memoize
-    def get_stimulus_templates(self):
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
-        return get_stimulus_templates(data)
-
-    @memoize
     def get_sync_licks(self):
         lick_times = self.get_sync_data()['lick_times']
         return pd.DataFrame({'time': lick_times})
 
     @memoize
     def get_licks(self):
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
+        data = self._behavior_stimulus_file()
         rebase_function = self.get_stimulus_rebase_function()
         # Get licks from pickle file (need to add an offset to align with
         # the trial_log time stream)
@@ -303,26 +240,19 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
 
     @memoize
     def get_rewards(self):
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
+        data = self._behavior_stimulus_file()
         rebase_function = self.get_stimulus_rebase_function()
         return get_rewards(data, rebase_function)
-
-    @memoize
-    def get_task_parameters(self):
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
-        return get_task_parameters(data)
 
     @memoize
     def get_trials(self):
 
         licks = self.get_licks()
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
         rewards = self.get_rewards()
         stimulus_presentations = self.get_stimulus_presentations()
+        data = self._behavior_stimulus_file()
         rebase_function = self.get_stimulus_rebase_function()
+
         trial_df = get_trials(data, licks, rewards,
                               stimulus_presentations, rebase_function)
 
@@ -383,17 +313,11 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         stimulus_timestamps_no_monitor_delay = (
             self.get_sync_data()['stimulus_times_no_delay'])
 
-        behavior_stimulus_file = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(behavior_stimulus_file)
+        data = self._behavior_stimulus_file()
         stimulus_rebase_function = get_stimulus_rebase_function(
             data, stimulus_timestamps_no_monitor_delay)
 
         return stimulus_rebase_function
-
-    def get_extended_trials(self):
-        filename = self.get_behavior_stimulus_file()
-        data = pd.read_pickle(filename)
-        return get_extended_trials(data)
 
     def get_eye_tracking(self,
                          z_threshold: float = 3.0,

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 import uuid
 
 import h5py
@@ -161,34 +161,37 @@ class BehaviorOphysDataXforms(BehaviorDataXforms, BehaviorOphysBase):
         return np.round(1 / np.mean(np.diff(ophys_timestamps)), 0)
 
     @memoize
-    def get_metadata(self):
-        mdata = dict()
-        mdata['ophys_experiment_id'] = self.get_ophys_experiment_id()
-        mdata['experiment_container_id'] = self.get_experiment_container_id()
-        mdata['ophys_frame_rate'] = self.get_ophys_frame_rate()
-        mdata['stimulus_frame_rate'] = self.get_stimulus_frame_rate()
-        mdata['targeted_structure'] = self.get_targeted_structure()
-        mdata['imaging_depth'] = self.get_imaging_depth()
-        mdata['session_type'] = self.get_stimulus_name()
-        mdata['experiment_datetime'] = self.get_experiment_date()
-        mdata['reporter_line'] = self.get_reporter_line()
-        mdata['driver_line'] = self.get_driver_line()
-        mdata['LabTracks_ID'] = self.get_external_specimen_name()
-        mdata['full_genotype'] = self.get_full_genotype()
+    def get_metadata(self) -> Dict[str, Any]:
+        """Return metadata about the session.
+        :rtype: dict
+        """
         behavior_session_uuid = self.get_behavior_session_uuid()
-        mdata['behavior_session_uuid'] = uuid.UUID(behavior_session_uuid)
-        mdata["imaging_plane_group"] = self.get_imaging_plane_group()
-        mdata['rig_name'] = self.get_rig_name()
-        mdata['sex'] = self.get_sex()
-        mdata['age'] = self.get_age()
-        mdata['excitation_lambda'] = 910.
-        mdata['emission_lambda'] = 520.
-        mdata['indicator'] = 'GCAMP6f'
-        mdata['field_of_view_width'] = self.get_field_of_view_shape()['width']
-        mdata['field_of_view_height'] = (
-            self.get_field_of_view_shape()['height'])
 
-        return mdata
+        metadata = {
+            'ophys_experiment_id': self.get_ophys_experiment_id(),
+            'experiment_container_id': self.get_experiment_container_id(),
+            'ophys_frame_rate': self.get_ophys_frame_rate(),
+            'stimulus_frame_rate': self.get_stimulus_frame_rate(),
+            'targeted_structure': self.get_targeted_structure(),
+            'imaging_depth': self.get_imaging_depth(),
+            'session_type': self.get_stimulus_name(),
+            'experiment_datetime': self.get_experiment_date(),
+            'reporter_line': self.get_reporter_line(),
+            'driver_line': self.get_driver_line(),
+            'LabTracks_ID': self.get_external_specimen_name(),
+            'full_genotype': self.get_full_genotype(),
+            'behavior_session_uuid': uuid.UUID(behavior_session_uuid),
+            'imaging_plane_group': self.get_imaging_plane_group(),
+            'rig_name': self.get_rig_name(),
+            'sex': self.get_sex(),
+            'age': self.get_age(),
+            'excitation_lambda': 910.0,
+            'emission_lambda': 520.0,
+            'indicator': 'GCAMP6f',
+            'field_of_view_width': self.get_field_of_view_shape()['width'],
+            'field_of_view_height': self.get_field_of_view_shape()['height']
+        }
+        return metadata
 
     @memoize
     def get_cell_roi_ids(self):

--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
@@ -1,0 +1,73 @@
+import os
+import logging
+import sys
+import argschema
+import marshmallow
+
+from allensdk.brain_observatory.behavior.behavior_session import (
+    BehaviorSession)
+from allensdk.brain_observatory.behavior.session_apis.data_io import (
+    BehaviorNwbApi, BehaviorJsonApi)
+from allensdk.brain_observatory.behavior.write_behavior_nwb._schemas import (
+    InputSchema, OutputSchema)
+from allensdk.brain_observatory.argschema_utilities import (
+    write_or_print_outputs)
+from allensdk.brain_observatory.session_api_utils import sessions_are_equal
+
+
+def write_behavior_nwb(session_data, nwb_filepath):
+
+    nwb_filepath_inprogress = nwb_filepath+'.inprogress'
+    nwb_filepath_error = nwb_filepath+'.error'
+
+    # Clean out files from previous runs:
+    for filename in [nwb_filepath_inprogress,
+                     nwb_filepath_error,
+                     nwb_filepath]:
+        if os.path.exists(filename):
+            os.remove(filename)
+
+    try:
+        session = BehaviorSession(api=BehaviorJsonApi(session_data))
+        BehaviorNwbApi(nwb_filepath_inprogress).save(session)
+        api = BehaviorNwbApi(nwb_filepath_inprogress)
+        assert sessions_are_equal(session, BehaviorSession(api=api))
+        os.rename(nwb_filepath_inprogress, nwb_filepath)
+        return {'output_path': nwb_filepath}
+    except Exception as e:
+        os.rename(nwb_filepath_inprogress, nwb_filepath_error)
+        raise e
+
+
+def main():
+
+    logging.basicConfig(
+        format='%(asctime)s - %(process)s - %(levelname)s - %(message)s')
+
+    args = sys.argv[1:]
+    try:
+        parser = argschema.ArgSchemaParser(
+            args=args,
+            schema_type=InputSchema,
+            output_schema_type=OutputSchema,
+        )
+        logging.info('Input successfully parsed')
+    except marshmallow.exceptions.ValidationError as err:
+        logging.error('Parsing failure')
+        print(err)
+        raise err
+
+    try:
+        output = write_behavior_nwb(parser.args['session_data'],
+                                    parser.args['output_path'])
+        logging.info('File successfully created')
+    except Exception as err:
+        logging.error('NWB write failure')
+        print(err)
+        raise err
+
+    write_or_print_outputs(output, parser)
+
+
+if __name__ == "__main__":
+    main()

--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
@@ -1,0 +1,80 @@
+from argschema import ArgSchema
+from argschema.fields import (LogLevel, String, Int, Nested, List)
+import marshmallow as mm
+import pandas as pd
+
+from allensdk.brain_observatory.argschema_utilities import (
+    check_read_access, check_write_access_overwrite, RaisingSchema)
+
+
+class BehaviorSessionData(RaisingSchema):
+    behavior_session_id = Int(required=True,
+                              description=("Unique identifier for the "
+                                           "behavior session to write into "
+                                           "NWB format"))
+    foraging_id = String(required=True,
+                         description=("The foraging_id for the behavior "
+                                      "session"))
+    driver_line = List(String,
+                       required=True,
+                       description='Genetic driver line(s) of subject')
+    reporter_line = List(String,
+                         required=True,
+                         description='Genetic reporter line(s) of subject')
+    full_genotype = String(required=True,
+                           description='Full genotype of subject')
+    rig_name = String(required=True,
+                      description=("Name of experimental rig used for "
+                                   "the behavior session"))
+    date_of_acquisition = String(required=True,
+                                 description=("Date of acquisition of "
+                                              "behavior session, in string "
+                                              "format"))
+    external_specimen_name = Int(required=True,
+                                 description='LabTracks ID of the subject')
+    behavior_stimulus_file = String(required=True,
+                                    validate=check_read_access,
+                                    description=("Path of behavior_stimulus "
+                                                 "camstim *.pkl file"))
+    date_of_birth = String(required=True, description="Subject date of birth")
+    sex = String(required=True, description="Subject sex")
+    age = String(required=True, description="Subject age")
+    stimulus_name = String(required=True,
+                           description=("Name of stimulus presented during "
+                                        "behavior session"))
+
+    @mm.pre_load
+    def set_stimulus_name(self, data, **kwargs):
+        if data.get("stimulus_name") is None:
+            pkl = pd.read_pickle(data["behavior_stimulus_file"])
+            try:
+                stimulus_name = pkl["items"]["behavior"]["cl_params"]["stage"]
+            except KeyError:
+                raise mm.ValidationError(
+                    f"Could not obtain stimulus_name/stage information from "
+                    f"the *.pkl file ({data['behavior_stimulus_file']}) "
+                    f"for the behavior session to save as NWB! The "
+                    f"following series of nested keys did not work: "
+                    f"['items']['behavior']['cl_params']['stage']"
+                )
+            data["stimulus_name"] = stimulus_name
+        return data
+
+
+class InputSchema(ArgSchema):
+    class Meta:
+        unknown = mm.RAISE
+    log_level = LogLevel(default='INFO',
+                         description='Logging level of the module')
+    session_data = Nested(BehaviorSessionData,
+                          required=True,
+                          description='Data pertaining to a behavior session')
+    output_path = String(required=True,
+                         validate=check_write_access_overwrite,
+                         description='Path of output.json to be written')
+
+
+class OutputSchema(RaisingSchema):
+    output_path = String(required=True,
+                         validate=check_write_access_overwrite,
+                         description='Path of output.json to be written')

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -15,7 +15,8 @@ from pynwb.base import TimeSeries, Images
 from pynwb.behavior import BehavioralEvents
 from pynwb import ProcessingModule, NWBFile
 from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
-from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
+from pynwb.ophys import (
+    DfOverF, ImageSegmentation, OpticalChannel, Fluorescence)
 from ndx_events import Events
 
 from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
@@ -306,7 +307,8 @@ def add_eye_gaze_mapping_data_to_nwbfile(nwbfile: pynwb.NWBFile,
     return nwbfile
 
 
-def add_running_speed_to_nwbfile(nwbfile, running_speed, name='speed', unit='cm/s'):
+def add_running_speed_to_nwbfile(nwbfile, running_speed,
+                                 name='speed', unit='cm/s'):
     ''' Adds running speed data to an NWBFile as a timeseries in acquisition
 
     Parameters
@@ -344,8 +346,10 @@ def add_running_speed_to_nwbfile(nwbfile, running_speed, name='speed', unit='cm/
     return nwbfile
 
 
-def add_running_data_dfs_to_nwbfile(nwbfile, running_data_df, running_data_df_unfiltered, unit_dict):
-    """Adds both unfiltered (raw) and filtered running speed data to an NWBFile as timeseries in acquisition and processing
+def add_running_data_dfs_to_nwbfile(nwbfile, running_data_df,
+                                    running_data_df_unfiltered, unit_dict):
+    """Adds both unfiltered (raw) and filtered running speed data to an
+    NWBFile as timeseries in acquisition and processing
 
     Parameters
     ----------
@@ -354,11 +358,13 @@ def add_running_data_dfs_to_nwbfile(nwbfile, running_data_df, running_data_df_un
     running_data_df : pandas.DataFrame
         Filtered running data
         Contains 'speed', 'v_in', 'vsig', 'dx'
-        Note that 'v_in', 'vsig', 'dx' are expected to be the same as in running_data_df_unfiltered
+        Note that 'v_in', 'vsig', 'dx' are expected to be the same as in
+        running_data_df_unfiltered
     running_data_df_unfiltered : pandas.DataFrame
         Unfiltered (raw) Running data
         Contains 'speed', 'v_in', 'vsig', 'dx'
-        Note that 'v_in', 'vsig', 'dx' are expected to be the same as in running_data_df
+        Note that 'v_in', 'vsig', 'dx' are expected to be the same as in
+        running_data_df
     unit_dict : dict, optional
         SI units of running speed values
 
@@ -370,11 +376,15 @@ def add_running_data_dfs_to_nwbfile(nwbfile, running_data_df, running_data_df_un
     running_speed = RunningSpeed(timestamps=running_data_df.index.values,
                                  values=running_data_df['speed'].values)
 
-    running_speed_unfiltered = RunningSpeed(timestamps=running_data_df_unfiltered.index.values,
-                                            values=running_data_df_unfiltered['speed'].values)
+    running_speed_unfiltered = RunningSpeed(
+        timestamps=running_data_df_unfiltered.index.values,
+        values=running_data_df_unfiltered['speed'].values)
 
-    add_running_speed_to_nwbfile(nwbfile, running_speed, name='speed', unit=unit_dict['speed'])
-    add_running_speed_to_nwbfile(nwbfile, running_speed_unfiltered, name='speed_unfiltered', unit=unit_dict['speed'])
+    add_running_speed_to_nwbfile(nwbfile, running_speed,
+                                 name='speed', unit=unit_dict['speed'])
+    add_running_speed_to_nwbfile(nwbfile, running_speed_unfiltered,
+                                 name='speed_unfiltered',
+                                 unit=unit_dict['speed'])
 
     running_mod = nwbfile.processing['running']
     timestamps_ts = running_mod.get_data_interface('speed').timestamps

--- a/allensdk/brain_observatory/nwb/behavior_ophys_nwb_extension_builder.py
+++ b/allensdk/brain_observatory/nwb/behavior_ophys_nwb_extension_builder.py
@@ -1,4 +1,7 @@
+import os
+
 from allensdk.brain_observatory.behavior.schemas import (
+    BehaviorMetadataSchema,
     OphysBehaviorMetadataSchema,
     BehaviorTaskParametersSchema,
     SubjectMetadataSchema
@@ -12,5 +15,7 @@ if __name__ == "__main__":
     # Run this module to regenerate the extension yaml files into this dir:
     prefix = 'ndx-aibs-behavior-ophys'
     schemas = [BehaviorTaskParametersSchema, SubjectMetadataSchema,
-               OphysBehaviorMetadataSchema]
-    create_pynwb_extension_from_schemas(schemas, prefix)
+               BehaviorMetadataSchema, OphysBehaviorMetadataSchema]
+    curr_dir = os.path.abspath(os.path.dirname(__file__))
+    create_pynwb_extension_from_schemas(schemas, prefix, save_dir=curr_dir)
+    print("Creation of NWB extension complete!")

--- a/allensdk/brain_observatory/nwb/metadata.py
+++ b/allensdk/brain_observatory/nwb/metadata.py
@@ -54,12 +54,14 @@ def load_pynwb_extension(schema, prefix: str):
     return pynwb.get_class(neurodata_type, prefix)
 
 
-def create_pynwb_extension_from_schemas(schema_list, prefix: str):
+def create_pynwb_extension_from_schemas(schema_list, prefix: str,
+                                        save_dir: str):
 
     # Initializations:
-    outdir = os.path.abspath(os.path.dirname(__file__))
     ext_source = f'{prefix}.extension.yaml'
     ns_path = f'{prefix}.namespace.yaml'
+
+    print(f"Saving extensions to: {save_dir}")
 
     extension_doc = ("Allen Institute behavior and optical "
                      "physiology extensions")
@@ -87,4 +89,4 @@ def create_pynwb_extension_from_schemas(schema_list, prefix: str):
         ns_builder.add_spec(ext_source, ext_group_spec)
 
     # Export spec
-    ns_builder.export(ns_path, outdir=outdir)
+    ns_builder.export(ns_path, outdir=save_dir)

--- a/allensdk/brain_observatory/nwb/ndx-aibs-behavior-ophys.extension.yaml
+++ b/allensdk/brain_observatory/nwb/ndx-aibs-behavior-ophys.extension.yaml
@@ -3,24 +3,6 @@ groups:
   neurodata_type_inc: LabMetaData
   doc: Metadata for behavior or behavior + ophys task parameters
   attributes:
-  - name: task
-    dtype: text
-    doc: The name of the behavioral task
-  - name: omitted_flash_fraction
-    dtype: float
-    doc: Fraction of flashes/image presentations that were omitted
-  - name: blank_duration_sec
-    dtype: text
-    shape:
-    - 2
-    doc: The lower and upper bound (in seconds) for a randomly chosen inter-stimulus
-      interval duration for a trial
-  - name: n_stimulus_frames
-    dtype: int
-    doc: Total number of stimuli frames
-  - name: stimulus
-    dtype: text
-    doc: Stimulus type
   - name: response_window_sec
     dtype: text
     shape:
@@ -33,9 +15,27 @@ groups:
   - name: reward_volume
     dtype: float
     doc: Volume of water (in mL) delivered as reward
+  - name: n_stimulus_frames
+    dtype: int
+    doc: Total number of stimuli frames
+  - name: stimulus
+    dtype: text
+    doc: Stimulus type
+  - name: blank_duration_sec
+    dtype: text
+    shape:
+    - 2
+    doc: The lower and upper bound (in seconds) for a randomly chosen inter-stimulus
+      interval duration for a trial
+  - name: omitted_flash_fraction
+    dtype: float
+    doc: Fraction of flashes/image presentations that were omitted
   - name: stimulus_duration_sec
     dtype: float
     doc: Duration of each stimulus presentation in seconds
+  - name: task
+    dtype: text
+    doc: The name of the behavioral task
   - name: stage
     dtype: text
     doc: Stage of behavioral task
@@ -53,34 +53,50 @@ groups:
     shape:
     - null
     doc: Reporter line of subject
-- neurodata_type_def: OphysBehaviorMetadata
+- neurodata_type_def: BehaviorMetadata
   neurodata_type_inc: LabMetaData
-  doc: Metadata for behavior + ophys experiments
+  doc: Metadata for behavior and behavior + ophys experiments
   attributes:
-  - name: imaging_depth
-    dtype: int
-    doc: Depth (microns) below the cortical surface targeted for two-photon acquisition
+  - name: rig_name
+    dtype: text
+    doc: Name of behavior or optical physiology experiment rig
   - name: session_type
     dtype: text
     doc: Experimental session description
-  - name: rig_name
-    dtype: text
-    doc: Name of optical physiology experiment rig
-  - name: ophys_experiment_id
-    dtype: int
-    doc: Id for this ophys session
-  - name: experiment_container_id
-    dtype: int
-    doc: Container ID for the container that contains this ophys session
   - name: stimulus_frame_rate
     dtype: float
     doc: Frame rate (frames/second) of the visual_stimulus from the monitor
   - name: behavior_session_uuid
     dtype: text
     doc: MTrain record for session, also called foraging_id
+- neurodata_type_def: OphysBehaviorMetadata
+  neurodata_type_inc: BehaviorMetadata
+  doc: Metadata for behavior + ophys experiments
+  attributes:
   - name: field_of_view_height
     dtype: int
     doc: Height of optical physiology imaging plane in pixels
+  - name: stimulus_frame_rate
+    dtype: float
+    doc: Frame rate (frames/second) of the visual_stimulus from the monitor
+  - name: rig_name
+    dtype: text
+    doc: Name of behavior or optical physiology experiment rig
+  - name: ophys_experiment_id
+    dtype: int
+    doc: Id for this ophys session
+  - name: experiment_container_id
+    dtype: int
+    doc: Container ID for the container that contains this ophys session
+  - name: imaging_depth
+    dtype: int
+    doc: Depth (microns) below the cortical surface targeted for two-photon acquisition
+  - name: session_type
+    dtype: text
+    doc: Experimental session description
   - name: field_of_view_width
     dtype: int
     doc: Width of optical physiology imaging plane in pixels
+  - name: behavior_session_uuid
+    dtype: text
+    doc: MTrain record for session, also called foraging_id

--- a/allensdk/test/brain_observatory/behavior/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/conftest.py
@@ -116,6 +116,23 @@ def stimulus_presentations_behavior(stimulus_templates, stimulus_presentations):
 
 
 @pytest.fixture
+def behavior_only_metadata():
+    """Fixture that provides mock behavior only session metadata"""
+    return {"session_type": 'Unknown',
+            "experiment_datetime": pytz.utc.localize(datetime.datetime.now()),
+            "reporter_line": ["Ai93(TITL-GCaMP6f)"],
+            "driver_line": ["Camk2a-tTA", "Slc17a7-IRES2-Cre"],
+            "LabTracks_ID": 416369,
+            "full_genotype": "Slc17a7-IRES2-Cre/wt;Camk2a-tTA/wt;Ai93(TITL-GCaMP6f)/wt",
+            "behavior_session_uuid": uuid.uuid4(),
+            "stimulus_frame_rate": 60.0,
+            "rig_name": 'my_device',
+            "sex": 'M',
+            "age": 'P139'
+            }
+
+
+@pytest.fixture
 def metadata():
     """Fixture that passes all possible behavior ophys session metadata"""
     return {"ophys_experiment_id": 1234,

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -27,20 +27,27 @@ def test_add_running_speed_to_nwbfile(nwbfile, running_speed,
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])
-def test_add_running_data_df_to_nwbfile(nwbfile, running_data_df,
-                                        roundtrip, roundtripper):
+def test_add_running_data_dfs_to_nwbfile(nwbfile, running_data_df,
+                                         roundtrip, roundtripper):
+    running_data_df_unfiltered = running_data_df.copy()
+    running_data_df_unfiltered['speed'] = running_data_df['speed'] * 2
 
     unit_dict = {'v_sig': 'V', 'v_in': 'V',
                  'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
-    nwbfile = nwb.add_running_data_df_to_nwbfile(nwbfile, running_data_df,
-                                                 unit_dict)
+    nwbfile = nwb.add_running_data_dfs_to_nwbfile(nwbfile,
+                                                  running_data_df,
+                                                  running_data_df_unfiltered,
+                                                  unit_dict)
 
     if roundtrip:
         obt = roundtripper(nwbfile, BehaviorNwbApi)
     else:
         obt = BehaviorNwbApi.from_nwbfile(nwbfile)
 
-    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df())
+    pd.testing.assert_frame_equal(
+        running_data_df, obt.get_running_data_df(lowpass=True))
+    pd.testing.assert_frame_equal(
+        running_data_df_unfiltered, obt.get_running_data_df(lowpass=False))
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -1,0 +1,190 @@
+import math
+
+import numpy as np
+import pandas as pd
+import pynwb
+import pytest
+
+import allensdk.brain_observatory.nwb as nwb
+from allensdk.brain_observatory.behavior.session_apis.data_io import (
+    BehaviorNwbApi)
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_running_speed_to_nwbfile(nwbfile, running_speed,
+                                      roundtrip, roundtripper):
+
+    nwbfile = nwb.add_running_speed_to_nwbfile(nwbfile, running_speed)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    running_speed_obt = obt.get_running_speed()
+    assert np.allclose(running_speed.timestamps, running_speed_obt.timestamps)
+    assert np.allclose(running_speed.values, running_speed_obt.values)
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_running_data_df_to_nwbfile(nwbfile, running_data_df,
+                                        roundtrip, roundtripper):
+
+    unit_dict = {'v_sig': 'V', 'v_in': 'V',
+                 'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
+    nwbfile = nwb.add_running_data_df_to_nwbfile(nwbfile, running_data_df,
+                                                 unit_dict)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df())
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_stimulus_templates(nwbfile, stimulus_templates,
+                                roundtrip, roundtripper):
+    for key, val in stimulus_templates.items():
+        nwb.add_stimulus_template(nwbfile, val, key)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    stimulus_templates_obt = obt.get_stimulus_templates()
+    template_union = (
+        set(stimulus_templates.keys()) | set(stimulus_templates_obt.keys()))
+    for key in template_union:
+        np.testing.assert_array_almost_equal(stimulus_templates[key],
+                                             stimulus_templates_obt[key])
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_stimulus_presentations(nwbfile, stimulus_presentations_behavior,
+                                    stimulus_timestamps, roundtrip,
+                                    roundtripper, stimulus_templates):
+    nwb.add_stimulus_timestamps(nwbfile, stimulus_timestamps)
+    nwb.add_stimulus_presentations(nwbfile, stimulus_presentations_behavior)
+    for key, val in stimulus_templates.items():
+        nwb.add_stimulus_template(nwbfile, val, key)
+
+        # Add index for this template to NWB in-memory object:
+        nwb_template = nwbfile.stimulus_template[key]
+        curr_stimulus_index = stimulus_presentations_behavior[
+            stimulus_presentations_behavior['image_set'] == nwb_template.name]
+        nwb.add_stimulus_index(nwbfile, curr_stimulus_index, nwb_template)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    pd.testing.assert_frame_equal(stimulus_presentations_behavior,
+                                  obt.get_stimulus_presentations(),
+                                  check_dtype=False)
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_stimulus_timestamps(nwbfile, stimulus_timestamps,
+                                 roundtrip, roundtripper):
+
+    nwb.add_stimulus_timestamps(nwbfile, stimulus_timestamps)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    np.testing.assert_array_almost_equal(stimulus_timestamps,
+                                         obt.get_stimulus_timestamps())
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_trials(nwbfile, roundtrip, roundtripper, trials):
+
+    nwb.add_trials(nwbfile, trials, {})
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    pd.testing.assert_frame_equal(trials, obt.get_trials(), check_dtype=False)
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_licks(nwbfile, roundtrip, roundtripper, licks):
+
+    nwb.add_licks(nwbfile, licks)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    pd.testing.assert_frame_equal(licks, obt.get_licks(), check_dtype=False)
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_rewards(nwbfile, roundtrip, roundtripper, rewards):
+
+    nwb.add_rewards(nwbfile, rewards)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    pd.testing.assert_frame_equal(rewards, obt.get_rewards(),
+                                  check_dtype=False)
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_behavior_only_metadata(roundtrip, roundtripper,
+                                    behavior_only_metadata):
+
+    metadata = behavior_only_metadata
+    nwbfile = pynwb.NWBFile(
+        session_description='asession',
+        identifier='afile',
+        session_start_time=metadata['experiment_datetime']
+    )
+    nwb.add_metadata(nwbfile, metadata, behavior_only=True)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    metadata_obt = obt.get_metadata()
+
+    assert len(metadata_obt) == len(metadata)
+    for key, val in metadata.items():
+        assert val == metadata_obt[key]
+
+
+@pytest.mark.parametrize('roundtrip', [True, False])
+def test_add_task_parameters(nwbfile, roundtrip,
+                             roundtripper, task_parameters):
+
+    nwb.add_task_parameters(nwbfile, task_parameters)
+
+    if roundtrip:
+        obt = roundtripper(nwbfile, BehaviorNwbApi)
+    else:
+        obt = BehaviorNwbApi.from_nwbfile(nwbfile)
+
+    task_parameters_obt = obt.get_task_parameters()
+
+    assert len(task_parameters_obt) == len(task_parameters)
+    for key, val in task_parameters.items():
+        if key == 'omitted_flash_fraction':
+            if math.isnan(val):
+                assert math.isnan(task_parameters_obt[key])
+            if math.isnan(task_parameters_obt[key]):
+                assert math.isnan(val)
+        else:
+            assert val == task_parameters_obt[key]

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -167,7 +167,7 @@ def test_add_partial_metadata(test_partial_metadata, roundtrip, roundtripper,
         identifier='afile',
         session_start_time=meta['experiment_datetime']
     )
-    nwb.add_metadata(nwbfile, meta)
+    nwb.add_metadata(nwbfile, meta, behavior_only=False)
     if not test_partial_metadata:
         nwb.add_cell_specimen_table(nwbfile, cell_specimen_table, meta)
 
@@ -218,7 +218,7 @@ def test_add_task_parameters(nwbfile, roundtrip, roundtripper, task_parameters):
 @pytest.mark.parametrize("filter_invalid_rois", [True, False])
 def test_get_cell_specimen_table(nwbfile, roundtrip, filter_invalid_rois, valid_roi_ids, roundtripper, cell_specimen_table, metadata, ophys_timestamps):
 
-    nwb.add_metadata(nwbfile, metadata)
+    nwb.add_metadata(nwbfile, metadata, behavior_only=False)
     nwb.add_cell_specimen_table(nwbfile, cell_specimen_table, metadata)
 
     if roundtrip:
@@ -236,7 +236,7 @@ def test_get_cell_specimen_table(nwbfile, roundtrip, filter_invalid_rois, valid_
 @pytest.mark.parametrize("filter_invalid_rois", [True, False])
 def test_get_dff_traces(nwbfile, roundtrip, filter_invalid_rois, valid_roi_ids, roundtripper, dff_traces, cell_specimen_table, metadata, ophys_timestamps):
 
-    nwb.add_metadata(nwbfile, metadata)
+    nwb.add_metadata(nwbfile, metadata, behavior_only=False)
     nwb.add_cell_specimen_table(nwbfile, cell_specimen_table, metadata)
     nwb.add_dff_traces(nwbfile, dff_traces, ophys_timestamps)
 
@@ -255,7 +255,7 @@ def test_get_dff_traces(nwbfile, roundtrip, filter_invalid_rois, valid_roi_ids, 
 @pytest.mark.parametrize("filter_invalid_rois", [True, False])
 def test_get_corrected_fluorescence_traces(nwbfile, roundtrip, filter_invalid_rois, valid_roi_ids, roundtripper, dff_traces, corrected_fluorescence_traces, cell_specimen_table, metadata, ophys_timestamps):
 
-    nwb.add_metadata(nwbfile, metadata)
+    nwb.add_metadata(nwbfile, metadata, behavior_only=False)
     nwb.add_cell_specimen_table(nwbfile, cell_specimen_table, metadata)
     nwb.add_dff_traces(nwbfile, dff_traces, ophys_timestamps)
     nwb.add_corrected_fluorescence_traces(nwbfile, corrected_fluorescence_traces)
@@ -274,7 +274,7 @@ def test_get_corrected_fluorescence_traces(nwbfile, roundtrip, filter_invalid_ro
 @pytest.mark.parametrize('roundtrip', [True, False])
 def test_get_motion_correction(nwbfile, roundtrip, roundtripper, motion_correction, ophys_timestamps, metadata, cell_specimen_table, dff_traces):
 
-    nwb.add_metadata(nwbfile, metadata)
+    nwb.add_metadata(nwbfile, metadata, behavior_only=False)
     nwb.add_cell_specimen_table(nwbfile, cell_specimen_table, metadata)
     nwb.add_dff_traces(nwbfile, dff_traces, ophys_timestamps)
     nwb.add_motion_correction(nwbfile, motion_correction)

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -12,22 +12,27 @@ from allensdk.brain_observatory.behavior.session_apis.data_io import (
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])
-def test_add_running_data_df_to_nwbfile(nwbfile, running_data_df, roundtrip, roundtripper):
+def test_add_running_data_dfs_to_nwbfile(nwbfile, running_data_df, roundtrip, roundtripper):
     # Just make it different from running_data_df
     running_data_df_unfiltered = running_data_df.copy()
     running_data_df_unfiltered['speed'] = running_data_df['speed'] * 2
 
     unit_dict = {'v_sig': 'V', 'v_in': 'V', 'speed': 'cm/s', 'timestamps': 's', 'dx': 'cm'}
-    nwbfile = nwb.add_running_data_dfs_to_nwbfile(nwbfile, running_data_df=running_data_df,
-                                                  running_data_df_unfiltered=running_data_df_unfiltered, unit_dict=unit_dict)
+    nwbfile = nwb.add_running_data_dfs_to_nwbfile(
+        nwbfile,
+        running_data_df=running_data_df,
+        running_data_df_unfiltered=running_data_df_unfiltered,
+        unit_dict=unit_dict)
 
     if roundtrip:
         obt = roundtripper(nwbfile, BehaviorOphysNwbApi)
     else:
         obt = BehaviorOphysNwbApi.from_nwbfile(nwbfile)
 
-    pd.testing.assert_frame_equal(running_data_df, obt.get_running_data_df(lowpass=True))
-    pd.testing.assert_frame_equal(running_data_df_unfiltered, obt.get_running_data_df(lowpass=False))
+    pd.testing.assert_frame_equal(
+        running_data_df, obt.get_running_data_df(lowpass=True))
+    pd.testing.assert_frame_equal(
+        running_data_df_unfiltered, obt.get_running_data_df(lowpass=False))
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])
@@ -229,6 +234,9 @@ def test_get_cell_specimen_table(nwbfile, roundtrip, filter_invalid_rois, valid_
     if filter_invalid_rois:
         cell_specimen_table = cell_specimen_table[cell_specimen_table["cell_roi_id"].isin(valid_roi_ids)]
 
+    print(cell_specimen_table)
+    print(obt.get_cell_specimen_table())
+
     pd.testing.assert_frame_equal(cell_specimen_table, obt.get_cell_specimen_table(), check_dtype=False)
 
 
@@ -248,6 +256,10 @@ def test_get_dff_traces(nwbfile, roundtrip, filter_invalid_rois, valid_roi_ids, 
     if filter_invalid_rois:
         dff_traces = dff_traces[dff_traces["cell_roi_id"].isin(valid_roi_ids)]
 
+    print(dff_traces)
+
+    print(obt.get_dff_traces())
+
     pd.testing.assert_frame_equal(dff_traces, obt.get_dff_traces(), check_dtype=False)
 
 
@@ -261,14 +273,22 @@ def test_get_corrected_fluorescence_traces(nwbfile, roundtrip, filter_invalid_ro
     nwb.add_corrected_fluorescence_traces(nwbfile, corrected_fluorescence_traces)
 
     if roundtrip:
-        obt = roundtripper(nwbfile, BehaviorOphysNwbApi, filter_invalid_rois=filter_invalid_rois)
+        obt = roundtripper(nwbfile, BehaviorOphysNwbApi,
+                          filter_invalid_rois=filter_invalid_rois)
     else:
-        obt = BehaviorOphysNwbApi.from_nwbfile(nwbfile, filter_invalid_rois=filter_invalid_rois)
+        obt = BehaviorOphysNwbApi.from_nwbfile(
+            nwbfile, filter_invalid_rois=filter_invalid_rois)
 
     if filter_invalid_rois:
-        corrected_fluorescence_traces = corrected_fluorescence_traces[corrected_fluorescence_traces["cell_roi_id"].isin(valid_roi_ids)]
+        corrected_fluorescence_traces = corrected_fluorescence_traces[
+            corrected_fluorescence_traces["cell_roi_id"].isin(valid_roi_ids)]
 
-    pd.testing.assert_frame_equal(corrected_fluorescence_traces, obt.get_corrected_fluorescence_traces(), check_dtype=False)
+    print(corrected_fluorescence_traces)
+    print(obt.get_corrected_fluorescence_traces())
+
+    pd.testing.assert_frame_equal(
+        corrected_fluorescence_traces,
+        obt.get_corrected_fluorescence_traces(), check_dtype=False)
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -90,6 +90,10 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
+What's New - 2.6.0 (TBD)
+-----------------------------------------------------------------------
+- Adds ability to write and read behavior only experiments
+
 
 What's New - 2.5.0 (January 29, 2021)
 -----------------------------------------------------------------------


### PR DESCRIPTION
# Overview:

This PR aims to address #1356 

# Detailed Overview:

This PR is intended to allow creation and reading of 'behavior' data in NWB format for visual behavior training or experiment sessions.

Some examples of 'Behavior' specific data:
- stimulus presentation data
- stimulus template data
- lick data
- rewards data
- running speed data
- trials data
- task parameters
- other metadata

Previously, only behavior + ophys experiments data were saved into NWB. These used apis that did not distinguish between behavior and the ophys components (`BehaviorOphysNwbApi`, `BehaviorOphysLimsApi`, `BehaviorOphysJsonApi`) of an experiment. Additionally, these apis did not distinguish between data sources (from LIMs queries or JSON fields) and data processing methods (e.g. filtering raw running speed data from LIMS/Json into a form end-users can work with). This resulted in each API class having its own flavor of the same data processing method and/or very convoluted inheritence.

A recent large refactor effort re-organized these APIs such that:
1. Data collection (`BehaviorOphysNwbApi`, `BehaviorOphysLimsApi`, `BehaviorOphysJsonApi`) could be separated from data processing (`BehaviorDataXforms`) and relevant data collection APIs could share the same data processing
2.  Behavior specific data/metadata (`BehaviorLimsApi`) and behavior specific data processing (`BehaviorDataXforms`) could be separated from experiments with behavior + ophys data/metadata.

This PR started from the above situation and required:
- Creation of new behavior specific APIs (`BehaviorJsonApi`, `BehaviorNwbApi`) necessary for creation and loading of NWB
- Updates to API inheritance so that behavior + ophys classes would inherit from behavior only classes
- Creation of a new write_nwb python module that LIMS could call to create behavior only NWB files

Along the way, it was discovered that classes like `BehaviorOphysDataXforms` and `BehaviorOphysNwbApi` had not properly inherited from their behavior only counterparts (`BehaviorDataXforms` and `BehaviorNwbApi`) which needed to be addressed as well.

# Validation:
Example NWB file produced can be found at:
`/allen/scratch/aibstemp/nicholasm/test_behavior_nwb/programs/braintv/production/visualbehavior/prod5/specimen_1042470352/behavior_session_1064164185/behavior_session_1064164185.nwb`
