### PR TITLE
Ticket/1932/dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [2.8.0] = TBD
 - Created lookup table to get monitor_delay for cases where calculation from data fails
-- 
+- If sync timestamp file has more timestamps than eye tracking moving has frame, trim excess timestamps (up to 15)
+-
 
 ## [2.7.0] = 2021-02-19
 - Refactored behavior and ophys session and data APIs to remove a circular inheritance issue

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -186,7 +186,14 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
         eye tracking frames.
     """
 
-    if len(frame_times) != len(eye_data.index):
+    n_sync = len(frame_times)
+    n_eye_frames = len(eye_data.index)
+
+    if n_sync > n_eye_frames and n_sync <= n_eye_frames+15:
+        frame_times = frame_times[:n_eye_frames]
+        n_sync = len(frame_times)
+
+    if n_sync != n_eye_frames:
         raise RuntimeError(f"Error! The number of sync file frame times "
                            f"({len(frame_times)} does not match the "
                            f"number of eye tracking frames "

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -189,6 +189,13 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
     n_sync = len(frame_times)
     n_eye_frames = len(eye_data.index)
 
+    # If n_sync exceeds n_eye_frames by <= 15,
+    # just trim the excess sync pulses from the end
+    # of the timestamps array.
+    #
+    # This solution was discussed in
+    # https://github.com/AllenInstitute/AllenSDK/issues/1545
+
     if n_sync > n_eye_frames and n_sync <= n_eye_frames+15:
         frame_times = frame_times[:n_eye_frames]
         n_sync = len(frame_times)

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -195,7 +195,7 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
 
     if n_sync != n_eye_frames:
         raise RuntimeError(f"Error! The number of sync file frame times "
-                           f"({len(frame_times)} does not match the "
+                           f"({len(frame_times)}) does not match the "
                            f"number of eye tracking frames "
                            f"({len(eye_data.index)})!")
 

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -44,7 +44,7 @@ def load_eye_tracking_hdf(eye_tracking_file: Path) -> pd.DataFrame:
 
     # Values in the hdf5 may be complex (likely an artifact of the ellipse
     # fitting process). Take only the real component.
-    eye_tracking_data = eye_tracking_data.apply(lambda x: np.real(x.to_numpy()))
+    eye_tracking_data = eye_tracking_data.apply(lambda x: np.real(x.to_numpy()))  # noqa: E501
 
     return eye_tracking_data.astype(float)
 

--- a/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
@@ -174,12 +174,35 @@ def test_determine_likely_blinks(eye_areas, pupil_areas, outliers,
     (create_loaded_eye_tracking_df(
         np.array([[1, 1, 2, 1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1],
                   [2, 2, 1, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2]])),
-     pd.Series([0.1, 0.2, 0.3])),
+     pd.Series(np.arange(0, 1.8, 0.1))),
 ])
 def test_process_eye_tracking_data_raises_on_sync_error(eye_tracking_df,
                                                         frame_times):
+    """
+    Test that an error is raised when the number of sync timestamps exceeds
+    the number of eye tracking frames by more than 15
+    """
     with pytest.raises(RuntimeError, match='Error! The number of sync file'):
         process_eye_tracking_data(eye_tracking_df, frame_times)
+
+
+@pytest.mark.parametrize("eye_tracking_df, frame_times", [
+    (create_loaded_eye_tracking_df(
+        np.array([[1, 1, 2, 1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 2, 1],
+                  [2, 2, 1, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2]])),
+     pd.Series(np.arange(0, 1.7, 0.1))),
+])
+def test_process_eye_tracking_data_truncation(eye_tracking_df,
+                                              frame_times):
+    """
+    Test that the array of sync times is truncated when the number
+    of raw sync timestamps exceeds the numer of eye tracking frames
+    by <= 15
+    """
+    df = process_eye_tracking_data(eye_tracking_df, frame_times)
+    np.testing.assert_array_almost_equal(df.time.to_numpy(),
+                                         np.array([0.0, 0.1]),
+                                         decimal=10)
 
 
 @pytest.mark.parametrize("eye_tracking_df, frame_times, expected", [

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -94,6 +94,7 @@ See the `mouse connectivity section <connectivity.html>`_ for more details.
 What's New - 2.8.0
 -----------------------------------------------------------------------
 - Created lookup table to get monitor_delay for cases where calculation from data fails
+- If sync timestamp file has more timestamps than eye tracking moving has frame, trim excess timestamps (up to 15)
 -
 
 What's New - 2.7.0


### PR DESCRIPTION
In the event that the number of timestamps in the eye tracking sync file exceeds the number of eye tracking frames by <= 15, remove the excess timestamps from the end of the sync file. This is a known bug in the experimental hardware.
