### PR TITLE
Danielsf/1818/dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+jobs:
+  linux-py36: &linux-template
+    executor:
+      name: python/default
+      tag: "3.6.12"
+    environment:
+      TEST_NWB_FILES: skip
+      TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA: skip
+      TEST_API_ENDPOINT: http://api.brain-map.org
+      TEST_COMPLETE: false
+      TEST_BAMBOO: false
+      LIMS_DBNAME: db
+      LIMS_PORT: 1234
+      LIMS_PASSWORD: password
+      LIMS_HOST: host
+      LIMS_USER: user
+      MTRAIN_DBNAME: db
+      MTRAIN_USER: user
+      MTRAIN_HOST: host
+      MTRAIN_PORT: 1234
+      MTRAIN_PASSWORD: password
+    steps:
+      - checkout
+      - run: sudo apt-get update
+      - run: sudo apt-get install rsync grsync
+      - run:
+          command: |
+            pip install codecov
+            pip install -r test_requirements.txt
+            pip install .
+          name: Install
+      - run:
+          command: |
+            python -m pytest -n 4 --cov allensdk --cov-report xml
+            bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
+          name: Test
+    
+  linux-py37:
+    <<: *linux-template
+    executor:
+      name: python/default
+      tag: "3.7.7"
+
+orbs:
+  python: circleci/python@1.3.2
+version: 2.1
+workflows:
+  main:
+    jobs:
+      - linux-py36
+      - linux-py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,6 @@ env:
 
 matrix:
   include:
-    - os: linux
-      sudo: required
-      python: 3.6
-      env: TEST_PYTHON_VERSION=3.6
-    - os: linux
-      sudo: required
-      python: 3.7
-      env: TEST_PYTHON_VERSION=3.7.3
     - os: osx
       language: generic
       env: TEST_PYTHON_VERSION=3.6
@@ -40,13 +32,8 @@ matrix:
       env: TEST_PYTHON_VERSION=3.7
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      sudo apt-get update;
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      brew update;
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-    fi
+  - brew update
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 - Refactored behavior and ophys session and data APIs to remove a circular inheritance issue
 - Fixed segmentation mask and roi_mask misregistration in 'BehaviorOphysSession'
 - Replaces BehaviorOphysSession.get_roi_masks() method with roi_masks property
+- Fixes bug which prevented the SDK from loading stimuli dataframes for static gratings
 
 ## [2.6.0] = 2021-02-05
 - Adds ability to write and read behavior only NWB files

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -399,19 +399,6 @@ def get_visual_stimuli_df(data, time) -> pd.DataFrame:
 
     visual_stimuli_df = pd.DataFrame(data=visual_stimuli_data)
 
-    draw_log_rising_edges = 0
-    draw_log_gratings = 0
-    # if images are contained in stimuli
-    if 'images' in stimuli.keys():
-        # ensure that every rising edge in the draw_log is accounted for in the visual_stimuli_df
-        draw_log_rising_edges = len(np.where(np.diff(stimuli['images']['draw_log']) == 1)[0])
-    if 'grating' in stimuli.keys():
-        draw_log_gratings = len(np.where(np.diff(stimuli['grating']['draw_log']) == 1)[0])
-
-    discrete_flashes = len(visual_stimuli_data)
-    assert (draw_log_rising_edges +
-            draw_log_gratings) == discrete_flashes, "the number of rising edges in the draw log is expected to match the number of flashes in the stimulus table"
-
     # Add omitted flash info:
     omitted_flash_list = []
     omitted_flash_frame_log = data['items']['behavior']['omitted_flash_frame_log']

--- a/allensdk/test/brain_observatory/behavior/test_stimulus_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_stimulus_processing.py
@@ -309,6 +309,27 @@ def test_get_stimulus_presentations(behavior_stimuli_time_fixture,
                                "end_frame": [5.0, 5.0, 12.0, 12.0],
                                "time": [2.0, 3.0, 9.0, 10.0],
                                "duration": [3.0, 2.0, 3.0, 2.0],
+                               "omitted": [False, False, False, False]}),
+
+                              # test case with images and a static grating
+                              ({"timestamp_count": 30, "time_step": 1},
+                              {"images_set_log": [
+                                  ('Image', 'im065', 5, 0),
+                                  ('Image', 'im064', 25, 6)
+                              ],
+                                  "images_draw_log": (([0] * 2 + [1] * 2 +
+                                                       [0] * 3) * 2 + [0]*16),
+                                  "grating_set_log": [
+                                      ("Ori", 90, -1, 12),  # -1 because that element is not used
+                                      ("Ori", 270, -1, 24)
+                                  ],
+                                  "grating_draw_log": ([0]*17 + [1]*11 + [0, 0])},
+                              {"orientation": [None, None, 90, 270],
+                               "image_name": ['im065', 'im064', None, None],
+                               "frame": [3.0, 10.0, 18.0, 25.0],
+                               "end_frame": [5.0, 12.0, 25.0, 29.0],
+                               "time": [3.0, 10.0, 18.0, 25.0],
+                               "duration": [2.0, 2.0, 7.0, 4.0],
                                "omitted": [False, False, False, False]})
                          ],
                          indirect=["behavior_stimuli_time_fixture",

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -96,6 +96,8 @@ What's New - 2.7.0
 - Refactored behavior and ophys session and data APIs to remove a circular inheritance issue
 - Fixed segmentation mask and roi_mask misregistration in 'BehaviorOphysSession'
 - Replaces BehaviorOphysSession.get_roi_masks() method with roi_masks property
+- Fixes bug which prevented the SDK from loading stimuli dataframes for static gratings
+
 
 What's New - 2.6.0
 -----------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the bug initially documented in issue 1818

https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/allensdk/1818

(not the conversation that grew from that bug). The SDK was failing to load stimuli tables for static gratings because it contained an internal validation check that asserted the number of rows in the stimuli table should be equal to the number of rising edges in the stimulus draw log. Static gratings are not flashed, so there are no rising edges.

We fixed the problem by removing the internal validation (there was no obvious way to reimplement it without being tautological). There is now a unit test that verifies that stimuli table has the correct shape when a static grating is present.

<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
