### PR TITLE
uses correct key name for flash_omit_probability

### DIFF
--- a/allensdk/brain_observatory/behavior/metadata_processing.py
+++ b/allensdk/brain_observatory/behavior/metadata_processing.py
@@ -81,19 +81,26 @@ def get_expt_description(session_type: str) -> str:
 
 
 def get_task_parameters(data):
+    behavior = data["items"]["behavior"]
 
     task_parameters = {}
-    task_parameters['blank_duration_sec'] = [float(x) for x in data["items"]["behavior"]['config']['DoC']['blank_duration_range']]
-    task_parameters['stimulus_duration_sec'] = data["items"]["behavior"]['config']['DoC']['stimulus_window']
-    task_parameters['omitted_flash_fraction'] = data["items"]["behavior"]['params'].get('omitted_flash_fraction', float('nan'))
-    task_parameters['response_window_sec'] = [float(x) for x in data["items"]["behavior"]["config"]["DoC"]["response_window"]]
-    task_parameters['reward_volume'] = data["items"]["behavior"]["config"]["reward"]["reward_volume"]
-    task_parameters['stage'] = data["items"]["behavior"]["params"]["stage"]
-    task_parameters['stimulus'] = next(iter(data["items"]["behavior"]["stimuli"]))
-    task_parameters['stimulus_distribution'] = data["items"]["behavior"]["config"]["DoC"]["change_time_dist"]
-    task_parameters['task'] = data["items"]["behavior"]["config"]["behavior"]["task_id"]
+    task_parameters['blank_duration_sec'] = \
+        [float(x) for x in behavior['config']['DoC']['blank_duration_range']]
+    task_parameters['stimulus_duration_sec'] = \
+        behavior['config']['DoC']['stimulus_window']
+    task_parameters['omitted_flash_fraction'] = \
+        behavior['params'].get('flash_omit_probability', float('nan'))
+    task_parameters['response_window_sec'] = \
+        [float(x) for x in behavior["config"]["DoC"]["response_window"]]
+    task_parameters['reward_volume'] = \
+        behavior["config"]["reward"]["reward_volume"]
+    task_parameters['stage'] = behavior["params"]["stage"]
+    task_parameters['stimulus'] = next(iter(behavior["stimuli"]))
+    task_parameters['stimulus_distribution'] = \
+        behavior["config"]["DoC"]["change_time_dist"]
+    task_parameters['task'] = behavior["config"]["behavior"]["task_id"]
     n_stimulus_frames = 0
-    for stim_type, stim_table in data["items"]["behavior"]["stimuli"].items():
+    for stim_type, stim_table in behavior["stimuli"].items():
         n_stimulus_frames += sum(stim_table.get("draw_log", []))
     task_parameters['n_stimulus_frames'] = n_stimulus_frames
 

--- a/allensdk/test/brain_observatory/behavior/test_metadata_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_metadata_processing.py
@@ -26,6 +26,7 @@ def test_get_task_parameters():
                 },
                 "params": {
                     "stage": "TRAINING_3_images_A",
+                    "flash_omit_probability": 0.05
                 },
                 "stimuli": {
                     "images": {"draw_log": [1]*10}
@@ -37,7 +38,7 @@ def test_get_task_parameters():
     expected = {
         "blank_duration_sec": [0.5, 0.6],
         "stimulus_duration_sec": 6.0,
-        "omitted_flash_fraction": np.nan,
+        "omitted_flash_fraction": 0.05,
         "response_window_sec": [0.15, 0.75],
         "reward_volume": 0.007,
         "stage": "TRAINING_3_images_A",


### PR DESCRIPTION
Updated example with this change:
```
from allensdk.brain_observatory.behavior.session_apis.data_io import BehaviorOphysLimsApi 
from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession 

experiment_id = 905551719 
api = BehaviorOphysLimsApi(experiment_id) 
data = BehaviorOphysSession(api) 
data.task_parameters
```
`omitted_flash_fraction` is no longer `nan`
```                                                         
{'blank_duration_sec': [0.5, 0.5],
 'stimulus_duration_sec': 6.0,
 'omitted_flash_fraction': 0.05,
 'response_window_sec': [0.15, 0.75],
 'reward_volume': 0.007,
 'stage': 'OPHYS_6_images_A',
 'stimulus': 'images',
 'stimulus_distribution': 'geometric',
 'task': 'DoC_untranslated',
 'n_stimulus_frames': 69355}
```