### PR TITLE
Decrosstalk/dev/demixing/interface

### DIFF
--- a/allensdk/internal/pipeline_modules/run_demixing.py
+++ b/allensdk/internal/pipeline_modules/run_demixing.py
@@ -16,7 +16,12 @@ from allensdk.config.manifest import Manifest
 import allensdk.core.json_utilities as ju
 import logging
 
-EXCLUDE_LABELS = ["union", "duplicate", "motion_border" ]
+EXCLUDE_LABELS = ["union", "duplicate", "motion_border",
+                  "decrosstalk_ghost",
+                  "decrosstalk_invalid_raw",
+                  "decrosstalk_invalid_raw_active",
+                  "decrosstalk_invalid_unmixed",
+                  "decrosstalk_invalid_unmixed_active" ]
 
 def debug(experiment_id, local=False):
     OUTPUT_DIRECTORY = "/data/informatics/CAM/demix"

--- a/allensdk/internal/pipeline_modules/run_demixing.py
+++ b/allensdk/internal/pipeline_modules/run_demixing.py
@@ -104,8 +104,8 @@ def parse_input(data, exclude_labels):
         movie_shape = f["data"].shape[1:]
 
     with h5py.File(traces_h5, "r") as f:
-        traces = f["data"].value
-        trace_ids = [ int(rid) for rid in f["roi_names"].value ]
+        traces = f["data"][()]
+        trace_ids = [ int(rid) for rid in f["roi_names"][()] ]
 
     rois = get_path(data, "roi_masks", False)
     masks = None
@@ -150,7 +150,7 @@ def main():
 
     logging.debug("reading movie")
     with h5py.File(movie_h5, 'r') as f:
-        movie = f['data'].value
+        movie = f['data'][()]
 
     # only demix non-union, non-duplicate ROIs
     valid_idxs = np.where(valid)

--- a/allensdk/internal/pipeline_modules/run_demixing.py
+++ b/allensdk/internal/pipeline_modules/run_demixing.py
@@ -34,13 +34,13 @@ where cr.ophys_experiment_id = %d
 """ % experiment_id)
 
     nrois = { roi['id']: dict(width=roi['width'],
-                              height=roi['height'], 
+                              height=roi['height'],
                               x=roi['x'],
                               y=roi['y'],
                               id=roi['id'],
                               valid=roi['valid_roi'],
                               mask=roi['mask_matrix'],
-                              exclusion_labels=[]) 
+                              exclusion_labels=[])
               for roi in rois }
 
     for exc_label in exc_labels:
@@ -48,12 +48,12 @@ where cr.ophys_experiment_id = %d
 
     movie_path_response = lu.query('''
         select wkf.filename, wkf.storage_directory from well_known_files wkf
-        join well_known_file_types wkft on wkft.id = wkf.well_known_file_type_id 
+        join well_known_file_types wkft on wkft.id = wkf.well_known_file_type_id
         where wkf.attachable_id = {} and wkf.attachable_type = 'OphysExperiment'
         and wkft.name = 'MotionCorrectedImageStack'
     '''.format(experiment_id))
     movie_h5_path = os.path.join(movie_path_response[0]['storage_directory'], movie_path_response[0]['filename'])
-        
+
     exp_dir = os.path.join(OUTPUT_DIRECTORY, str(experiment_id))
 
     input_data = {
@@ -62,9 +62,9 @@ where cr.ophys_experiment_id = %d
         "roi_masks": nrois.values(),
         "output_file": os.path.join(exp_dir, "demixed_traces.h5")
         }
- 
-    run_module(SCRIPT, 
-               input_data, 
+
+    run_module(SCRIPT,
+               input_data,
                exp_dir,
                sdk_path=SDK_PATH,
                pbs=dict(vmem=160,
@@ -135,7 +135,7 @@ def main():
     logging.debug("reading input")
 
     traces, masks, valid, trace_ids, movie_h5, output_h5 = parse_input(data, mod.args.exclude_labels)
-    
+
     logging.debug("excluded masks: %s", str(zip(np.where(~valid)[0], trace_ids[~valid])))
     output_dir = os.path.dirname(output_h5)
     plot_dir = os.path.join(output_dir, "demix_plots")
@@ -154,9 +154,9 @@ def main():
 
     logging.debug("demixing")
     demixed_traces, drop_frames = demixer.demix_time_dep_masks(demix_traces, movie, demix_masks)
-    
-    nt_inds = demixer.plot_negative_transients(demix_traces, 
-                                               demixed_traces, 
+
+    nt_inds = demixer.plot_negative_transients(demix_traces,
+                                               demixed_traces,
                                                valid[valid_idxs],
                                                demix_masks,
                                                trace_ids[valid_idxs],
@@ -164,17 +164,17 @@ def main():
 
     logging.debug("rois with negative transients: %s", str(trace_ids[valid_idxs][nt_inds]))
 
-    nb_inds = demixer.plot_negative_baselines(demix_traces, 
-                                              demixed_traces, 
+    nb_inds = demixer.plot_negative_baselines(demix_traces,
+                                              demixed_traces,
                                               demix_masks,
                                               trace_ids[valid_idxs],
                                               plot_dir)
 
-    # negative baseline rois (and those that overlap with them) become nans 
+    # negative baseline rois (and those that overlap with them) become nans
     logging.debug("rois with negative baselines (or overlap with them): %s", str(trace_ids[valid_idxs][nb_inds]))
     demixed_traces[nb_inds, :] = np.nan
 
-    logging.info("Saving output")    
+    logging.info("Saving output")
     out_traces = np.zeros(traces.shape, dtype=demix_traces.dtype)
     out_traces[:] = np.nan
     out_traces[valid_idxs] = demixed_traces


### PR DESCRIPTION
The decrosstalking module that we are introducing into the OPhys pipeline only writes out traces for ROIs that can successfully be decrosstalked (running decrosstalking on invalid ROIs is not well-defined).

This caused run_demixing.py to break because run_demixing expected an HDF5 file with one trace per ROI and a separate set of flags to determine if the ROI was valid.

Rather than add rows to the output of decrosstalking containing nonsense values for the invalid ROIs (I was afraid of accidentally breaking something downstream), I added a block of code to run_demixing.py that gracefully ignores any ROIs that are not in the input trace file. This should work as before with data produced by the old pipeline (without decrosstalking), since the new code will detect a trace for every ROI.

I have already run this module on some example data that was failing for Wayne. The module ran. I will wait for Wayne to confirm that there aren't new failure before actually merging, but wanted to solicit feedback on this solution to the problem.

<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
