### PR TITLE
Updates lick events to use Events data type

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/abcs/behavior_base.py
+++ b/allensdk/brain_observatory/behavior/session_apis/abcs/behavior_base.py
@@ -27,7 +27,7 @@ class BehaviorBase(abc.ABC):
 
         Returns
         -------
-        np.ndarray
+        pd.Dataframe
             A dataframe containing lick timestamps.
         """
         raise NotImplementedError()

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -183,9 +183,9 @@ class BehaviorOphysNwbApi(NwbApi, BehaviorOphysBase):
         trials.index = trials.index.rename('trials_id')
         return trials
 
-    def get_licks(self) -> np.ndarray:
+    def get_licks(self) -> pd.DataFrame:
         if 'licking' in self.nwbfile.processing:
-            return pd.DataFrame({'time': self.nwbfile.processing['licking'].get_data_interface('licks')['timestamps'].timestamps[:]})
+            return pd.DataFrame({'time': self.nwbfile.processing['licking'].get_data_interface('licks').timestamps[:]})
         else:
             return pd.DataFrame({'time': []})
 

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -16,8 +16,8 @@ from pynwb.behavior import BehavioralEvents
 from pynwb import ProcessingModule, NWBFile
 from pynwb.image import ImageSeries, GrayscaleImage, IndexSeries
 from pynwb.ophys import DfOverF, ImageSegmentation, OpticalChannel, Fluorescence
+from ndx_events import Events
 
-import allensdk.brain_observatory.roi_masks as roi
 from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory import dict_to_indexed_array
@@ -627,19 +627,15 @@ def add_trials(nwbfile, trials, description_dict={}):
 
 def add_licks(nwbfile, licks):
 
-    licks_event_series = TimeSeries(
-        data=licks.time.values,
-        name='timestamps',
+    lick_events = Events(
         timestamps=licks.time.values,
-        unit='s'
+        name='licks',
+        description='Timestamps for lick events'
     )
-
-    # Add lick event timeseries to lick interface:
-    licks_interface = BehavioralEvents([licks_event_series], 'licks')
 
     # Add lick interface to nwb file, by way of a processing module:
     licks_mod = ProcessingModule('licking', 'Licking behavior processing module')
-    licks_mod.add_data_interface(licks_interface)
+    licks_mod.add_data_interface(lick_events)
     nwbfile.add_processing_module(licks_mod)
 
     return nwbfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ seaborn<1.0.0
 aiohttp==3.6.2
 nest_asyncio==1.2.0
 tqdm>=4.27
+ndx-events<=0.2.0


### PR DESCRIPTION
It was suggested by NWB team to phase out any usage of timeseries where there is no data component and we just care about the timestamps. 

This replaces `TimeSeries` with an extension `Events` which is made just for timestamps.

Note: eventually this extension will become a pynwb data type, in which case we should switch to the pynwb data type.