### PR TITLE
Ticket/1933/dev

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_transforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_ophys_data_transforms.py
@@ -327,25 +327,6 @@ class BehaviorOphysDataTransforms(BehaviorDataTransforms, BehaviorOphysBase):
         return pd.DataFrame({'time': lick_times})
 
     @memoize
-    def get_licks(self) -> pd.DataFrame:
-        """
-        Returns
-        -------
-        pd.DataFrame
-            Two columns: "time", which contains the sync time
-            of the licks that occurred in this session and "frame",
-            the frame numbers of licks that occurred in this session
-        """
-        data = self._behavior_stimulus_file()
-        timestamps = self.get_stimulus_timestamps()
-        # Get licks from pickle file (need to add an offset to align with
-        # the trial_log time stream)
-        lick_frames = (data["items"]["behavior"]["lick_sensors"][0]
-                       ["lick_events"])
-        lick_times = timestamps[lick_frames]
-        return pd.DataFrame({"time": lick_times, "frame": lick_frames})
-
-    @memoize
     def get_rewards(self):
         data = self._behavior_stimulus_file()
         timestamps = self.get_stimulus_timestamps()

--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
@@ -1,3 +1,5 @@
+import pytest
+import logging
 import numpy as np
 import pandas as pd
 from allensdk.brain_observatory.behavior.session_apis.data_transforms import BehaviorDataTransforms  # noqa: E501
@@ -152,3 +154,119 @@ def test_get_licks(monkeypatch):
         np.testing.assert_array_almost_equal(expected_df.frame.to_numpy(),
                                              licks.frame.to_numpy(),
                                              decimal=10)
+
+
+def test_get_licks_excess(monkeypatch):
+    """
+    Test that BehaviorDataTransforms.get_licks() in the case where
+    there is an extra frame at the end of the trial log and the mouse
+    licked on that frame
+
+    https://github.com/AllenInstitute/visual_behavior_analysis/blob/master/visual_behavior/translator/foraging2/extract.py#L640-L647
+    """
+
+    def dummy_init(self):
+        self.logger = logging.getLogger('dummy')
+        pass
+
+    def dummy_stimulus_timestamps(self):
+        return np.arange(0, 2.0, 0.01)
+
+    def dummy_stimulus_file(self):
+
+        # in this test, the trial log exists to make sure
+        # that get_licks is *not* reading the licks from
+        # here
+        trial_log = []
+        trial_log.append({'licks': [(-1.0, 100), (-1.0, 200)]})
+        trial_log.append({'licks': [(-1.0, 300), (-1.0, 400)]})
+        trial_log.append({'licks': [(-1.0, 500), (-1.0, 600)]})
+
+        lick_events = [12, 15, 90, 136, 200]  # len(timestamps) == 200
+        lick_events = [{'lick_events': lick_events}]
+
+        data = {}
+        data['items'] = {}
+        data['items']['behavior'] = {}
+        data['items']['behavior']['trial_log'] = trial_log
+        data['items']['behavior']['lick_sensors'] = lick_events
+        return data
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(BehaviorDataTransforms,
+                    '__init__',
+                    dummy_init)
+
+        ctx.setattr(BehaviorDataTransforms,
+                    'get_stimulus_timestamps',
+                    dummy_stimulus_timestamps)
+
+        ctx.setattr(BehaviorDataTransforms,
+                    '_behavior_stimulus_file',
+                    dummy_stimulus_file)
+
+        xforms = BehaviorDataTransforms()
+
+        licks = xforms.get_licks()
+
+        expected_dict = {'time': [0.12, 0.15, 0.90, 1.36],
+                         'frame': [12, 15, 90, 136]}
+        expected_df = pd.DataFrame(expected_dict)
+        assert expected_df.columns.equals(licks.columns)
+        np.testing.assert_array_almost_equal(expected_df.time.to_numpy(),
+                                             licks.time.to_numpy(),
+                                             decimal=10)
+        np.testing.assert_array_almost_equal(expected_df.frame.to_numpy(),
+                                             licks.frame.to_numpy(),
+                                             decimal=10)
+
+
+def test_get_licks_failure(monkeypatch):
+    """
+    Test that BehaviorDataTransforms.get_licks() fails if the last lick
+    is more than one frame beyond the end of the timestamps
+    """
+
+    def dummy_init(self):
+        self.logger = logging.getLogger('dummy')
+        pass
+
+    def dummy_stimulus_timestamps(self):
+        return np.arange(0, 2.0, 0.01)
+
+    def dummy_stimulus_file(self):
+
+        # in this test, the trial log exists to make sure
+        # that get_licks is *not* reading the licks from
+        # here
+        trial_log = []
+        trial_log.append({'licks': [(-1.0, 100), (-1.0, 200)]})
+        trial_log.append({'licks': [(-1.0, 300), (-1.0, 400)]})
+        trial_log.append({'licks': [(-1.0, 500), (-1.0, 600)]})
+
+        lick_events = [12, 15, 90, 136, 201]  # len(timestamps) == 200
+        lick_events = [{'lick_events': lick_events}]
+
+        data = {}
+        data['items'] = {}
+        data['items']['behavior'] = {}
+        data['items']['behavior']['trial_log'] = trial_log
+        data['items']['behavior']['lick_sensors'] = lick_events
+        return data
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(BehaviorDataTransforms,
+                    '__init__',
+                    dummy_init)
+
+        ctx.setattr(BehaviorDataTransforms,
+                    'get_stimulus_timestamps',
+                    dummy_stimulus_timestamps)
+
+        ctx.setattr(BehaviorDataTransforms,
+                    '_behavior_stimulus_file',
+                    dummy_stimulus_file)
+
+        xforms = BehaviorDataTransforms()
+        with pytest.raises(IndexError):
+            _ = xforms.get_licks()


### PR DESCRIPTION
Occasionally, an extra frame is appended to the list of stimulus frames. If the mouse licks on this frame, it can cause a failure aligning licks to stimulus timestamps. This was a known problem that visual_behavior_analysis fixed. This PR just ports the fix from VBA into the SDK.