### PR TITLE
Improvements to stimulus_template in NWB

### DIFF
--- a/allensdk/brain_observatory/behavior/write_nwb/extensions/stimulus_template/extension_builder.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/extensions/stimulus_template/extension_builder.py
@@ -23,7 +23,10 @@ def main():
     stimulus_template_spec = NWBGroupSpec(
         neurodata_type_def='StimulusTemplate',
         neurodata_type_inc='ImageSeries',
-        doc='Each image shown to the animals is warped to account for '
+        doc='Note: image names in control_description are referenced by '
+            'stimulus/presentation table as well as intervals '
+            ''
+            'Each image shown to the animals is warped to account for '
             'distance and eye position relative to the monitor. This  '
             'extension stores the warped images that were shown to the animal '
             'as well as an unwarped version of each image in which a mask has '

--- a/allensdk/brain_observatory/behavior/write_nwb/extensions/stimulus_template/extension_builder.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/extensions/stimulus_template/extension_builder.py
@@ -25,7 +25,7 @@ def main():
         neurodata_type_inc='ImageSeries',
         doc='Note: image names in control_description are referenced by '
             'stimulus/presentation table as well as intervals '
-            ''
+            '\n'
             'Each image shown to the animals is warped to account for '
             'distance and eye position relative to the monitor. This  '
             'extension stores the warped images that were shown to the animal '

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -518,8 +518,8 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
                 cleaned_table[colname] = series.transform(str)
 
         interval_description = (f"Presentation times and stimuli details "
-                                f"for '{stim_name}' stimuli."
-                                f""
+                                f"for '{stim_name}' stimuli. "
+                                f"\n"
                                 f"Note: image_name references "
                                 f"control_description in stimulus/templates")
         presentation_interval = create_stimulus_presentation_time_interval(

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -520,7 +520,7 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
         interval_description = (f"Presentation times and stimuli details "
                                 f"for '{stim_name}' stimuli."
                                 f""
-                                f"Note: image_name reference "
+                                f"Note: image_name references "
                                 f"control_description in stimulus/templates")
         presentation_interval = create_stimulus_presentation_time_interval(
             name=f"{stim_name}_presentations",

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -416,7 +416,8 @@ def add_stimulus_template(nwbfile: NWBFile,
         unwarped_images.append(image_data.unwarped)
         warped_images.append(image_data.warped)
 
-    image_index = list(range(len(image_names)))
+    image_index = np.zeros(len(image_names))
+    image_index[:] = np.nan
 
     visual_stimulus_image_series = \
         StimulusTemplateExtension(
@@ -517,7 +518,10 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
                 cleaned_table[colname] = series.transform(str)
 
         interval_description = (f"Presentation times and stimuli details "
-                                f"for '{stim_name}' stimuli")
+                                f"for '{stim_name}' stimuli."
+                                f""
+                                f"Note: image names reference "
+                                f"control_description in stimulus/templates")
         presentation_interval = create_stimulus_presentation_time_interval(
             name=f"{stim_name}_presentations",
             description=interval_description,

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -520,7 +520,7 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
         interval_description = (f"Presentation times and stimuli details "
                                 f"for '{stim_name}' stimuli."
                                 f""
-                                f"Note: image names reference "
+                                f"Note: image_name reference "
                                 f"control_description in stimulus/templates")
         presentation_interval = create_stimulus_presentation_time_interval(
             name=f"{stim_name}_presentations",


### PR DESCRIPTION
We are using `ImageSeries` to store stimulus_templates which requires timestamps. Since the images themselves don't have timestamps, we were using dummy timestamps of rangeindex. This updates to use nans instead (requested by NWB folks). Also updates doc to be clear that image_names reference control_description in stimulus/templates. 

A more long-term solution would programmatically reference the images from other tables.  