### PR TITLE
1919-time-column-names

### DIFF
--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -231,7 +231,7 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
     cr_areas[likely_blinks] = np.nan
     eye_areas[likely_blinks] = np.nan
 
-    eye_data.insert(0, "time", frame_times)
+    eye_data.insert(0, "timestamps", frame_times)
     eye_data.insert(1, "cr_area", cr_areas)
     eye_data.insert(2, "eye_area", eye_areas)
     eye_data.insert(3, "pupil_area", pupil_areas)

--- a/allensdk/brain_observatory/behavior/rewards_processing.py
+++ b/allensdk/brain_observatory/behavior/rewards_processing.py
@@ -1,7 +1,6 @@
 from typing import Dict
 import numpy as np
 import pandas as pd
-from collections import defaultdict
 
 
 def get_rewards(data: Dict,
@@ -31,7 +30,8 @@ def get_rewards(data: Dict,
     trial_df = pd.DataFrame(data["items"]["behavior"]["trial_log"])
     rewards_dict = {"volume": [], "timestamps": [], "autorewarded": []}
     for idx, trial in trial_df.iterrows():
-        rewards = trial["rewards"]  # as i write this there can only ever be one reward per trial
+        rewards = trial["rewards"]
+        # as i write this there can only ever be one reward per trial
         if rewards:
             rewards_dict["volume"].append(rewards[0][0])
             rewards_dict["timestamps"].append(timestamps[rewards[0][2]])

--- a/allensdk/brain_observatory/behavior/rewards_processing.py
+++ b/allensdk/brain_observatory/behavior/rewards_processing.py
@@ -38,6 +38,6 @@ def get_rewards(data: Dict,
             auto_rwrd = trial["trial_params"]["auto_reward"]
             rewards_dict["autorewarded"].append(auto_rwrd)
 
-    df = pd.DataFrame(rewards_dict).set_index("timestamps", drop=True)
+    df = pd.DataFrame(rewards_dict)
 
     return df

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
@@ -224,7 +224,7 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
             licks = lick_module.get_data_interface('licks')
 
             return pd.DataFrame({
-                'time': licks.timestamps[:],
+                'timestamps': licks.timestamps[:],
                 'frame': licks.data[:]
             })
         else:

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
@@ -238,11 +238,11 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
             volume = rewards.get_data_interface('volume').data[:]
             return pd.DataFrame({
                 'volume': volume, 'timestamps': time,
-                'autorewarded': autorewarded}).set_index('timestamps')
+                'autorewarded': autorewarded})
         else:
             return pd.DataFrame({
                 'volume': [], 'timestamps': [],
-                'autorewarded': []}).set_index('timestamps')
+                'autorewarded': []})
 
     def get_metadata(self) -> dict:
 

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -233,7 +233,7 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
             eye_tracking_acquisition.corneal_reflection_tracking
 
         eye_tracking_dict = {
-            "time": eye_tracking.timestamps[:],
+            "timestamps": eye_tracking.timestamps[:],
             "cr_area": corneal_reflection_tracking.area_raw[:],
             "eye_area": eye_tracking.area_raw[:],
             "pupil_area": pupil_tracking.area_raw[:],
@@ -480,7 +480,7 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
             width=eye_tracking_df['eye_width'].values,
             height=eye_tracking_df['eye_height'].values,
             angle=eye_tracking_df['eye_phi'].values,
-            timestamps=eye_tracking_df['time'].values
+            timestamps=eye_tracking_df['timestamps'].values
         )
 
         pupil_tracking = EllipseSeries(

--- a/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_transforms.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_transforms/behavior_data_transforms.py
@@ -110,7 +110,7 @@ class BehaviorDataTransforms(BehaviorBase):
                                   'range')
 
         lick_times = [stimulus_timestamps[frame] for frame in lick_frames]
-        return pd.DataFrame({"time": lick_times, "frame": lick_frames})
+        return pd.DataFrame({"timestamps": lick_times, "frame": lick_frames})
 
     @memoize
     def get_rewards(self) -> pd.DataFrame:

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -519,7 +519,6 @@ def get_trials_from_data_transform(input_transform) -> pd.DataFrame:
     monitor_delay = input_transform.get_monitor_delay()
     data = input_transform._behavior_stimulus_file()
 
-    assert rewards_df.index.name == 'timestamps'
     stimuli = data["items"]["behavior"]["stimuli"]
     trial_log = data["items"]["behavior"]["trial_log"]
 
@@ -527,7 +526,7 @@ def get_trials_from_data_transform(input_transform) -> pd.DataFrame:
 
     all_trial_data = [None] * len(trial_log)
     lick_frames = licks_df.frame.values
-    reward_times = rewards_df.index.values
+    reward_times = rewards_df['timestamps'].values
 
     for idx, trial in enumerate(trial_log):
         # match each event in the trial log to the sync timestamps

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -627,7 +627,7 @@ def get_time(exp_data):
 def data_to_licks(data, time):
     lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_events']
     lick_times = time[lick_frames]
-    return pd.DataFrame(data={"frame": lick_frames, 'time': lick_times})
+    return pd.DataFrame(data={"frame": lick_frames, 'timestamps': lick_times})
 
 
 def get_mouse_id(exp_data):
@@ -925,12 +925,12 @@ def find_licks(reward_times, licks, window=3.5):
         return []
     else:
         reward_time = one(reward_times)
-        reward_lick_mask = ((licks['time'] > reward_time) &
-                            (licks['time'] < (reward_time + window)))
+        reward_lick_mask = ((licks['timestamps'] > reward_time) &
+                            (licks['timestamps'] < (reward_time + window)))
 
         tr_licks = licks[reward_lick_mask].copy()
-        tr_licks['time'] -= reward_time
-        return tr_licks['time'].values
+        tr_licks['timestamps'] -= reward_time
+        return tr_licks['timestamps'].values
 
 
 def calculate_reward_rate(response_latency=None,

--- a/allensdk/brain_observatory/behavior/trials_processing.py
+++ b/allensdk/brain_observatory/behavior/trials_processing.py
@@ -627,7 +627,8 @@ def get_time(exp_data):
 def data_to_licks(data, time):
     lick_frames = data['items']['behavior']['lick_sensors'][0]['lick_events']
     lick_times = time[lick_frames]
-    return pd.DataFrame(data={"frame": lick_frames, 'timestamps': lick_times})
+    return pd.DataFrame(data={"timestamps": lick_times,
+                              "frame": lick_frames})
 
 
 def get_mouse_id(exp_data):

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -1066,7 +1066,8 @@ def add_corrected_fluorescence_traces(nwbfile, corrected_fluorescence_traces):
     ophys_module = nwbfile.processing['ophys']
     # trace data in the form of rois x timepoints
     f_trace_data = np.array(
-            corrected_fluorescence_traces.corrected_fluorescence)
+        [corrected_fluorescence_traces.loc[cell_roi_id].corrected_fluorescence
+         for cell_roi_id in corrected_fluorescence_traces.index.values])
 
     roi_table_region = nwbfile.processing['ophys'].data_interfaces['dff'].roi_response_series['traces'].rois  # noqa: E501
     ophys_timestamps = ophys_module.get_data_interface(

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -674,12 +674,10 @@ def add_licks(nwbfile, licks):
 
 
 def add_rewards(nwbfile, rewards_df):
-    assert rewards_df.index.name == 'timestamps'
-
     reward_volume_ts = TimeSeries(
         name='volume',
         data=rewards_df.volume.values,
-        timestamps=rewards_df.index.values,
+        timestamps=rewards_df['timestamps'].values,
         unit='mL'
     )
 

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -658,7 +658,7 @@ def add_licks(nwbfile, licks):
     lick_timeseries = TimeSeries(
         name='licks',
         data=licks.frame.values,
-        timestamps=licks.time.values,
+        timestamps=licks.timestamps.values,
         description=('Timestamps and stimulus presentation '
                      'frame indices for lick events'),
         unit='N/A'

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import Iterable, Union
+from typing import Iterable
 
 import h5py
 import marshmallow
@@ -17,10 +17,8 @@ from pynwb.image import GrayscaleImage, IndexSeries
 from pynwb.ophys import (
     DfOverF, ImageSegmentation, OpticalChannel, Fluorescence)
 
-from allensdk.brain_observatory.behavior.stimulus_processing.stimulus_templates import \
-    StimulusTemplate
-from allensdk.brain_observatory.behavior.write_nwb.extensions.stimulus_template.ndx_stimulus_template import \
-    StimulusTemplateExtension
+from allensdk.brain_observatory.behavior.stimulus_processing.stimulus_templates import StimulusTemplate  # noqa: E501
+from allensdk.brain_observatory.behavior.write_nwb.extensions.stimulus_template.ndx_stimulus_template import StimulusTemplateExtension  # noqa: E501
 from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
@@ -36,12 +34,12 @@ from allensdk.brain_observatory.nwb.metadata import load_pynwb_extension
 log = logging.getLogger("allensdk.brain_observatory.nwb")
 
 CELL_SPECIMEN_COL_DESCRIPTIONS = {
-    'cell_specimen_id': 'Unified id of segmented cell across experiments (after'
-                        ' cell matching)',
+    'cell_specimen_id': 'Unified id of segmented cell across experiments '
+                        '(after cell matching)',
     'height': 'Height of ROI in pixels',
     'width': 'Width of ROI in pixels',
-    'mask_image_plane': 'Which image plane an ROI resides on. Overlapping ROIs '
-                        'are stored on different mask image planes.',
+    'mask_image_plane': 'Which image plane an ROI resides on. Overlapping '
+                        'ROIs are stored on different mask image planes.',
     'max_correction_down': 'Max motion correction in down direction in pixels',
     'max_correction_left': 'Max motion correction in left direction in pixels',
     'max_correction_up': 'Max motion correction in up direction in pixels',
@@ -53,31 +51,31 @@ CELL_SPECIMEN_COL_DESCRIPTIONS = {
     'y': 'y position of ROI in Image Plane in pixels (top left corner)'
 }
 
+
 def check_nwbfile_version(nwbfile_path: str,
                           desired_minimum_version: str,
                           warning_msg: str):
-
-        with h5py.File(nwbfile_path, 'r') as f:
-            # nwb 2.x files store version as an attribute
+    with h5py.File(nwbfile_path, 'r') as f:
+        # nwb 2.x files store version as an attribute
+        try:
+            nwb_version = str(f.attrs["nwb_version"]).split(".")
+        except KeyError:
+            # nwb 1.x files store version as dataset
             try:
-                nwb_version = str(f.attrs["nwb_version"]).split(".")
-            except KeyError:
-                # nwb 1.x files store version as dataset
-                try:
-                    nwb_version = str(f["nwb_version"][...].astype(str))
-                    # Stored in the form: `NWB-x.y.z`
-                    nwb_version = nwb_version.split("-")[1].split(".")
-                except (KeyError, IndexError):
-                    nwb_version = None
+                nwb_version = str(f["nwb_version"][...].astype(str))
+                # Stored in the form: `NWB-x.y.z`
+                nwb_version = nwb_version.split("-")[1].split(".")
+            except (KeyError, IndexError):
+                nwb_version = None
 
-        if nwb_version is None:
-            warnings.warn(f"'{nwbfile_path}' doesn't appear to be a valid "
-                          f"Neurodata Without Borders (*.nwb) format file as "
-                          f"neither a 'nwb_version' field nor dataset could "
-                          f"be found!")
-        else:
-            if tuple(nwb_version) < tuple(desired_minimum_version.split(".")):
-                warnings.warn(warning_msg)
+    if nwb_version is None:
+        warnings.warn(f"'{nwbfile_path}' doesn't appear to be a valid "
+                      f"Neurodata Without Borders (*.nwb) format file as "
+                      f"neither a 'nwb_version' field nor dataset could "
+                      f"be found!")
+    else:
+        if tuple(nwb_version) < tuple(desired_minimum_version.split(".")):
+            warnings.warn(warning_msg)
 
 
 def read_eye_dlc_tracking_ellipses(input_path: Path) -> dict:
@@ -121,44 +119,58 @@ def read_eye_gaze_mappings(input_path: Path) -> dict:
             *_eye_areas: Area of eye (in pixels^2) over time
             *_pupil_areas: Area of pupil (in pixels^2) over time
             *_screen_coordinates: y, x screen coordinates (in cm) over time
-            *_screen_coordinates_spherical: y, x screen coordinates (in deg) over time
-            synced_frame_timestamps: synced timestamps for video frames (in sec)
+            *_screen_coordinates_spherical: y, x screen coordinates (in deg)
+             over time
+            synced_frame_timestamps: synced timestamps for video frames
+             (in sec)
     """
 
     eye_gaze_data = {}
-
-    eye_gaze_data["raw_eye_areas"] = pd.read_hdf(input_path, key="raw_eye_areas")
-    eye_gaze_data["raw_pupil_areas"] = pd.read_hdf(input_path, key="raw_pupil_areas")
-    eye_gaze_data["raw_screen_coordinates"] = pd.read_hdf(input_path, key="raw_screen_coordinates")
-    eye_gaze_data["raw_screen_coordinates_spherical"] = pd.read_hdf(input_path, key="raw_screen_coordinates_spherical")
-
-    eye_gaze_data["new_eye_areas"] = pd.read_hdf(input_path, key="new_eye_areas")
-    eye_gaze_data["new_pupil_areas"] = pd.read_hdf(input_path, key="new_pupil_areas")
-    eye_gaze_data["new_screen_coordinates"] = pd.read_hdf(input_path, key="new_screen_coordinates")
-    eye_gaze_data["new_screen_coordinates_spherical"] = pd.read_hdf(input_path, key="new_screen_coordinates_spherical")
-
-    eye_gaze_data["synced_frame_timestamps"] = pd.read_hdf(input_path, key="synced_frame_timestamps")
+    eye_gaze_data["raw_eye_areas"] = \
+        pd.read_hdf(input_path, key="raw_eye_areas")
+    eye_gaze_data["raw_pupil_areas"] = \
+        pd.read_hdf(input_path, key="raw_pupil_areas")
+    eye_gaze_data["raw_screen_coordinates"] = \
+        pd.read_hdf(input_path, key="raw_screen_coordinates")
+    eye_gaze_data["raw_screen_coordinates_spherical"] = \
+        pd.read_hdf(input_path, key="raw_screen_coordinates_spherical")
+    eye_gaze_data["new_eye_areas"] = \
+        pd.read_hdf(input_path, key="new_eye_areas")
+    eye_gaze_data["new_pupil_areas"] = \
+        pd.read_hdf(input_path, key="new_pupil_areas")
+    eye_gaze_data["new_screen_coordinates"] = \
+        pd.read_hdf(input_path, key="new_screen_coordinates")
+    eye_gaze_data["new_screen_coordinates_spherical"] = \
+        pd.read_hdf(input_path, key="new_screen_coordinates_spherical")
+    eye_gaze_data["synced_frame_timestamps"] = \
+        pd.read_hdf(input_path, key="synced_frame_timestamps")
 
     return eye_gaze_data
 
 
 def create_eye_gaze_mapping_dataframe(eye_gaze_data: dict) -> pd.DataFrame:
 
-    eye_gaze_mapping_df = pd.DataFrame(
-        {
-            "raw_eye_area": eye_gaze_data["raw_eye_areas"].values,
-            "raw_pupil_area": eye_gaze_data["raw_pupil_areas"].values,
-            "raw_screen_coordinates_x_cm": eye_gaze_data["raw_screen_coordinates"]["x_pos_cm"].values,
-            "raw_screen_coordinates_y_cm": eye_gaze_data["raw_screen_coordinates"]["y_pos_cm"].values,
-            "raw_screen_coordinates_spherical_x_deg": eye_gaze_data["raw_screen_coordinates_spherical"]["x_pos_deg"].values,
-            "raw_screen_coordinates_spherical_y_deg": eye_gaze_data["raw_screen_coordinates_spherical"]["y_pos_deg"].values,
-
-            "filtered_eye_area": eye_gaze_data["new_eye_areas"].values,
-            "filtered_pupil_area": eye_gaze_data["new_pupil_areas"].values,
-            "filtered_screen_coordinates_x_cm": eye_gaze_data["new_screen_coordinates"]["x_pos_cm"].values,
-            "filtered_screen_coordinates_y_cm": eye_gaze_data["new_screen_coordinates"]["y_pos_cm"].values,
-            "filtered_screen_coordinates_spherical_x_deg": eye_gaze_data["new_screen_coordinates_spherical"]["x_pos_deg"].values,
-            "filtered_screen_coordinates_spherical_y_deg": eye_gaze_data["new_screen_coordinates_spherical"]["y_pos_deg"].values
+    eye_gaze_mapping_df = pd.DataFrame({
+        "raw_eye_area": eye_gaze_data["raw_eye_areas"].values,
+        "raw_pupil_area": eye_gaze_data["raw_pupil_areas"].values,
+        "raw_screen_coordinates_x_cm":
+        eye_gaze_data["raw_screen_coordinates"]["x_pos_cm"].values,
+        "raw_screen_coordinates_y_cm":
+        eye_gaze_data["raw_screen_coordinates"]["y_pos_cm"].values,
+        "raw_screen_coordinates_spherical_x_deg":
+        eye_gaze_data["raw_screen_coordinates_spherical"]["x_pos_deg"].values,
+        "raw_screen_coordinates_spherical_y_deg":
+        eye_gaze_data["raw_screen_coordinates_spherical"]["y_pos_deg"].values,
+        "filtered_eye_area": eye_gaze_data["new_eye_areas"].values,
+        "filtered_pupil_area": eye_gaze_data["new_pupil_areas"].values,
+        "filtered_screen_coordinates_x_cm":
+        eye_gaze_data["new_screen_coordinates"]["x_pos_cm"].values,
+        "filtered_screen_coordinates_y_cm":
+        eye_gaze_data["new_screen_coordinates"]["y_pos_cm"].values,
+        "filtered_screen_coordinates_spherical_x_deg":
+        eye_gaze_data["new_screen_coordinates_spherical"]["x_pos_deg"].values,
+        "filtered_screen_coordinates_spherical_y_deg":
+        eye_gaze_data["new_screen_coordinates_spherical"]["y_pos_deg"].values
         },
         index=eye_gaze_data["synced_frame_timestamps"].values
     )
@@ -187,31 +199,37 @@ def eye_tracking_data_is_valid(eye_dlc_tracking_data: dict,
         log.warn("The number of camera sync pulses in the "
                  f"sync file ({len(synced_timestamps)}) do not match "
                  "with the number of eye tracking frames "
-                 f"({pupil_params.shape[0]})! No ellipse fits will be written!")
+                 f"({pupil_params.shape[0]})! No ellipse fits will be "
+                 "written!")
         is_valid = False
 
     return is_valid
 
 
 def create_eye_tracking_nwb_processing_module(eye_dlc_tracking_data: dict,
-                                              synced_timestamps: pd.Series) -> pynwb.ProcessingModule:
+                                              synced_timestamps: pd.Series
+                                              ) -> pynwb.ProcessingModule:
 
     # Top level container for eye tracking processed data
-    eye_tracking_mod = pynwb.ProcessingModule(name='eye_tracking',
-                                              description='Eye tracking processing module')
+    eye_tracking_mod = pynwb.ProcessingModule(
+            name='eye_tracking',
+            description='Eye tracking processing module')
 
     # Data interfaces of dlc_fits_container
-    pupil_fits = eye_dlc_tracking_data["pupil_params"].assign(timestamps=synced_timestamps)
-    pupil_params = pynwb.core.DynamicTable.from_dataframe(df=pupil_fits,
-                                                          name="pupil_ellipse_fits")
+    pupil_fits = eye_dlc_tracking_data["pupil_params"].assign(
+            timestamps=synced_timestamps)
+    pupil_params = pynwb.core.DynamicTable.from_dataframe(
+            df=pupil_fits, name="pupil_ellipse_fits")
 
-    cr_fits = eye_dlc_tracking_data["cr_params"].assign(timestamps=synced_timestamps)
+    cr_fits = eye_dlc_tracking_data["cr_params"].assign(
+            timestamps=synced_timestamps)
     cr_params = pynwb.core.DynamicTable.from_dataframe(df=cr_fits,
                                                        name="cr_ellipse_fits")
 
-    eye_fits = eye_dlc_tracking_data["eye_params"].assign(timestamps=synced_timestamps)
-    eye_params = pynwb.core.DynamicTable.from_dataframe(df=eye_fits,
-                                                        name="eye_ellipse_fits")
+    eye_fits = eye_dlc_tracking_data["eye_params"].assign(
+            timestamps=synced_timestamps)
+    eye_params = pynwb.core.DynamicTable.from_dataframe(
+            df=eye_fits, name="eye_ellipse_fits")
 
     eye_tracking_mod.add_data_interface(pupil_params)
     eye_tracking_mod.add_data_interface(cr_params)
@@ -225,7 +243,8 @@ def add_eye_gaze_data_interfaces(pynwb_container: pynwb.NWBContainer,
                                  eye_areas: pd.Series,
                                  screen_coordinates: pd.DataFrame,
                                  screen_coordinates_spherical: pd.DataFrame,
-                                 synced_timestamps: pd.Series) -> pynwb.NWBContainer:
+                                 synced_timestamps: pd.Series
+                                 ) -> pynwb.NWBContainer:
 
     pupil_area_ts = pynwb.base.TimeSeries(
         name="pupil_area",
@@ -265,35 +284,40 @@ def add_eye_gaze_data_interfaces(pynwb_container: pynwb.NWBContainer,
 
 def create_gaze_mapping_nwb_processing_modules(eye_gaze_data: dict):
     # Container for raw gaze mapped data
-    raw_gaze_mapping_mod = pynwb.ProcessingModule(name='raw_gaze_mapping',
-                                                  description='Gaze mapping processing module raw outputs')
+    raw_gaze_mapping_mod = pynwb.ProcessingModule(
+            name='raw_gaze_mapping',
+            description='Gaze mapping processing module raw outputs')
 
-    raw_gaze_mapping_mod = add_eye_gaze_data_interfaces(raw_gaze_mapping_mod,
-                                                        pupil_areas=eye_gaze_data["raw_pupil_areas"],
-                                                        eye_areas=eye_gaze_data["raw_eye_areas"],
-                                                        screen_coordinates=eye_gaze_data["raw_screen_coordinates"],
-                                                        screen_coordinates_spherical=eye_gaze_data["raw_screen_coordinates_spherical"],
-                                                        synced_timestamps=eye_gaze_data["synced_frame_timestamps"])
+    raw_gaze_mapping_mod = add_eye_gaze_data_interfaces(
+            raw_gaze_mapping_mod,
+            pupil_areas=eye_gaze_data["raw_pupil_areas"],
+            eye_areas=eye_gaze_data["raw_eye_areas"],
+            screen_coordinates=eye_gaze_data["raw_screen_coordinates"],
+            screen_coordinates_spherical=eye_gaze_data["raw_screen_coordinates_spherical"],  # noqa: E501
+            synced_timestamps=eye_gaze_data["synced_frame_timestamps"])
 
     # Container for filtered gaze mapped data
-    filt_gaze_mapping_mod = pynwb.ProcessingModule(name='filtered_gaze_mapping',
-                                                   description='Gaze mapping processing module filtered outputs')
+    filt_gaze_mapping_mod = pynwb.ProcessingModule(
+            name='filtered_gaze_mapping',
+            description='Gaze mapping processing module filtered outputs')
 
-    filt_gaze_mapping_mod = add_eye_gaze_data_interfaces(filt_gaze_mapping_mod,
-                                                         pupil_areas=eye_gaze_data["new_pupil_areas"],
-                                                         eye_areas=eye_gaze_data["new_eye_areas"],
-                                                         screen_coordinates=eye_gaze_data["new_screen_coordinates"],
-                                                         screen_coordinates_spherical=eye_gaze_data["new_screen_coordinates_spherical"],
-                                                         synced_timestamps=eye_gaze_data["synced_frame_timestamps"])
+    filt_gaze_mapping_mod = add_eye_gaze_data_interfaces(
+        filt_gaze_mapping_mod,
+        pupil_areas=eye_gaze_data["new_pupil_areas"],
+        eye_areas=eye_gaze_data["new_eye_areas"],
+        screen_coordinates=eye_gaze_data["new_screen_coordinates"],
+        screen_coordinates_spherical=eye_gaze_data["new_screen_coordinates_spherical"],  # noqa: E501
+        synced_timestamps=eye_gaze_data["synced_frame_timestamps"])
 
     return (raw_gaze_mapping_mod, filt_gaze_mapping_mod)
 
 
 def add_eye_tracking_ellipse_fit_data_to_nwbfile(nwbfile: pynwb.NWBFile,
                                                  eye_dlc_tracking_data: dict,
-                                                 synced_timestamps: pd.Series) -> pynwb.NWBFile:
-    eye_tracking_mod = create_eye_tracking_nwb_processing_module(eye_dlc_tracking_data,
-                                                                 synced_timestamps)
+                                                 synced_timestamps: pd.Series
+                                                 ) -> pynwb.NWBFile:
+    eye_tracking_mod = create_eye_tracking_nwb_processing_module(
+            eye_dlc_tracking_data, synced_timestamps)
     nwbfile.add_processing_module(eye_tracking_mod)
 
     return nwbfile
@@ -301,7 +325,8 @@ def add_eye_tracking_ellipse_fit_data_to_nwbfile(nwbfile: pynwb.NWBFile,
 
 def add_eye_gaze_mapping_data_to_nwbfile(nwbfile: pynwb.NWBFile,
                                          eye_gaze_data: dict) -> pynwb.NWBFile:
-    raw_gaze_mapping_mod, filt_gaze_mapping_mod = create_gaze_mapping_nwb_processing_modules(eye_gaze_data)
+    raw_gaze_mapping_mod, filt_gaze_mapping_mod = \
+        create_gaze_mapping_nwb_processing_modules(eye_gaze_data)
     nwbfile.add_processing_module(raw_gaze_mapping_mod)
     nwbfile.add_processing_module(filt_gaze_mapping_mod)
 
@@ -434,11 +459,13 @@ def add_stimulus_template(nwbfile: NWBFile,
     return nwbfile
 
 
-def create_stimulus_presentation_time_interval(name: str, description: str,
-                                               columns_to_add: Iterable) -> pynwb.epoch.TimeIntervals:
+def create_stimulus_presentation_time_interval(
+        name: str, description: str,
+        columns_to_add: Iterable) -> pynwb.epoch.TimeIntervals:
     column_descriptions = {
         "stimulus_name": "Name of stimulus",
-        "stimulus_block": "Index of contiguous presentations of one stimulus type",
+        "stimulus_block": ("Index of contiguous presentations of "
+                           "one stimulus type"),
         "temporal_frequency": "Temporal frequency of stimulus",
         "x_position": "Horizontal position of stimulus on screen",
         "y_position": "Vertical position of stimulus on screen",
@@ -470,13 +497,15 @@ def create_stimulus_presentation_time_interval(name: str, description: str,
 
     for column_name in columns_to_add:
         if column_name not in columns_to_ignore:
-            description = column_descriptions.get(column_name, "No description")
+            description = column_descriptions.get(
+                    column_name, "No description")
             interval.add_column(name=column_name, description=description)
 
     return interval
 
 
-def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_interval'):
+def add_stimulus_presentations(nwbfile, stimulus_table,
+                               tag='stimulus_time_interval'):
     """Adds a stimulus table (defining stimulus characteristics for each
     time point in a session) to an nwbfile as TimeIntervals.
 
@@ -484,9 +513,10 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
     ----------
     nwbfile : pynwb.NWBFile
     stimulus_table: pd.DataFrame
-        Each row corresponds to an interval of time. Columns define the interval
-        (start and stop time) and its characteristics.
-        Nans in columns with string data will be replaced with the empty strings.
+        Each row corresponds to an interval of time. Columns define the
+        interval (start and stop time) and its characteristics.
+        Nans in columns with string data will be replaced with the empty
+        strings.
         Required columns are:
             start_time :: the time at which this interval started
             stop_time :: the time  at which this interval ended
@@ -507,7 +537,7 @@ def add_stimulus_presentations(nwbfile, stimulus_table, tag='stimulus_time_inter
     stimulus_names = stimulus_table[stimulus_name_column].unique()
 
     for stim_name in sorted(stimulus_names):
-        specific_stimulus_table = stimulus_table[stimulus_table[stimulus_name_column] == stim_name]
+        specific_stimulus_table = stimulus_table[stimulus_table[stimulus_name_column] == stim_name]  # noqa: E501
         # Drop columns where all values in column are NaN
         cleaned_table = specific_stimulus_table.dropna(axis=1, how='all')
         # For columns with mixed strings and NaNs, fill NaNs with 'N/A'
@@ -579,7 +609,8 @@ def setup_table_for_invalid_times(invalid_epochs):
 
     Returns
     -------
-    pd.DataFrame of invalid times if epochs are not empty, otherwise return None
+    pd.DataFrame of invalid times if epochs are not empty,
+    otherwise return None
     """
 
     if invalid_epochs:
@@ -604,21 +635,23 @@ def setup_table_for_invalid_times(invalid_epochs):
 
 
 def setup_table_for_epochs(table, timeseries, tag):
-
     table = table.copy()
-    indices = np.searchsorted(timeseries.timestamps[:], table['start_time'].values)
+    indices = np.searchsorted(timeseries.timestamps[:],
+                              table['start_time'].values)
     if len(indices > 0):
-        diffs = np.concatenate([np.diff(indices), [table.shape[0] - indices[-1]]])
+        diffs = np.concatenate([np.diff(indices),
+                                [table.shape[0] - indices[-1]]])
     else:
         diffs = []
 
     table['tags'] = [(tag,)] * table.shape[0]
-    table['timeseries'] = [[[indices[ii], diffs[ii], timeseries]] for ii in range(table.shape[0])]
+    table['timeseries'] = [[[indices[ii], diffs[ii], timeseries]]
+                           for ii in range(table.shape[0])]
     return table
 
 
-def add_stimulus_timestamps(nwbfile, stimulus_timestamps, module_name='stimulus'):
-
+def add_stimulus_timestamps(nwbfile, stimulus_timestamps,
+                            module_name='stimulus'):
     stimulus_ts = TimeSeries(
         data=stimulus_timestamps,
         name='timestamps',
@@ -635,22 +668,32 @@ def add_stimulus_timestamps(nwbfile, stimulus_timestamps, module_name='stimulus'
 
 
 def add_trials(nwbfile, trials, description_dict={}):
-
     order = list(trials.index)
     for _, row in trials[['start_time', 'stop_time']].iterrows():
         row_dict = row.to_dict()
         nwbfile.add_trial(**row_dict)
 
-    for c in [c for c in trials.columns if c not in ['start_time', 'stop_time']]:
+    for c in trials.columns:
+        if c in ['start_time', 'stop_time']:
+            continue
         index, data = dict_to_indexed_array(trials[c].to_dict(), order)
         if data.dtype == '<U1':  # data type is composed of unicode characters
             data = trials[c].tolist()
         if not len(data) == len(order):
             if len(data) == 0:
                 data = ['']
-            nwbfile.add_trial_column(name=c, description=description_dict.get(c, 'NOT IMPLEMENTED: %s' % c), data=data, index=index)
+            nwbfile.add_trial_column(
+                    name=c,
+                    description=description_dict.get(
+                        c, 'NOT IMPLEMENTED: %s' % c),
+                    data=data,
+                    index=index)
         else:
-            nwbfile.add_trial_column(name=c, description=description_dict.get(c, 'NOT IMPLEMENTED: %s' % c), data=data)
+            nwbfile.add_trial_column(
+                    name=c,
+                    description=description_dict.get(
+                        c, 'NOT IMPLEMENTED: %s' % c),
+                    data=data)
 
 
 def add_licks(nwbfile, licks):
@@ -688,7 +731,8 @@ def add_rewards(nwbfile, rewards_df):
         unit='mL'
     )
 
-    rewards_mod = ProcessingModule('rewards', 'Licking behavior processing module')
+    rewards_mod = ProcessingModule('rewards',
+                                   'Licking behavior processing module')
     rewards_mod.add_data_interface(reward_volume_ts)
     rewards_mod.add_data_interface(autorewarded_ts)
     nwbfile.add_processing_module(rewards_mod)
@@ -696,7 +740,8 @@ def add_rewards(nwbfile, rewards_df):
     return nwbfile
 
 
-def add_image(nwbfile, image_data, image_name, module_name, module_description, image_api=None):
+def add_image(nwbfile, image_data, image_name, module_name,
+              module_description, image_api=None):
 
     description = '{} image at pixels/cm resolution'.format(image_name)
 
@@ -710,7 +755,8 @@ def add_image(nwbfile, image_data, image_name, module_name, module_description, 
         spacing = image_data.spacing
         unit = image_data.unit
     else:
-        raise ValueError("Not a supported image_data type: {}".format(type(image_data)))
+        raise ValueError("Not a supported image_data type: "
+                         f"{type(image_data)}")
 
     assert spacing[0] == spacing[1] and len(spacing) == 2 and unit == 'mm'
 
@@ -720,7 +766,10 @@ def add_image(nwbfile, image_data, image_name, module_name, module_description, 
     else:
         ophys_mod = nwbfile.processing[module_name]
 
-    image = GrayscaleImage(image_name, data, resolution=spacing[0] / 10, description=description)
+    image = GrayscaleImage(image_name,
+                           data,
+                           resolution=spacing[0] / 10,
+                           description=description)
 
     if 'images' not in ophys_mod.containers:
         images = Images(name='images')
@@ -733,18 +782,32 @@ def add_image(nwbfile, image_data, image_name, module_name, module_description, 
 
 
 def add_max_projection(nwbfile, max_projection, image_api=None):
-
-    add_image(nwbfile, max_projection, 'max_projection', 'ophys', 'Ophys processing module', image_api=image_api)
+    add_image(nwbfile,
+              max_projection,
+              'max_projection',
+              'ophys',
+              'Ophys processing module',
+              image_api=image_api)
 
 
 def add_average_image(nwbfile, average_image, image_api=None):
+    add_image(nwbfile,
+              average_image,
+              'average_image',
+              'ophys',
+              'Ophys processing module',
+              image_api=image_api)
 
-    add_image(nwbfile, average_image, 'average_image', 'ophys', 'Ophys processing module', image_api=image_api)
 
-
-def add_segmentation_mask_image(nwbfile, segmentation_mask_image, image_api=None):
-
-    add_image(nwbfile, segmentation_mask_image, 'segmentation_mask_image', 'ophys', 'Ophys processing module', image_api=image_api)
+def add_segmentation_mask_image(nwbfile,
+                                segmentation_mask_image,
+                                image_api=None):
+    add_image(nwbfile,
+              segmentation_mask_image,
+              'segmentation_mask_image',
+              'ophys',
+              'Ophys processing module',
+              image_api=image_api)
 
 
 def add_stimulus_index(nwbfile, stimulus_index, nwb_template):
@@ -837,7 +900,8 @@ def add_task_parameters(nwbfile, task_parameters):
             new_task_parameters_dict[key] = np.array(val)
         else:
             new_task_parameters_dict[key] = val
-    nwb_task_parameters = OphysBehaviorTaskParameters(name='task_parameters', **new_task_parameters_dict)
+    nwb_task_parameters = OphysBehaviorTaskParameters(
+            name='task_parameters', **new_task_parameters_dict)
     nwbfile.add_lab_meta_data(nwb_task_parameters)
 
 
@@ -933,14 +997,17 @@ def add_cell_specimen_table(nwbfile: NWBFile,
         imaging_plane=imaging_plane)
 
     for col_name in cell_roi_table.columns:
-        # the columns 'roi_mask', 'pixel_mask', and 'voxel_mask' are already defined
-        # in the nwb.ophys::PlaneSegmentation Object
-        if col_name not in ['id', 'mask_matrix', 'roi_mask', 'pixel_mask', 'voxel_mask']:
-            # This builds the columns with name of column and description of column
-            # both equal to the column name in the cell_roi_table
-            plane_segmentation.add_column(col_name,
-                                          CELL_SPECIMEN_COL_DESCRIPTIONS.get(col_name,
-                                                                             "No Description Available"))
+        # the columns 'roi_mask', 'pixel_mask', and 'voxel_mask' are
+        # already defined in the nwb.ophys::PlaneSegmentation Object
+        if col_name not in ['id', 'mask_matrix', 'roi_mask',
+                            'pixel_mask', 'voxel_mask']:
+            # This builds the columns with name of column and description
+            # of column both equal to the column name in the cell_roi_table
+            plane_segmentation.add_column(
+                    col_name,
+                    CELL_SPECIMEN_COL_DESCRIPTIONS.get(
+                        col_name,
+                        "No Description Available"))
 
     # go through each roi and add it to the plan segmentation object
     for cell_roi_id, table_row in cell_roi_table.iterrows():
@@ -969,7 +1036,7 @@ def add_dff_traces(nwbfile, dff_traces, ophys_timestamps):
     trace_data = np.array([dff_traces.loc[cell_roi_id].dff
                            for cell_roi_id in dff_traces.index.values])
 
-    cell_specimen_table = nwbfile.processing['ophys'].data_interfaces['image_segmentation'].plane_segmentations['cell_specimen_table']
+    cell_specimen_table = nwbfile.processing['ophys'].data_interfaces['image_segmentation'].plane_segmentations['cell_specimen_table']  # noqa: E501
     roi_table_region = cell_specimen_table.create_roi_table_region(
         description="segmented cells labeled by cell_specimen_id",
         region=slice(len(dff_traces)))
@@ -990,17 +1057,20 @@ def add_dff_traces(nwbfile, dff_traces, ophys_timestamps):
 
 
 def add_corrected_fluorescence_traces(nwbfile, corrected_fluorescence_traces):
-    corrected_fluorescence_traces = corrected_fluorescence_traces.reset_index().set_index('cell_roi_id')[['corrected_fluorescence']]
+    corrected_fluorescence_traces = \
+        corrected_fluorescence_traces.reset_index().set_index(
+                'cell_roi_id')[['corrected_fluorescence']]
 
     # Create/Add corrected_fluorescence_traces modules and interfaces:
     assert corrected_fluorescence_traces.index.name == 'cell_roi_id'
     ophys_module = nwbfile.processing['ophys']
     # trace data in the form of rois x timepoints
-    f_trace_data = np.array([corrected_fluorescence_traces.loc[cell_roi_id].corrected_fluorescence
-                             for cell_roi_id in corrected_fluorescence_traces.index.values])
+    f_trace_data = np.array(
+            corrected_fluorescence_traces.corrected_fluorescence)
 
-    roi_table_region = nwbfile.processing['ophys'].data_interfaces['dff'].roi_response_series['traces'].rois
-    ophys_timestamps = ophys_module.get_data_interface('dff').roi_response_series['traces'].timestamps
+    roi_table_region = nwbfile.processing['ophys'].data_interfaces['dff'].roi_response_series['traces'].rois  # noqa: E501
+    ophys_timestamps = ophys_module.get_data_interface(
+            'dff').roi_response_series['traces'].timestamps
     f_interface = Fluorescence(name='corrected_fluorescence')
     ophys_module.add_data_interface(f_interface)
 
@@ -1017,7 +1087,8 @@ def add_corrected_fluorescence_traces(nwbfile, corrected_fluorescence_traces):
 def add_motion_correction(nwbfile, motion_correction):
 
     ophys_module = nwbfile.processing['ophys']
-    ophys_timestamps = ophys_module.get_data_interface('dff').roi_response_series['traces'].timestamps
+    ophys_timestamps = ophys_module.get_data_interface(
+            'dff').roi_response_series['traces'].timestamps
 
     t1 = TimeSeries(
         name='ophys_motion_correction_x',

--- a/allensdk/test/brain_observatory/behavior/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/conftest.py
@@ -96,8 +96,8 @@ def licks():
 @pytest.fixture
 def rewards():
     return pd.DataFrame({'volume': [.01, .01, .01],
-                         'autorewarded': [True, False, False]},
-                        index=pd.Index(data=[1., 2., 3.], name='timestamps'))
+                         'timestamps': [1., 2., 3.],
+                         'autorewarded': [True, False, False]})
 
 
 @pytest.fixture

--- a/allensdk/test/brain_observatory/behavior/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/conftest.py
@@ -90,7 +90,8 @@ def trials():
 
 @pytest.fixture
 def licks():
-    return pd.DataFrame({'time': [1., 2., 3.], 'frame': [4., 5., 6.]})
+    return pd.DataFrame({'timestamps': [1., 2., 3.],
+                         'frame': [4., 5., 6.]})
 
 
 @pytest.fixture

--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
@@ -90,7 +90,7 @@ def test_get_rewards(monkeypatch):
                          'timestamps': [0.04, 0.1],
                          'autorewarded': [True, False]}
         expected_df = pd.DataFrame(expected_dict)
-        expected_df = expected_df.set_index('timestamps', drop=True)
+        expected_df = expected_df
         assert expected_df.equals(rewards)
 
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
@@ -329,4 +329,4 @@ def test_get_licks_failure(monkeypatch):
 
         xforms = BehaviorDataTransforms()
         with pytest.raises(IndexError):
-            _ = xforms.get_licks()
+            xforms.get_licks()

--- a/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_data_xforms.py
@@ -144,12 +144,12 @@ def test_get_licks(monkeypatch):
 
         licks = xforms.get_licks()
 
-        expected_dict = {'time': [0.12, 0.15, 0.90, 1.36],
+        expected_dict = {'timestamps': [0.12, 0.15, 0.90, 1.36],
                          'frame': [12, 15, 90, 136]}
         expected_df = pd.DataFrame(expected_dict)
         assert expected_df.columns.equals(licks.columns)
-        np.testing.assert_array_almost_equal(expected_df.time.to_numpy(),
-                                             licks.time.to_numpy(),
+        np.testing.assert_array_almost_equal(expected_df.timestamps.to_numpy(),
+                                             licks.timestamps.to_numpy(),
                                              decimal=10)
         np.testing.assert_array_almost_equal(expected_df.frame.to_numpy(),
                                              licks.frame.to_numpy(),
@@ -206,12 +206,12 @@ def test_empty_licks(monkeypatch):
 
         licks = xforms.get_licks()
 
-        expected_dict = {'time': [],
+        expected_dict = {'timestamps': [],
                          'frame': []}
         expected_df = pd.DataFrame(expected_dict)
         assert expected_df.columns.equals(licks.columns)
-        np.testing.assert_array_equal(expected_df.time.to_numpy(),
-                                      licks.time.to_numpy())
+        np.testing.assert_array_equal(expected_df.timestamps.to_numpy(),
+                                      licks.timestamps.to_numpy())
         np.testing.assert_array_equal(expected_df.frame.to_numpy(),
                                       licks.frame.to_numpy())
 
@@ -269,12 +269,12 @@ def test_get_licks_excess(monkeypatch):
 
         licks = xforms.get_licks()
 
-        expected_dict = {'time': [0.12, 0.15, 0.90, 1.36],
+        expected_dict = {'timestamps': [0.12, 0.15, 0.90, 1.36],
                          'frame': [12, 15, 90, 136]}
         expected_df = pd.DataFrame(expected_dict)
         assert expected_df.columns.equals(licks.columns)
-        np.testing.assert_array_almost_equal(expected_df.time.to_numpy(),
-                                             licks.time.to_numpy(),
+        np.testing.assert_array_almost_equal(expected_df.timestamps.to_numpy(),
+                                             licks.timestamps.to_numpy(),
                                              decimal=10)
         np.testing.assert_array_almost_equal(expected_df.frame.to_numpy(),
                                              licks.frame.to_numpy(),

--- a/allensdk/test/brain_observatory/behavior/test_behavior_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_lims_api.py
@@ -273,9 +273,8 @@ class TestBehaviorRegression:
                 == self.od.extractor.get_behavior_stimulus_file())
 
     def test_get_rewards_regression(self):
-        """Index is timestamps here, so remove it before comparing."""
-        bd_rewards = self.bd.get_rewards().reset_index(drop=True)
-        od_rewards = self.od.get_rewards().reset_index(drop=True)
+        bd_rewards = self.bd.get_rewards().drop(columns=['timestamps'])
+        od_rewards = self.od.get_rewards().drop(columns=['timestamps'])
         pd.testing.assert_frame_equal(bd_rewards, od_rewards)
 
     def test_ophys_experiment_id_regression(self):

--- a/allensdk/test/brain_observatory/behavior/test_behavior_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_lims_api.py
@@ -201,7 +201,7 @@ def test_get_stimulus_timestamps(MockBehaviorLimsApi):
 
 def test_get_licks(MockBehaviorLimsApi):
     api = MockBehaviorLimsApi
-    expected = pd.DataFrame({"time": [0.016 * i for i in [2., 6., 9.]],
+    expected = pd.DataFrame({"timestamps": [0.016 * i for i in [2., 6., 9.]],
                              "frame": [2, 6, 9]})
     pd.testing.assert_frame_equal(expected, api.get_licks())
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_data_xforms.py
@@ -336,7 +336,7 @@ def test_get_licks_failure(monkeypatch):
 
         xforms = BehaviorOphysDataTransforms()
         with pytest.raises(IndexError):
-            _ = xforms.get_licks()
+            xforms.get_licks()
 
 
 def test_timestamps_and_delay(monkeypatch):
@@ -493,4 +493,4 @@ def test_monitor_delay(monkeypatch):
 
         xforms = BehaviorOphysDataTransforms()
         with pytest.raises(RuntimeError):
-            _ = xforms.get_monitor_delay()
+            xforms.get_monitor_delay()

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_data_xforms.py
@@ -97,7 +97,7 @@ def test_get_rewards(monkeypatch):
                          'timestamps': [0.04, 0.1],
                          'autorewarded': [True, False]}
         expected_df = pd.DataFrame(expected_dict)
-        expected_df = expected_df.set_index('timestamps', drop=True)
+        expected_df = expected_df
         assert expected_df.equals(rewards)
 
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_data_xforms.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_data_xforms.py
@@ -151,12 +151,12 @@ def test_get_licks(monkeypatch):
 
         licks = xforms.get_licks()
 
-        expected_dict = {'time': [0.12, 0.15, 0.90, 1.36],
+        expected_dict = {'timestamps': [0.12, 0.15, 0.90, 1.36],
                          'frame': [12, 15, 90, 136]}
         expected_df = pd.DataFrame(expected_dict)
         assert expected_df.columns.equals(licks.columns)
-        np.testing.assert_array_almost_equal(expected_df.time.to_numpy(),
-                                             licks.time.to_numpy(),
+        np.testing.assert_array_almost_equal(expected_df.timestamps.to_numpy(),
+                                             licks.timestamps.to_numpy(),
                                              decimal=10)
         np.testing.assert_array_almost_equal(expected_df.frame.to_numpy(),
                                              licks.frame.to_numpy(),
@@ -216,12 +216,12 @@ def test_get_licks_excess(monkeypatch):
 
         licks = xforms.get_licks()
 
-        expected_dict = {'time': [0.12, 0.15, 0.90, 1.36],
+        expected_dict = {'timestamps': [0.12, 0.15, 0.90, 1.36],
                          'frame': [12, 15, 90, 136]}
         expected_df = pd.DataFrame(expected_dict)
         assert expected_df.columns.equals(licks.columns)
-        np.testing.assert_array_almost_equal(expected_df.time.to_numpy(),
-                                             licks.time.to_numpy(),
+        np.testing.assert_array_almost_equal(expected_df.timestamps.to_numpy(),
+                                             licks.timestamps.to_numpy(),
                                              decimal=10)
         np.testing.assert_array_almost_equal(expected_df.frame.to_numpy(),
                                              licks.frame.to_numpy(),
@@ -278,12 +278,12 @@ def test_empty_licks(monkeypatch):
 
         licks = xforms.get_licks()
 
-        expected_dict = {'time': [],
+        expected_dict = {'timestamps': [],
                          'frame': []}
         expected_df = pd.DataFrame(expected_dict)
         assert expected_df.columns.equals(licks.columns)
-        np.testing.assert_array_equal(expected_df.time.to_numpy(),
-                                      licks.time.to_numpy())
+        np.testing.assert_array_equal(expected_df.timestamps.to_numpy(),
+                                      licks.timestamps.to_numpy())
         np.testing.assert_array_equal(expected_df.frame.to_numpy(),
                                       licks.frame.to_numpy())
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -1,7 +1,6 @@
 import os
 import datetime
 import uuid
-import math
 import pytest
 import pandas as pd
 import pytz
@@ -74,7 +73,7 @@ def test_visbeh_ophys_data_set():
 
     # All sorts of assert relationships:
     assert data_set.api.extractor.get_foraging_id() == \
-           str(data_set.api.get_behavior_session_uuid())
+        str(data_set.api.get_behavior_session_uuid())
 
     stimulus_templates = data_set._stimulus_templates
     assert len(stimulus_templates) == 8
@@ -82,17 +81,17 @@ def test_visbeh_ophys_data_set():
     assert stimulus_templates['im000'].unwarped.shape == MONITOR_DIMENSIONS
 
     assert len(data_set.licks) == 2421 and set(data_set.licks.columns) \
-           == set(['timestamps', 'frame'])
+        == set(['timestamps', 'frame'])
     assert len(data_set.rewards) == 85 and set(data_set.rewards.columns) == \
-           set(['timestamps', 'volume', 'autorewarded'])
+        set(['timestamps', 'volume', 'autorewarded'])
     assert len(data_set.corrected_fluorescence_traces) == 258 and \
-           set(data_set.corrected_fluorescence_traces.columns) == \
-           set(['cell_roi_id', 'corrected_fluorescence'])
+        set(data_set.corrected_fluorescence_traces.columns) == \
+        set(['cell_roi_id', 'corrected_fluorescence'])
     np.testing.assert_array_almost_equal(data_set.running_speed.timestamps,
                                          data_set.stimulus_timestamps)
     assert len(data_set.cell_specimen_table) == len(data_set.dff_traces)
     assert data_set.average_projection.data.shape == \
-           data_set.max_projection.data.shape
+        data_set.max_projection.data.shape
     assert set(data_set.motion_correction.columns) == set(['x', 'y'])
     assert len(data_set.trials) == 602
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -81,19 +81,19 @@ def test_visbeh_ophys_data_set():
     assert stimulus_templates['im000'].warped.shape == MONITOR_DIMENSIONS
     assert stimulus_templates['im000'].unwarped.shape == MONITOR_DIMENSIONS
 
-    assert len(data_set.licks) == 2421 and list(data_set.licks.columns) \
-           == ['time', 'frame']
-    assert len(data_set.rewards) == 85 and list(data_set.rewards.columns) == \
-           ['volume', 'autorewarded']
+    assert len(data_set.licks) == 2421 and set(data_set.licks.columns) \
+           == set(['timestamps', 'frame'])
+    assert len(data_set.rewards) == 85 and set(data_set.rewards.columns) == \
+           set(['timestamps', 'volume', 'autorewarded'])
     assert len(data_set.corrected_fluorescence_traces) == 258 and \
-           sorted(data_set.corrected_fluorescence_traces.columns) == \
-           ['cell_roi_id', 'corrected_fluorescence']
+           set(data_set.corrected_fluorescence_traces.columns) == \
+           set(['cell_roi_id', 'corrected_fluorescence'])
     np.testing.assert_array_almost_equal(data_set.running_speed.timestamps,
                                          data_set.stimulus_timestamps)
     assert len(data_set.cell_specimen_table) == len(data_set.dff_traces)
     assert data_set.average_projection.data.shape == \
            data_set.max_projection.data.shape
-    assert list(data_set.motion_correction.columns) == ['x', 'y']
+    assert set(data_set.motion_correction.columns) == set(['x', 'y'])
     assert len(data_set.trials) == 602
 
     expected_metadata = {

--- a/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
@@ -32,7 +32,7 @@ def create_area_df(data: np.ndarray) -> pd.DataFrame:
 
 
 def create_refined_eye_tracking_df(data: np.ndarray) -> pd.DataFrame:
-    columns = ["time", "cr_area", "eye_area", "pupil_area", "likely_blink",
+    columns = ["timestamps", "cr_area", "eye_area", "pupil_area", "likely_blink",
                "pupil_area_raw", "cr_area_raw", "eye_area_raw",
                "cr_center_x", "cr_center_y", "cr_width", "cr_height", "cr_phi",
                "eye_center_x", "eye_center_y", "eye_width", "eye_height",
@@ -200,7 +200,7 @@ def test_process_eye_tracking_data_truncation(eye_tracking_df,
     by <= 15
     """
     df = process_eye_tracking_data(eye_tracking_df, frame_times)
-    np.testing.assert_array_almost_equal(df.time.to_numpy(),
+    np.testing.assert_array_almost_equal(df.timestamps.to_numpy(),
                                          np.array([0.0, 0.1]),
                                          decimal=10)
 

--- a/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_eye_tracking_processing.py
@@ -32,8 +32,8 @@ def create_area_df(data: np.ndarray) -> pd.DataFrame:
 
 
 def create_refined_eye_tracking_df(data: np.ndarray) -> pd.DataFrame:
-    columns = ["timestamps", "cr_area", "eye_area", "pupil_area", "likely_blink",
-               "pupil_area_raw", "cr_area_raw", "eye_area_raw",
+    columns = ["timestamps", "cr_area", "eye_area", "pupil_area",
+               "likely_blink", "pupil_area_raw", "cr_area_raw", "eye_area_raw",
                "cr_center_x", "cr_center_y", "cr_width", "cr_height", "cr_phi",
                "eye_center_x", "eye_center_y", "eye_width", "eye_height",
                "eye_phi", "pupil_center_x", "pupil_center_y", "pupil_width",

--- a/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_rewards_processing.py
@@ -30,7 +30,7 @@ def test_get_rewards():
     expected = pd.DataFrame(
         {"volume": [0.007, 0.008],
          "timestamps": [14.0, 15.0],
-         "autorewarded": [False, True]}).set_index("timestamps", drop=True)
+         "autorewarded": [False, True]})
 
     timesteps = -1*np.ones(100, dtype=float)
     timesteps[55] = 14.0


### PR DESCRIPTION
### Tests passing:
- [x] cloud ci
- [x] bamboo
- [x] bamboo nightly (2 failed, fixed locally)

### Validation for rewards table:
```
from allensdk.brain_observatory.behavior.behavior_ophys_session import BehaviorOphysSession

bs = BehaviorOphysSession.from_lims(995280513)
print(bs.rewards.head())
```
```
   volume  timestamps  autorewarded
0   0.005   313.77275          True
1   0.005   331.78736          True
2   0.005   351.30325          True
3   0.005   362.56253          True
4   0.005   374.57222          True
```

### Validation for licks table
```
print(bs.licks.head())
```
```
   timestamps  frame
0     8.74129    113
1     8.94148    125
2     9.17471    139
3    11.77682    295
4    15.16290    498
```

### Validation for eye_tracking table
```
print(bs.eye_tracking.head())
```
```
       timestamps     cr_area      eye_area  ...  pupil_width  pupil_height  pupil_phi
frame                                        ...                                      
0         0.56207  115.637908  67646.821697  ...    68.146547     72.966538   0.066032
1         0.57353  117.025194  67869.446623  ...    67.734262     72.240309   0.172283
2         0.57545  107.573781  67942.492130  ...    68.316086     72.513558   0.033658
3         0.60897         NaN           NaN  ...    68.005698     73.963582   0.072744
4         0.64236         NaN           NaN  ...    68.815023     73.677158   0.100999
```