### PR TITLE
modify eye_tracking_processing.py to remove CR from outlier detection

### DIFF
--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -69,12 +69,8 @@ def determine_outliers(data_df: pd.DataFrame,
         A pandas boolean Series whose length == len(data_df.index).
         True denotes that a row in the data_df contains at least one outlier.
     """
-    # Dataframe must have NANs filled to prevent warning when performing
-    # comparisons against the z_threshold. NANs will be filtered out
-    # in determine_likely_blinks().
-    nan_filled_df = data_df.fillna(data_df.mean())
 
-    outliers = (nan_filled_df.apply(stats.zscore).apply(np.abs) > z_threshold)
+    outliers = (data_df.apply(stats.zscore, nan_policy='omit').apply(np.abs) > z_threshold)
     return pd.Series(outliers.any(axis=1))
 
 
@@ -202,7 +198,7 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
     pupil_areas = (eye_data[["pupil_width", "pupil_height"]]
                    .apply(compute_circular_area, axis=1))
 
-    area_df = pd.concat([cr_areas, eye_areas, pupil_areas], axis=1)
+    area_df = pd.concat([eye_areas, pupil_areas], axis=1)
     outliers = determine_outliers(area_df, z_threshold=z_threshold)
 
     likely_blinks = determine_likely_blinks(eye_areas,

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -198,6 +198,7 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
     pupil_areas = (eye_data[["pupil_width", "pupil_height"]]
                    .apply(compute_circular_area, axis=1))
 
+    # only use eye and pupil areas for outlier detection
     area_df = pd.concat([eye_areas, pupil_areas], axis=1)
     outliers = determine_outliers(area_df, z_threshold=z_threshold)
 


### PR DESCRIPTION
# Overview:
This PR removes the corneal reflection data from the outlier detection algorithm when loading eye tracking data. Inclusion of the corneal reflection was leading to false positives in the blink_detection logic.

Also, simplified the outlier detection algorithm to apply the scipy `nan_policy='omit'` kwarg instead of filling NaNs with the mean prior to calculating.

# Addresses:
Address #1861

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
* Removes `cr_areas` from call to `determine_outliers`
* Passes `nan_policy='omit'` kwarg instead of filling NaNs with the mean prior to calculating.

# Changes:
See above

# Validation:
Here is a plot of the likely_blink output after this change. Compare to the plot in #1861. The false positive blink frames caused by the corneal reflection (denoted as points 1 and 2 in the plot) are no longer marked as outliers.

![image](https://user-images.githubusercontent.com/19944442/107309610-9a59ea80-6a3f-11eb-9084-7af49d36f2fc.png)


# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
none
