### PR TITLE
Validation for session 7 behavior sessions

### DIFF
--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
@@ -64,7 +64,7 @@ class BehaviorSessionData(RaisingSchema):
 
             if not params:
                 raise mm.ValidationError(
-                    f'The stimuls file is missing cl_params. '
+                    f'The stimulus file is missing cl_params. '
                     f'Cannot create NWB file.'
                 )
 

--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
@@ -60,7 +60,7 @@ class BehaviorSessionData(RaisingSchema):
                     f'create NWB file.'
                 )
 
-            params = items['behavior']['params']
+            params = items['behavior']['cl_params']
 
             if not params:
                 raise mm.ValidationError(


### PR DESCRIPTION
Relates to #1893

This PR improves on the error message for validating the stimulus file by including that we can't process the session if the stimulus file is missing "behavior" data. 
These sessions should not be processed through NWB. 