### PR TITLE
Bug1828/dev/dff/roi/association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.6.0]
+-  OPhys Behavior data retrieval methods no longer depend on ROIs being ordered identically in different files.
+
 ## [2.5.0] = 2021-01-29
 -  Adds unfiltered running speed as new data stream
 -  run_demixing gracefully ignores any ROIs that are not in the input trace file

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -209,11 +209,11 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         dff_path = self.get_dff_file()
         with h5py.File(dff_path, 'r') as raw_file:
             raw_dff_traces = np.asarray(raw_file['data'])
-            roi_names = np.asarray(raw_file['roi_names']).astype(int)
+            roi_names = np.asarray(raw_file['roi_names'])
 
         # guarantee that DFF traces are ordered the same
         # way as ROIs in the cell_specimen_table
-        cell_roi_id_list = self.get_cell_roi_ids().astype(int)
+        cell_roi_id_list = self.get_cell_roi_ids()
 
         if not np.in1d(roi_names, cell_roi_id_list).all():
             raise RuntimeError("DFF traces contains ROI IDs that "

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -347,18 +347,27 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
     def get_corrected_fluorescence_traces(self):
         demix_file = self.get_demix_file()
 
-        g = h5py.File(demix_file)
-        corrected_fluorescence_traces = np.asarray(g['data'])
-        g.close()
+        with h5py.File(demix_file, 'r') as in_file:
+            corrected_fluorescence_traces = in_file['data'][()]
+            corrected_fluorescence_roi_id = in_file['roi_names'][()]
 
         cell_roi_id_list = self.get_cell_roi_ids()
+
+        if not np.in1d(corrected_fluorescence_roi_id, cell_roi_id_list).all():
+            raise RuntimeError("corrected_fluorescence_traces contains ROI IDs "
+                               "not present in cell_specimen_table")
+        if not np.in1d(cell_roi_id_list, corrected_fluorescence_roi_id).all():
+            raise RuntimeError("cell_specimen_table contains ROI IDs "
+                               "not present in corrected_fluorescence_traces")
+
         ophys_timestamps = self.get_ophys_timestamps()
 
         num_trace_timepoints = corrected_fluorescence_traces.shape[1]
         assert num_trace_timepoints == ophys_timestamps.shape[0]
         df = pd.DataFrame(
             {'corrected_fluorescence': list(corrected_fluorescence_traces)},
-            index=pd.Index(cell_roi_id_list, name='cell_roi_id'))
+            index=pd.Index(corrected_fluorescence_roi_id.astype(int),
+                           name='cell_roi_id'))
 
         cell_specimen_table = self.get_cell_specimen_table()
         df = cell_specimen_table[['cell_roi_id']].join(df, on='cell_roi_id')

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -209,11 +209,11 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         dff_path = self.get_dff_file()
         with h5py.File(dff_path, 'r') as raw_file:
             raw_dff_traces = np.asarray(raw_file['data'])
-            roi_names = np.asarray(raw_file['roi_names'])
+            roi_names = np.asarray(raw_file['roi_names']).astype(bytes)
 
         # guarantee that DFF traces are ordered the same
         # way as ROIs in the cell_specimen_table
-        cell_roi_id_list = self.get_cell_roi_ids()
+        cell_roi_id_list = self.get_cell_roi_ids().astype(bytes)
 
         if not np.in1d(roi_names, cell_roi_id_list).all():
             raise RuntimeError("DFF traces contains ROI IDs that "

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -373,7 +373,7 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         assert num_trace_timepoints == ophys_timestamps.shape[0]
         df = pd.DataFrame(
             {'corrected_fluorescence': list(corrected_fluorescence_traces)},
-            index=pd.Index(corrected_fluorescence_roi_id.astype(int),
+            index=pd.Index(corrected_fluorescence_roi_id,
                            name='cell_roi_id'))
 
         cell_specimen_table = self.get_cell_specimen_table()

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -223,9 +223,9 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
                                "that are not in DFF traces file")
 
         dff_traces = np.zeros(raw_dff_traces.shape, dtype=float)
-        for ii in range(dff_traces.shape[0]):
-            idx = np.where(cell_roi_id_list==roi_names[ii])[0][0]
-            dff_traces[idx,:] = raw_dff_traces[ii, :]
+        for raw_trace, roi_id in zip(raw_dff_traces, roi_names):
+            idx = np.where(cell_roi_id_list==roi_id)[0][0]
+            dff_traces[idx,:] = raw_trace
 
         return dff_traces
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
@@ -167,7 +167,7 @@ def test_dff_trace_order(monkeypatch, tmpdir):
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_cell_roi_ids',
-                       lambda x: np.array([1,2,3,4,5]))
+                       lambda x: np.array([1,2,3,4,5]).astype(bytes))
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                         'get_dff_file',
@@ -212,7 +212,7 @@ def test_dff_trace_exceptions(monkeypatch, tmpdir):
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_cell_roi_ids',
-                       lambda x: np.array([1,3,4,5]))
+                       lambda x: np.array([1,3,4,5]).astype(bytes))
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                         'get_dff_file',
@@ -243,7 +243,7 @@ def test_dff_trace_exceptions(monkeypatch, tmpdir):
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_cell_roi_ids',
-                       lambda x: np.array([1,2,3,4,5,6]))
+                       lambda x: np.array([1,2,3,4,5,6]).astype(bytes))
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                         'get_dff_file',

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
@@ -143,6 +143,10 @@ def test_get_ophys_timestamps(monkeypatch, plane_group, ophys_timestamps,
 
 
 def test_dff_trace_order(monkeypatch, tmpdir):
+    """
+    Test that BehaviorOphysLimsApi.get_raw_dff_data can reorder
+    ROIs to align with what is in the cell_specimen_table
+    """
 
     out_fname = os.path.join(tmpdir, 'dummy_dff_data.h5')
     rng = np.random.RandomState(1234)
@@ -174,6 +178,10 @@ def test_dff_trace_order(monkeypatch, tmpdir):
 
 
 def test_dff_trace_exceptions(monkeypatch, tmpdir):
+    """
+    Test that BehaviorOphysLimsApi.get_raw_dff_data() raises exceptions when
+    dff trace file and cell_specimen_table contain different ROI IDs
+    """
 
     # check that an exception is raised if dff_traces has an ROI ID
     # that cell_specimen_table does not

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_lims_api.py
@@ -157,6 +157,14 @@ def test_dff_trace_order(monkeypatch, tmpdir):
         out_file.create_dataset('data', data=data)
         out_file.create_dataset('roi_names', data=roi_names.astype(bytes))
 
+    def dummy_init(self, ophys_experiment_id, **kwargs):
+        self.ophys_experiment_id = 1
+        self.get_behavior_session_id = 2
+
+    monkeypatch.setattr(BehaviorOphysLimsApi,
+                        '__init__',
+                        dummy_init)
+
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_cell_roi_ids',
                        lambda x: np.array([1,2,3,4,5]))
@@ -194,6 +202,14 @@ def test_dff_trace_exceptions(monkeypatch, tmpdir):
         out_file.create_dataset('data', data=data)
         out_file.create_dataset('roi_names', data=roi_names.astype(bytes))
 
+    def dummy_init(self, ophys_experiment_id, **kwargs):
+        self.ophys_experiment_id = 1
+        self.get_behavior_session_id = 2
+
+    monkeypatch.setattr(BehaviorOphysLimsApi,
+                        '__init__',
+                        dummy_init)
+
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_cell_roi_ids',
                        lambda x: np.array([1,3,4,5]))
@@ -216,6 +232,14 @@ def test_dff_trace_exceptions(monkeypatch, tmpdir):
     with h5py.File(out_fname, 'w') as out_file:
         out_file.create_dataset('data', data=data)
         out_file.create_dataset('roi_names', data=roi_names.astype(bytes))
+
+    def dummy_init(self, ophys_experiment_id, **kwargs):
+        self.ophys_experiment_id = 1
+        self.get_behavior_session_id = 2
+
+    monkeypatch.setattr(BehaviorOphysLimsApi,
+                        '__init__',
+                        dummy_init)
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_cell_roi_ids',
@@ -251,6 +275,14 @@ def test_corrected_fluorescence_trace_order(monkeypatch, tmpdir):
     cell_table = pd.DataFrame(data=cell_data,
                               index=pd.Index([10,20,30,40,50],
                                              name='cell_specimen_id'))
+
+    def dummy_init(self, ophys_experiment_id, **kwargs):
+        self.ophys_experiment_id = 1
+        self.get_behavior_session_id = 2
+
+    monkeypatch.setattr(BehaviorOphysLimsApi,
+                        '__init__',
+                        dummy_init)
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_ophys_timestamps',
@@ -305,6 +337,14 @@ def test_corrected_fluorescence_trace_exceptions(monkeypatch, tmpdir):
                               index=pd.Index([10,20,30,40,50],
                                              name='cell_specimen_id'))
 
+    def dummy_init(self, ophys_experiment_id, **kwargs):
+        self.ophys_experiment_id = 1
+        self.get_behavior_session_id = 2
+
+    monkeypatch.setattr(BehaviorOphysLimsApi,
+                        '__init__',
+                        dummy_init)
+
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_ophys_timestamps',
                         lambda x: np.zeros(n_t))
@@ -347,6 +387,14 @@ def test_corrected_fluorescence_trace_exceptions2(monkeypatch, tmpdir):
     cell_table = pd.DataFrame(data=cell_data,
                               index=pd.Index([10,20,30,40,50,60],
                                              name='cell_specimen_id'))
+
+    def dummy_init(self, ophys_experiment_id, **kwargs):
+        self.ophys_experiment_id = 1
+        self.get_behavior_session_id = 2
+
+    monkeypatch.setattr(BehaviorOphysLimsApi,
+                        '__init__',
+                        dummy_init)
 
     monkeypatch.setattr(BehaviorOphysLimsApi,
                        'get_ophys_timestamps',

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -90,6 +90,10 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
+What's New - 2.6.0
+-----------------------------------------------------------------------
+-  OPhys Behavior data retrieval methods no longer depend on ROIs being ordered identically in different files.
+
 
 What's New - 2.5.0 (January 29, 2021)
 -----------------------------------------------------------------------


### PR DESCRIPTION
This addresses Issue # 1828 by adding code to `get_raw_dff_data` that intentionally reorders the dff traces read from the h5 file into the order of the roi_ids in the cell_specimen_table.

There was also a change to the method to get corrected fluorescence traces to make sure those get returned in the correct order.

<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
