### PR TITLE
adds case for sessions with no omitted flash frames

### DIFF
--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -400,12 +400,13 @@ def get_visual_stimuli_df(data, time) -> pd.DataFrame:
     visual_stimuli_df = pd.DataFrame(data=visual_stimuli_data)
 
     # Add omitted flash info:
-    if 'flash_omit_probability' not in data['items']['behavior']['params']:
-        # For sessions for which there were no omitted flashes
-        omitted_flash_frame_log = dict()
-    else:
+    try:
         omitted_flash_frame_log = \
             data['items']['behavior']['omitted_flash_frame_log']
+    except KeyError:
+        # For sessions for which there were no omitted flashes
+        omitted_flash_frame_log = dict()
+
     omitted_flash_list = []
 
     for stimuli_group_name, omitted_flash_frames in omitted_flash_frame_log.items():

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -400,8 +400,13 @@ def get_visual_stimuli_df(data, time) -> pd.DataFrame:
     visual_stimuli_df = pd.DataFrame(data=visual_stimuli_data)
 
     # Add omitted flash info:
+    if 'flash_omit_probability' not in data['items']['behavior']['params']:
+        # For sessions for which there were no omitted flashes
+        omitted_flash_frame_log = dict()
+    else:
+        omitted_flash_frame_log = \
+            data['items']['behavior']['omitted_flash_frame_log']
     omitted_flash_list = []
-    omitted_flash_frame_log = data['items']['behavior']['omitted_flash_frame_log']
 
     for stimuli_group_name, omitted_flash_frames in omitted_flash_frame_log.items():
         stim_frames = visual_stimuli_df['frame'].values


### PR DESCRIPTION
### validation
this was failing:
```
python -m allensdk.brain_observatory.behavior.write_behavior_nwb \
  --input_json /allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/behavior_session_772128781/BEHAVIOR_WRITE_NWB_QUEUE_772128781_input.json \
  --output_path ./output/out.nwb \
  --output_json ./output/out.json
```
now, the nwb write runs through.