### PR TITLE
Deprecate travis linux tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Install
       - run:
           command: |
-            python -m pytest -n 4 --durations=0 --cov allensdk --cov-report xml
+            python -m pytest -n 4 --cov allensdk --cov-report xml
             bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
           name: Test
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,6 @@ env:
 
 matrix:
   include:
-    - os: linux
-      sudo: required
-      python: 3.6
-      env: TEST_PYTHON_VERSION=3.6
-    - os: linux
-      sudo: required
-      python: 3.7
-      env: TEST_PYTHON_VERSION=3.7.3
     - os: osx
       language: generic
       env: TEST_PYTHON_VERSION=3.6
@@ -40,13 +32,8 @@ matrix:
       env: TEST_PYTHON_VERSION=3.7
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      sudo apt-get update;
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      brew update;
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
-    fi
+  - brew update
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r


### PR DESCRIPTION
linux builds are now passing on circleci
This PR eliminates the travis linux builds which are taking a long time.
Future work: possibly migrate travis osx builds to circleci.

If adopted, after this PR:
* linux builds on circleci
* windows builds on appveyor
* osx builds on travis

Last travis python3.6 linux result:
```
=== 2116 passed, 207 skipped, 1 xfailed, 1037 warnings in 242.80s (0:04:02) ====
```
This PR circleci python3.6 linux result:
```
=== 2116 passed, 207 skipped, 1 xfailed, 1047 warnings in 177.28s (0:02:57) ====
```

Last travis python 3.7 linux result:
```
=== 2116 passed, 207 skipped, 1 xfailed, 1068 warnings in 215.71s (0:03:35) ====
```
this PR circleci python3.7 linux result:
```
=== 2116 passed, 207 skipped, 1 xfailed, 1050 warnings in 163.95s (0:02:43) ====
```