### PR TITLE
Renames "image_mask" to "roi_mask"

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -516,11 +516,11 @@ class BehaviorOphysSession(ParamsMixin):
         table.set_index("cell_roi_id", inplace=True)
         table = table.loc[cell_roi_ids, :]
 
-        full_image_shape = table.iloc[0]["image_mask"].shape
+        full_image_shape = table.iloc[0]["roi_mask"].shape
 
         output = np.zeros((len(cell_roi_ids), full_image_shape[0], full_image_shape[1]), dtype=np.uint8)
         for ii, (_, row) in enumerate(table.iterrows()):
-            output[ii, :, :] = _translate_roi_mask(row["image_mask"], int(row["y"]), int(row["x"]))
+            output[ii, :, :] = _translate_roi_mask(row["roi_mask"], int(row["y"]), int(row["x"]))
 
         # Pixel spacing and units of mask image will match either the
         # max or avg projection image of 2P movie.

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -266,7 +266,7 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
 
         # Because pynwb stores this field as "image_mask", it is renamed here
         df = df.rename(columns={'image_mask': 'roi_mask'})
-        
+
         df.index.rename('cell_roi_id', inplace=True)
         df['cell_specimen_id'] = [None if csid == -1 else csid for csid in df['cell_specimen_id'].values]
 

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -263,6 +263,10 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
     def get_cell_specimen_table(self) -> pd.DataFrame:
         # NOTE: ROI masks are stored in full frame width and height arrays
         df = self.nwbfile.processing['ophys'].data_interfaces['image_segmentation'].plane_segmentations['cell_specimen_table'].to_dataframe()
+
+        # Because pynwb stores this field as "image_mask", it is renamed here
+        df = df.rename(columns={'image_mask': 'roi_mask'})
+        
         df.index.rename('cell_roi_id', inplace=True)
         df['cell_specimen_id'] = [None if csid == -1 else csid for csid in df['cell_specimen_id'].values]
 

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/ophys_lims_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/ophys_lims_api.py
@@ -458,7 +458,7 @@ class OphysLimsApi(CachedInstanceMethodMixin):
                 """.format(ophys_cell_seg_run_id)
         initial_cs_table = pd.read_sql(query, self.lims_db.get_connection())
         cell_specimen_table = initial_cs_table.rename(
-            columns={'id': 'cell_roi_id', 'mask_matrix': 'image_mask'})
+            columns={'id': 'cell_roi_id', 'mask_matrix': 'roi_mask'})
         cell_specimen_table.drop(['ophys_experiment_id',
                                   'ophys_cell_segmentation_run_id'],
                                  inplace=True, axis=1)

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -58,7 +58,7 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
             curr_roi.mask = np.array(table_row['image_mask'])
             image_mask_list.append(curr_roi.get_mask_plane().astype(np.bool))
 
-        cell_specimen_table['image_mask'] = image_mask_list
+        cell_specimen_table['roi_mask'] = image_mask_list
         cell_specimen_table = cell_specimen_table[sorted(cell_specimen_table.columns)]
 
         cell_specimen_table.index.rename('cell_roi_id', inplace=True)

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_xforms.py
@@ -46,7 +46,7 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
         fov_height = self.get_field_of_view_shape()['height']
 
         # Convert cropped ROI masks to uncropped versions
-        image_mask_list = []
+        roi_mask_list = []
         for cell_roi_id, table_row in cell_specimen_table.iterrows():
             # Deserialize roi data into AllenSDK RoiMask object
             curr_roi = roi.RoiMask(image_w=fov_width, image_h=fov_height,
@@ -55,10 +55,10 @@ class BehaviorOphysDataXforms(BehaviorOphysBase):
             curr_roi.y = table_row['y']
             curr_roi.width = table_row['width']
             curr_roi.height = table_row['height']
-            curr_roi.mask = np.array(table_row['image_mask'])
-            image_mask_list.append(curr_roi.get_mask_plane().astype(np.bool))
+            curr_roi.mask = np.array(table_row['roi_mask'])
+            roi_mask_list.append(curr_roi.get_mask_plane().astype(np.bool))
 
-        cell_specimen_table['roi_mask'] = image_mask_list
+        cell_specimen_table['roi_mask'] = roi_mask_list
         cell_specimen_table = cell_specimen_table[sorted(cell_specimen_table.columns)]
 
         cell_specimen_table.index.rename('cell_roi_id', inplace=True)

--- a/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
@@ -18,7 +18,7 @@ class CellSpecimenTable(RaisingSchema):
     height = Dict(String, Int, required=True)
     width = Dict(String, Int, required=True)
     mask_image_plane = Dict(String, Int, required=True)
-    image_mask = Dict(String, List(List(Boolean)), required=True)
+    roi_mask = Dict(String, List(List(Boolean)), required=True)
 
 
 

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -883,9 +883,9 @@ def add_cell_specimen_table(nwbfile: NWBFile,
         imaging_plane=imaging_plane)
 
     for col_name in cell_roi_table.columns:
-        # the columns 'image_mask', 'pixel_mask', and 'voxel_mask' are already defined
+        # the columns 'roi_mask', 'pixel_mask', and 'voxel_mask' are already defined
         # in the nwb.ophys::PlaneSegmentation Object
-        if col_name not in ['id', 'mask_matrix', 'image_mask', 'pixel_mask', 'voxel_mask']:
+        if col_name not in ['id', 'mask_matrix', 'roi_mask', 'pixel_mask', 'voxel_mask']:
             # This builds the columns with name of column and description of column
             # both equal to the column name in the cell_roi_table
             plane_segmentation.add_column(col_name,
@@ -895,13 +895,13 @@ def add_cell_specimen_table(nwbfile: NWBFile,
     # go through each roi and add it to the plan segmentation object
     for cell_roi_id, table_row in cell_roi_table.iterrows():
 
-        # NOTE: The 'image_mask' in this cell_roi_table has already been
+        # NOTE: The 'roi_mask' in this cell_roi_table has already been
         # processing by the function from 
         # allensdk.brain_observatory.behavior.session_apis.data_io.ophys_lims_api
         # get_cell_specimen_table() method. As a result, the ROI is stored in
         # an array that is the same shape as the FULL field of view of the
         # experiment (e.g. 512 x 512).
-        mask = table_row.pop('image_mask')
+        mask = table_row.pop('roi_mask')
 
         csid = table_row.pop('cell_specimen_id')
         table_row['cell_specimen_id'] = -1 if csid is None else csid

--- a/allensdk/test/brain_observatory/behavior/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/conftest.py
@@ -196,7 +196,7 @@ def cell_specimen_table():
                          'max_correction_right': [1., 1.],
                          'mask_image_plane': [1, 1],
                          'ophys_cell_segmentation_run_id': [1, 1],
-                         'image_mask': [np.array([[True, True],
+                         'roi_mask': [np.array([[True, True],
                                                   [True, False]]),
                                         np.array([[True, True],
                                                   [False, True]])]},

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -197,7 +197,7 @@ def cell_specimen_table_api():
                     "cell_roi_id": [1, 2],
                     "y": [1, 1],
                     "x": [2, 1],
-                    "image_mask": [roi_1, roi_2]
+                    "roi_mask": [roi_1, roi_2]
                 }, index=pd.Index(data=[10, 11], name="cell_specimen_id")
             )
 


### PR DESCRIPTION
Renames field "image_mask" to "roi_mask" in cell specimen table. 
Note: cannot rename in the NWB file because the logic to save this table in NWB lives in the pynwb repo, and not AllenSDK.

[#1822 ](url)