### PR TITLE
Adds circleci macosx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,9 @@ version: 2.1
 workflows:
   main:
     jobs:
-      - lint
+      # disable lint build, for merge to default branch
+      # turn back on when rc/2.8.0 is started
+      # - lint
       - linux-py36
       - linux-py37
       # disabled osx build. covered by github-actions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,27 @@
+env-vars: &env-vars
+  TEST_NWB_FILES: skip
+  TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA: skip
+  TEST_API_ENDPOINT: http://api.brain-map.org
+  TEST_COMPLETE: false
+  TEST_BAMBOO: false
+  LIMS_DBNAME: db
+  LIMS_PORT: 1234
+  LIMS_PASSWORD: password
+  LIMS_HOST: host
+  LIMS_USER: user
+  MTRAIN_DBNAME: db
+  MTRAIN_USER: user
+  MTRAIN_HOST: host
+  MTRAIN_PORT: 1234
+  MTRAIN_PASSWORD: password
+
 jobs:
   linux-py36: &linux-template
     executor:
       name: python/default
       tag: "3.6.12"
     environment:
-      TEST_NWB_FILES: skip
-      TEST_OBSERVATORY_EXPERIMENT_PLOTS_DATA: skip
-      TEST_API_ENDPOINT: http://api.brain-map.org
-      TEST_COMPLETE: false
-      TEST_BAMBOO: false
-      LIMS_DBNAME: db
-      LIMS_PORT: 1234
-      LIMS_PASSWORD: password
-      LIMS_HOST: host
-      LIMS_USER: user
-      MTRAIN_DBNAME: db
-      MTRAIN_USER: user
-      MTRAIN_HOST: host
-      MTRAIN_PORT: 1234
-      MTRAIN_PASSWORD: password
+      <<: *env-vars
     steps:
       - checkout
       - run: sudo apt-get update
@@ -40,7 +43,48 @@ jobs:
     executor:
       name: python/default
       tag: "3.7.7"
- 
+
+  osx-py36:
+    parameters:
+      pyversion:
+        default: "3.6.12"
+        type: string
+    macos:
+      xcode: 11.3.0
+    environment:
+      <<: *env-vars
+    steps:
+      - checkout
+      - run:
+          command: |
+            brew install wget
+          name: Install Wget
+      - run:
+          command: |
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+            bash miniconda.sh -b -p $HOME/miniconda
+            export PATH="$HOME/miniconda/bin:$PATH"
+            hash -r
+            conda config --set always_yes yes --set changeps1 no
+            conda update -q conda
+            conda create -q -n test-environment python=<<parameters.pyversion>> pip
+            source activate test-environment
+          name: Create conda test environment
+      - run:
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate test-environment
+            pip install codecov
+            pip install -r test_requirements.txt
+            pip install .
+          name: Install Allensdk
+      - run:
+          command: |
+            export PATH="$HOME/miniconda/bin:$PATH"
+            source activate test-environment
+            python -m pytest -n 4 --cov allensdk --cov-report xml
+          name: Test
+    
   lint:
     executor: python/default
     steps:
@@ -64,3 +108,4 @@ workflows:
       - lint
       - linux-py36
       - linux-py37
+      - osx-py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,4 +108,5 @@ workflows:
       - lint
       - linux-py36
       - linux-py37
-      - osx-py36
+      # disabled osx build. covered by github-actions
+      # - osx-py36


### PR DESCRIPTION
This PR establishes a circleci macosx build (python 3.6 demonstrated).
This took some back-and-forth with circleci support. In the meantime, our travis builds had stalled, so, we implemented github-actions macosx (and windows builds).
Circleci support resolved the account issue and we can now also build macosx (and presumably windows) on circleci as well.
This PR thus demonstrates a successful macos build on circleci, then disables it, while maintaining the yml configuration, in case we want to turn it back on later.