### PR TITLE
issue 1862 convert pupil_area to NaN where likely_blink == True (draft)

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -385,7 +385,9 @@ class BehaviorOphysSession(ParamsMixin):
           gaze location), with (0, 0) being the upper-left corner of the
           eye-tracking image.
         - The 'likely_blink' column is True for any row (frame) where the pupil
-          fit failed OR eye fit failed OR an outlier fit was identified.
+          fit failed OR eye fit failed OR an outlier fit was identified on the pupil or eye fit.
+        - The pupil_area column is set to NaN wherever 'likely_blink' == True
+        - The pupil_area_raw column contains all pupil fit values (including where 'likely_blink' == True)
         - All ellipse fits are derived from tracking points that were output by
           a DeepLabCut model that was trained on hand-annotated data frome a
           subset of imaging sessions on optical physiology rigs.

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -207,10 +207,16 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
                                             outliers,
                                             dilation_frames=dilation_frames)
 
+    # remove outliers/likely blinks from default `pupil_area` column
+    # maintain full fits in the `pupil_area_raw` column
+    pupil_area_raw = pupil_areas.copy()
+    pupil_areas[likely_blinks == True] = np.nan
+
     eye_data.insert(0, "time", frame_times)
     eye_data.insert(1, "cr_area", cr_areas)
     eye_data.insert(2, "eye_area", eye_areas)
     eye_data.insert(3, "pupil_area", pupil_areas)
     eye_data.insert(4, "likely_blink", likely_blinks)
+    eye_data.insert(5, "pupil_area_raw", pupil_area_raw)
 
     return eye_data

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -181,6 +181,8 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
             where "*" can be "corneal", "pupil" or "eye"
             likely_blink
         or None if no eye tracking data
+        Note: `pupil_area` is set to NaN where `likely_blink` == True
+              use `pupil_area_raw` column to access unfiltered pupil data
         """
         try:
             eye_tracking_acquisition = self.nwbfile.acquisition['EyeTracking']
@@ -205,7 +207,7 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
 
             "pupil_center_x": pupil_tracking.data[:, 0],
             "pupil_center_y": pupil_tracking.data[:, 1],
-            "pupil_area": pupil_tracking.area[:],
+            "pupil_area_raw": pupil_tracking.area[:],
             "pupil_height": pupil_tracking.height[:],
             "pupil_width": pupil_tracking.width[:],
             "pupil_phi": pupil_tracking.angle[:],
@@ -218,6 +220,7 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
             "cr_phi": corneal_reflection_tracking.angle[:],
 
             "likely_blink": eye_tracking_acquisition.likely_blink.data[:],
+            "pupil_area": pupil_tracking.area[:] * (eye_tracking_acquisition.likely_blink.data[:] == False),
             "time": eye_tracking.timestamps[:]
         }
 

--- a/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
@@ -31,7 +31,7 @@ def create_area_df(data: np.ndarray) -> pd.DataFrame:
 
 
 def create_refined_eye_tracking_df(data: np.ndarray) -> pd.DataFrame:
-    columns = ["time", "cr_area", "eye_area", "pupil_area", "likely_blink",
+    columns = ["time", "cr_area", "eye_area", "pupil_area", "likely_blink", "pupil_area_raw",
                "cr_center_x", "cr_center_y", "cr_width", "cr_height", "cr_phi",
                "eye_center_x", "eye_center_y", "eye_width", "eye_height",
                "eye_phi", "pupil_center_x", "pupil_center_y", "pupil_width",
@@ -180,9 +180,9 @@ def test_process_eye_tracking_data_raises_on_sync_error(eye_tracking_df,
                   [2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.]])),
      pd.Series([0.1, 0.2]),
      create_refined_eye_tracking_df(
-         np.array([[0.1, 12 * np.pi, 72 * np.pi, 196 * np.pi, False,
+         np.array([[0.1, 12 * np.pi, 72 * np.pi, 196 * np.pi, False, 196 * np.pi,
                     1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15.],
-                   [0.2, 20 * np.pi, 90 * np.pi, 225 * np.pi, False,
+                   [0.2, 20 * np.pi, 90 * np.pi, 225 * np.pi, False, 225 * np.pi,
                     2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.]]))
      ),
 ])

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -65,10 +65,10 @@ def rig_geometry():
 @pytest.fixture
 def eye_tracking_data():
     return create_refined_eye_tracking_df(
-        np.array([[0.1, 12 * np.pi, 72 * np.pi, 196 * np.pi, False,
+        np.array([[0.1, 12 * np.pi, 72 * np.pi, 196 * np.pi, False, 196 * np.pi,
                    1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.,
                    13., 14., 15.],
-                  [0.2, 20 * np.pi, 90 * np.pi, 225 * np.pi, False,
+                  [0.2, 20 * np.pi, 90 * np.pi, 225 * np.pi, False, 225 * np.pi,
                    2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13.,
                    14., 15., 16.]])
     )


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
@matchings requested in issue #1862 that the `pupil_area` column in the eye_tracking dataframe be set to NaN wherever the `likely_blink` column is True. This will prevent users from including possibly erroneous pupil fits in their analyses. The raw (unfiltered) pupil areas are maintained in a column called `pupil_area_raw`

# Addresses:
#1862

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
The solution is to create a new column called `pupil_area_raw` that contains a copy of the `pupil_area` column, then set the `pupil_area` column to NaN everywhere that `likely_blink` == True

# Changes:
* Implemented above described logic change in allensdk/brain_observatory/behavior/eye_tracking_processing.py
* updated documentation in /allensdk/brain_observatory/behavior/behavior_ophys_session.py
* updated `test_process_eye_tracking_data` in allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py

# Validation:
After the change, load a session:
```
from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession

ophys_experiment_id = 856938751
sdk_session = BehaviorOphysSession.from_lims(ophys_experiment_id)
```
then view a sample of frames where `likely_blink == True` (`pupil_area` should be NaN for all rows in this sample):
`sdk_session.eye_tracking.query('likely_blink').sample(10)`
![image](https://user-images.githubusercontent.com/19944442/107866478-504d7c00-6e26-11eb-846d-18a94b5d22f1.png)

And a sample of frames where `likely_blink == False` (`pupil_area` should be NaN for no rows in this sample and should match `pupil_area_raw`):
`sdk_session.eye_tracking.query('not likely_blink').sample(10)`
![image](https://user-images.githubusercontent.com/19944442/107866484-62c7b580-6e26-11eb-9fcb-de2ceae9224d.png)

Finally, plot both `pupil_area_raw` and `pupil_area`, confirming that the `pupil_area` column does not include the large, obvious outliers:

```
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
ax.plot(
    sdk_session.eye_tracking['time'],
    sdk_session.eye_tracking['pupil_area_raw'],
    color='red'
)
ax.plot(
    sdk_session.eye_tracking['time'],
    sdk_session.eye_tracking['pupil_area'],
    color='black'
)
ax.legend(['pupil_area_raw','pupil_area'])
ax.set_ylabel('pupil area ($pixels^2$)')
ax.set_xlabel('time (s)')
```

![image](https://user-images.githubusercontent.com/19944442/107866507-93a7ea80-6e26-11eb-863c-21fa72e19a65.png)


# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
None
