### PR TITLE
Add ability to skip adding eye tracking data for BehaviorOphysSession

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_json_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_json_api.py
@@ -14,9 +14,10 @@ class BehaviorOphysJsonApi(BehaviorOphysDataTransforms):
     a specified raw data source (extractor). Contains all methods
     needed to fill a BehaviorOphysSession."""
 
-    def __init__(self, data):
+    def __init__(self, data: dict, skip_eye_tracking: bool = False):
         extractor = BehaviorOphysJsonExtractor(data=data)
-        super().__init__(extractor=extractor)
+        super().__init__(extractor=extractor,
+                         skip_eye_tracking=skip_eye_tracking)
 
 
 class BehaviorOphysJsonExtractor(BehaviorJsonExtractor,

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_lims_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_lims_api.py
@@ -27,7 +27,8 @@ class BehaviorOphysLimsApi(BehaviorOphysDataTransforms,
                  ophys_experiment_id: Optional[int] = None,
                  lims_credentials: Optional[DbCredentials] = None,
                  mtrain_credentials: Optional[DbCredentials] = None,
-                 extractor: Optional[BehaviorOphysDataExtractorBase] = None):
+                 extractor: Optional[BehaviorOphysDataExtractorBase] = None,
+                 skip_eye_tracking: bool = False):
 
         if extractor is None:
             if ophys_experiment_id is not None:
@@ -40,7 +41,8 @@ class BehaviorOphysLimsApi(BehaviorOphysDataTransforms,
                     "BehaviorOphysLimsApi must be provided either an "
                     "instantiated 'extractor' or an 'ophys_experiment_id'!")
 
-        super().__init__(extractor=extractor)
+        super().__init__(extractor=extractor,
+                         skip_eye_tracking=skip_eye_tracking)
 
 
 class BehaviorOphysLimsExtractor(OphysLimsExtractor, BehaviorLimsExtractor,

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -156,11 +156,13 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
         # Add motion correction to NWB in-memory object:
         nwb.add_motion_correction(nwbfile, session_object.motion_correction)
 
-        # Add eye tracking and rig geometry to NWB in-memory object.
-        self.add_eye_tracking_data_to_nwb(
-            nwbfile=nwbfile,
-            eye_tracking_df=session_object.eye_tracking,
-            eye_tracking_rig_geometry=session_object.eye_tracking_rig_geometry)
+        # Add eye tracking and rig geometry to NWB in-memory object
+        # if eye_tracking data exists.
+        if session_object.eye_tracking:
+            self.add_eye_tracking_data_to_nwb(
+                nwbfile,
+                session_object.eye_tracking,
+                session_object.eye_tracking_rig_geometry)
 
         # Add events
         self.add_events(nwbfile=nwbfile, events=session_object.events)

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -158,7 +158,7 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
 
         # Add eye tracking and rig geometry to NWB in-memory object
         # if eye_tracking data exists.
-        if session_object.eye_tracking:
+        if session_object.eye_tracking is not None:
             self.add_eye_tracking_data_to_nwb(
                 nwbfile,
                 session_object.eye_tracking,

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -15,7 +15,9 @@ from allensdk.brain_observatory.argschema_utilities import (
 from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 
-def write_behavior_ophys_nwb(session_data, nwb_filepath):
+def write_behavior_ophys_nwb(session_data: dict,
+                             nwb_filepath: str,
+                             skip_eye_tracking: bool):
 
     nwb_filepath_inprogress = nwb_filepath+'.inprogress'
     nwb_filepath_error = nwb_filepath+'.error'
@@ -28,10 +30,12 @@ def write_behavior_ophys_nwb(session_data, nwb_filepath):
             os.remove(filename)
 
     try:
-        json_session = BehaviorOphysSession(
-            api=BehaviorOphysJsonApi(session_data))
+        json_api = BehaviorOphysJsonApi(data=session_data,
+                                        skip_eye_tracking=skip_eye_tracking)
+        json_session = BehaviorOphysSession(api=json_api)
         lims_api = BehaviorOphysLimsApi(
-            ophys_experiment_id=session_data['ophys_experiment_id'])
+            ophys_experiment_id=session_data['ophys_experiment_id'],
+            skip_eye_tracking=skip_eye_tracking)
         lims_session = BehaviorOphysSession(api=lims_api)
 
         logging.info("Comparing a BehaviorOphysSession created from JSON "
@@ -72,8 +76,10 @@ def main():
         raise err
 
     try:
+        skip_eye_tracking = parser.args['skip_eye_tracking']
         output = write_behavior_ophys_nwb(parser.args['session_data'],
-                                          parser.args['output_path'])
+                                          parser.args['output_path'],
+                                          skip_eye_tracking)
         logging.info('File successfully created')
     except Exception as err:
         logging.error('NWB write failure')

--- a/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
@@ -133,6 +133,10 @@ class InputSchema(ArgSchema):
                                       'used for this experiment')
     output_path = String(required=True, validate=check_write_access_overwrite,
                          description='write outputs to here')
+    skip_eye_tracking = Boolean(
+        required=True, default=False,
+        description="Whether or not to skip processing eye tracking data. "
+                    "If True, no eye tracking data will be written to NWB")
 
 
 class OutputSchema(RaisingSchema):


### PR DESCRIPTION
An alternative take to #1951.

This PR aims to address #1942 by adding a `skip_eye_tracking` param to the `BehaviorOphysJsonApi`, `BehaviorOphysLimsApi`, and `BehaviorOphysDataTransforms` classes. When set to true, it overrides default behavior for `get_eye_tracking_rig_geometry()` and `get_eye_tracking()` methods by making them return `None`. 

On the BehaviorOphysNwbApi side of things, the corresponding `get_eye_tracking` method already will return `None` if it does not find any eye tracking data in the NWB file. The only change that needed to be made was not to call  `add_eye_tracking_data_to_nwb` if the `eye_tracking` property of the `session` is `None`.

Validation:

Ran the following command:
```
python -m allensdk.brain_observatory.behavior.write_nwb --input_json /allen/scratch/aibstemp/nicholasm/programs/braintv/production/visualbehavior/prod4/specimen_1035958637/ophys_session_1050246780/ophys_experiment_1050406399/BEHAVIOR_OPHYS_WRITE_NWB_QUEUE_1050406399_input.json --output_json /allen/scratch/aibstemp/nicholasm/programs/braintv/production/visualbehavior/prod4/specimen_1035958637/ophys_session_1050246780/ophys_experiment_1050406399/202102190355_BEHAVIOR_OPHYS_WRITE_NWB_QUEUE_1050406399_output.json --skip_eye_tracking True
```

--------------------------------

NWB file without `--skip_eye_tracking True`:

![image](https://user-images.githubusercontent.com/43766899/109119876-191a7d00-76fa-11eb-905a-230a51213064.png)

----------------------------

NWB file with `--skip_eye_tracking True`:

![image](https://user-images.githubusercontent.com/43766899/109119908-26d00280-76fa-11eb-8bc9-0b105e1d4856.png)

---------------------------------

Resulting NWB files can be found at:
 /allen/scratch/aibstemp/nicholasm/programs/braintv/production/visualbehavior/prod4/specimen_1035958637/ophys_session_1050246780/ophys_experiment_1050406399/
