### PR TITLE
make it possible to skip eye tracking data when writing BehaviorOphys…

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -56,7 +56,9 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
         self.filter_invalid_rois = kwargs.pop("filter_invalid_rois", False)
         super().__init__(*args, **kwargs)
 
-    def save(self, session_object):
+    def save(self,
+             session_object,
+             skip_eye_tracking=False):
 
         session_type = str(session_object.metadata['session_type'])
 
@@ -156,11 +158,12 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
         # Add motion correction to NWB in-memory object:
         nwb.add_motion_correction(nwbfile, session_object.motion_correction)
 
-        # Add eye tracking and rig geometry to NWB in-memory object.
-        self.add_eye_tracking_data_to_nwb(
-            nwbfile=nwbfile,
-            eye_tracking_df=session_object.eye_tracking,
-            eye_tracking_rig_geometry=session_object.eye_tracking_rig_geometry)
+        if not skip_eye_tracking:
+            # Add eye tracking and rig geometry to NWB in-memory object.
+            self.add_eye_tracking_data_to_nwb(
+                nwbfile=nwbfile,
+                eye_tracking_df=session_object.eye_tracking,
+                eye_tracking_rig_geometry=session_object.eye_tracking_rig_geometry)
 
         # Add events
         self.add_events(nwbfile=nwbfile, events=session_object.events)

--- a/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
@@ -134,6 +134,8 @@ class InputSchema(ArgSchema):
     output_path = String(required=True, validate=check_write_access_overwrite,
                          description='write outputs to here')
 
+    skip_eye_tracking = Boolean(required=True, default=False,
+                                description='Skip eye tracking data')
 
 class OutputSchema(RaisingSchema):
     output_path = String(required=True, description='write outputs to here')

--- a/allensdk/brain_observatory/session_api_utils.py
+++ b/allensdk/brain_observatory/session_api_utils.py
@@ -152,7 +152,7 @@ class ParamsMixin:
         self._updated_params -= data_params
 
 
-def sessions_are_equal(A, B, reraise=False) -> bool:
+def sessions_are_equal(A, B, reraise=False, skip_field=None) -> bool:
     """Check if two Session objects are equal (have same methods and
     attributes).
 
@@ -165,6 +165,9 @@ def sessions_are_equal(A, B, reraise=False) -> bool:
     reraise : bool, optional
         Whether to reraise when encountering an Assertion or AttributeError,
         by default False
+    skip_field: iterable, optional
+        A list or set containing keys to skip when comparing sessions
+        (Default is None)
 
     Returns
     -------
@@ -172,11 +175,18 @@ def sessions_are_equal(A, B, reraise=False) -> bool:
         Whether the two sessions are equal to one another.
     """
 
+    if skip_field is None:
+        skip_field = set()
+
     field_set = set()
     for key, val in A.__dict__.items():
+        if key in skip_field:
+            continue
         if isinstance(val, LazyProperty):
             field_set.add(key)
     for key, val in B.__dict__.items():
+        if key in skip_field:
+            continue
         if isinstance(val, LazyProperty):
             field_set.add(key)
 


### PR DESCRIPTION
… NWB files

As discussed in #1942, there are three sessions in which only the eye tracking data failed. This PR adds a command line argument `skip_eye_tracking` to the NWB writing queue that would skip the eye tracking data.

In order to make this work, I had to add a kwarg `skip_field` to `sessions_are_equal` which is a list or set of fields to skip when comparing the results from two sessions. This is how I get the "is the NWB file equivalent to the LIMS API result" validation step to pass. I'm sure this isn't the best possible solution. It is the one I came up with given time constraints. Feel free to push back on it.

<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
<!-- Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket
example:
Solution to this problem is to update the value of the pixel resolution
to a default x if pixel resolution is database pixel resolution =0. This
will address the underlying problem by providing a fallback value if
the data is not available. A downfall is if default resolution is disparate
from actual resolution that wasn't saved, images might appear very distorted.
An alternative solution is to update the database to cover the missing 
experiment resolutions.-->

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
