### PR TITLE
change running_speed dataframe column name from values to speed

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
@@ -180,7 +180,7 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
         running_speed_df = pd.DataFrame(
             {
                 'timestamps': timestamps,
-                'values': values
+                'speed': values
             },
         )
         return running_speed_df

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_transforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_transforms.py
@@ -157,7 +157,7 @@ class BehaviorDataTransforms(BehaviorBase):
                 f"'{running_data_df.index.name}'.")
         return pd.DataFrame({
             "timestamps": running_data_df.index.values,
-            "values": running_data_df.speed.values})
+            "speed": running_data_df.speed.values})
 
     def get_stimulus_frame_rate(self) -> float:
         stimulus_timestamps = self.get_stimulus_timestamps()

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -241,7 +241,7 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         # RunningSpeed object. This will improve consistency for students. For SWDB we have also opted to 
         # have columns for both 'timestamps' and 'values' of things, since this is more intuitive for students
         running_speed = super(ExtendedNwbApi, self).get_running_speed()
-        return pd.DataFrame({'speed': running_speed.values,
+        return pd.DataFrame({'speed': running_speed.speed,
                              'timestamps': running_speed.timestamps})
 
     def get_trials(self, filter_aborted_trials=True):

--- a/allensdk/brain_observatory/behavior/swdb/save_extended_stimulus_presentations_df.py
+++ b/allensdk/brain_observatory/behavior/swdb/save_extended_stimulus_presentations_df.py
@@ -159,7 +159,7 @@ def get_extended_stimulus_presentations(session):
     # Average running speed on each flash
     flash_running_speed = intermediate_df.apply(
         lambda row: trace_average(
-            session.running_speed.speed,
+            session.running_speed.values,
             session.running_speed.timestamps,
             row["start_time"],
             row["start_time"]+0.25,

--- a/allensdk/brain_observatory/behavior/swdb/save_extended_stimulus_presentations_df.py
+++ b/allensdk/brain_observatory/behavior/swdb/save_extended_stimulus_presentations_df.py
@@ -159,7 +159,7 @@ def get_extended_stimulus_presentations(session):
     # Average running speed on each flash
     flash_running_speed = intermediate_df.apply(
         lambda row: trace_average(
-            session.running_speed.values,
+            session.running_speed.speed,
             session.running_speed.timestamps,
             row["start_time"],
             row["start_time"]+0.25,

--- a/allensdk/brain_observatory/behavior/swdb/summary_figures.py
+++ b/allensdk/brain_observatory/behavior/swdb/summary_figures.py
@@ -80,7 +80,7 @@ def plot_behavior_events_trace(session, xmin=360, length=3, ax=None, save_dir=No
     if ax is None:
         figsize = (15, 4)
         fig, ax = plt.subplots(figsize=figsize)
-    ax.plot(session.running_speed.timestamps, session.running_speed.values, color=sns.color_palette()[0])
+    ax.plot(session.running_speed.timestamps, session.running_speed.speed, color=sns.color_palette()[0])
     ax = add_stim_color_span(session, ax, xlim=[xmin, xmax])
     ax = plot_behavior_events(session, ax)
     ax = restrict_axes(xmin, xmax, interval, ax)
@@ -113,7 +113,7 @@ def plot_traces_heatmap(session, ax=None):
 def plot_behavior_segment(session, xlims=[620, 640], ax=None):
     if ax is None:
         fig, ax = plt.subplots()
-    ax.plot(session.running_speed.timestamps, session.running_speed.values)
+    ax.plot(session.running_speed.timestamps, session.running_speed.speed)
     ax.set_ylabel('running speed\ncm/s')
     ax.set_xlabel('time (s)')
     ax.set_xlim(xlims)
@@ -232,7 +232,7 @@ def plot_example_traces_and_behavior(session, xmin_seconds, length_mins, cell_la
 
     i += 1
     ax[i].tick_params(axis="x", bottom=True, top=False, labelbottom=True, labeltop=False)
-    ax[i].plot(session.running_speed.timestamps, session.running_speed.values, color=sns.color_palette()[0])
+    ax[i].plot(session.running_speed.timestamps, session.running_speed.speed, color=sns.color_palette()[0])
     ax[i] = plot_behavior_events(session, ax=ax[i])
     ax[i] = add_stim_color_span(session, ax=ax[i], xlim=xlim)
     ax[i] = restrict_axes(xmin_seconds, xmax_seconds, interval_seconds, ax=ax[i])
@@ -467,7 +467,7 @@ def plot_experiment_summary_figure(session, save_dir=None):
     ax.set_title(title)
 
     ax = placeAxesOnGrid(fig, dim=(1, 1), xspan=(.28, .92), yspan=(.32, .44))
-    ax.plot(session.running_speed.timestamps, session.running_speed.values)
+    ax.plot(session.running_speed.timestamps, session.running_speed.speed)
     ax.set_xlabel('time (seconds)')
     ax.set_ylabel('running speed\n(cm/s)')
 

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -380,7 +380,7 @@ def add_running_speed_to_nwbfile(nwbfile, running_speed,
     '''
 
     if from_dataframe:
-        data = running_speed['values'].values
+        data = running_speed['speed'].values
         timestamps = running_speed['timestamps'].values
     else:
         data = running_speed.values

--- a/allensdk/test/brain_observatory/behavior/test_behavior_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_lims_api.py
@@ -226,7 +226,7 @@ def test_get_experiment_date(MockBehaviorLimsApi):
 def test_get_running_speed(MockBehaviorLimsApi):
     expected = pd.DataFrame({
         "timestamps": [0.0, 0.1, 0.2],
-        "values": [8.0, 15.0, 16.0]})
+        "speed": [8.0, 15.0, 16.0]})
     api = MockBehaviorLimsApi
     actual = api.get_running_speed()
     pd.testing.assert_frame_equal(expected, actual)

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -52,7 +52,7 @@ def test_add_running_speed_to_nwbfile(nwbfile, running_speed,
     assert np.allclose(running_speed.timestamps,
                        obt_running_speed['timestamps'])
     assert np.allclose(running_speed.values,
-                       obt_running_speed['values'])
+                       obt_running_speed['speed'])
 
 
 @pytest.mark.parametrize('roundtrip', [True, False])


### PR DESCRIPTION
@njmei this could use a double-check. I'll also kick off some bamboo builds on this branch.

Mods I am unsure about, because I don't recall changing them in the first pass of implementing this dataframe, but I found them with grep:
* behavior_project_cache.py
* save_extended_stimulus_presentations_df.py
* summary_figures.py

Passing bamboo builds except for a new failure inherited from `1884-mesoscope-nwb`

### Validation, desired output:
```
from allensdk.brain_observatory.behavior.session_apis.data_io import BehaviorOphysLimsApi   
from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession                                               

api = BehaviorOphysLimsApi(843007058)                                 
dataset = BehaviorOphysSession(api)                                           
```

```
dataset.running_speed                                                         

         timestamps      speed
0          9.141764  -0.001570
1          9.158414   2.876533
2          9.175124   5.597272
3          9.191814   8.019805
4          9.208454  10.026117
...             ...        ...
269859  4510.466494  25.939683
269860  4510.483204  26.141283
269861  4510.499884  26.444313
269862  4510.516524  26.826698
269863  4510.533234  27.253158

[269864 rows x 2 columns]
```