### PR TITLE
1889 age_in_days parsed from age

### DIFF
--- a/allensdk/brain_observatory/behavior/metadata/behavior_metadata.py
+++ b/allensdk/brain_observatory/behavior/metadata/behavior_metadata.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytz
 
 from allensdk.brain_observatory.behavior.metadata.util import \
-    parse_cre_line
+    parse_cre_line, parse_age_in_days
 from allensdk.brain_observatory.session_api_utils import compare_session_fields
 
 description_dict = {
@@ -174,8 +174,16 @@ class BehaviorMetadata:
         return self._extractor.get_sex()
 
     @property
-    def age_in_days(self) -> str:
-        return self._extractor.get_age_in_days()
+    def age(self) -> str:
+        return self._extractor.get_age()
+
+    @property
+    def age_in_days(self) -> Optional[int]:
+        """Converts the age string into a numeric days representation"""
+        age_in_days = parse_age_in_days(age=self.age)
+        if age_in_days is None:
+            warnings.warn('Unable to parse age_in_days from age')
+        return age_in_days
 
     @property
     def stimulus_frame_rate(self) -> float:

--- a/allensdk/brain_observatory/behavior/metadata/util.py
+++ b/allensdk/brain_observatory/behavior/metadata/util.py
@@ -27,9 +27,9 @@ def parse_age_in_days(age: str):
     age
         String representation of age (ie P123)
     """
-    if not age:
+    if len(age) == 0:
         return None
-    
+
     if age[0] != 'P':
         return None
     try:

--- a/allensdk/brain_observatory/behavior/metadata/util.py
+++ b/allensdk/brain_observatory/behavior/metadata/util.py
@@ -17,3 +17,20 @@ def parse_cre_line(full_genotype: str) -> Optional[str]:
     if ';' not in full_genotype:
         return None
     return full_genotype.split(';')[0].replace('/wt', '')
+
+
+def parse_age_in_days(age: str):
+    """Converts the age string into a numeric days representation
+
+    Parameters
+    ----------
+    age
+        String representation of age (ie P123)
+    """
+    if age[0] != 'P':
+        return None
+    try:
+        age = int(age[1:])
+        return age
+    except ValueError:
+        return None

--- a/allensdk/brain_observatory/behavior/metadata/util.py
+++ b/allensdk/brain_observatory/behavior/metadata/util.py
@@ -27,6 +27,9 @@ def parse_age_in_days(age: str):
     age
         String representation of age (ie P123)
     """
+    if not age:
+        return None
+    
     if age[0] != 'P':
         return None
     try:

--- a/allensdk/brain_observatory/behavior/schemas.py
+++ b/allensdk/brain_observatory/behavior/schemas.py
@@ -26,8 +26,8 @@ class SubjectMetadataSchema(RaisingSchema):
     # In this case they already exist in the 'Subject' builtin pyNWB class
     neurodata_skip = {"age_in_days", "genotype", "sex", "subject_id"}
 
-    age_in_days = fields.String(
-        doc='Age of the specimen donor/subject (in days)',
+    age = fields.String(
+        doc='Age code of the specimen donor/subject',
         required=True,
     )
     driver_line = fields.List(

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
@@ -12,6 +12,7 @@ import allensdk.brain_observatory.nwb as nwb
 from allensdk.brain_observatory.behavior.metadata.behavior_metadata import (
     get_expt_description, BehaviorMetadata
 )
+from allensdk.brain_observatory.behavior.metadata.util import parse_age_in_days
 from allensdk.brain_observatory.behavior.session_apis.abcs import (
     BehaviorBase
 )
@@ -257,7 +258,8 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
         nwb_subject = self.nwbfile.subject
         data['mouse_id'] = int(nwb_subject.subject_id)
         data['sex'] = nwb_subject.sex
-        data['age_in_days'] = nwb_subject.age
+        data['age'] = nwb_subject.age
+        data['age_in_days'] = parse_age_in_days(age=nwb_subject.age)
         data['full_genotype'] = nwb_subject.genotype
         data['reporter_line'] = nwb_subject.reporter_line
         data['driver_line'] = sorted(list(nwb_subject.driver_line))

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -839,7 +839,7 @@ def add_metadata(nwbfile, metadata: dict, behavior_only: bool):
 
     # Subject related metadata should be saved to our BehaviorSubject
     # (augmented pyNWB 'Subject') NWB class
-    subject_fields = {"age_in_days", "driver_line", "genotype",
+    subject_fields = {"age", "driver_line", "genotype",
                       "subject_id", "reporter_line", "sex"}
     subject_metadata = {k: v for k, v in metadata_clean.items()
                         if k in subject_fields}
@@ -850,7 +850,7 @@ def add_metadata(nwbfile, metadata: dict, behavior_only: bool):
                                            'ndx-aibs-behavior-ophys')
     nwb_subject = BehaviorSubject(
         description="A visual behavior subject with a LabTracks ID",
-        age=subject_metadata["age_in_days"],
+        age=subject_metadata["age"],
         driver_line=subject_metadata["driver_line"],
         genotype=subject_metadata["genotype"],
         subject_id=str(subject_metadata["subject_id"]),

--- a/allensdk/brain_observatory/nwb/ndx-aibs-behavior-ophys.extension.yaml
+++ b/allensdk/brain_observatory/nwb/ndx-aibs-behavior-ophys.extension.yaml
@@ -3,45 +3,45 @@ groups:
   neurodata_type_inc: LabMetaData
   doc: Metadata for behavior or behavior + ophys task parameters
   attributes:
+  - name: stimulus_duration_sec
+    dtype: float
+    doc: Duration of each stimulus presentation in seconds
   - name: stimulus_distribution
     dtype: text
     doc: Distribution type of drawing change times (e.g. 'geometric', 'exponential')
   - name: task
     dtype: text
     doc: The name of the behavioral task
-  - name: reward_volume
-    dtype: float
-    doc: Volume of water (in mL) delivered as reward
-  - name: n_stimulus_frames
-    dtype: int
-    doc: Total number of stimuli frames
-  - name: auto_reward_volume
-    dtype: float
-    doc: Volume of water (in mL) delivered as an automatic reward
-  - name: session_type
-    dtype: text
-    doc: Stage of behavioral task
-  - name: response_window_sec
-    dtype: text
-    shape:
-    - 2
-    doc: The lower and upper bound (in seconds) for a randomly chosen time window
-      where subject response influences trial outcome
   - name: blank_duration_sec
     dtype: text
     shape:
     - 2
     doc: The lower and upper bound (in seconds) for a randomly chosen inter-stimulus
       interval duration for a trial
-  - name: stimulus_duration_sec
+  - name: auto_reward_volume
     dtype: float
-    doc: Duration of each stimulus presentation in seconds
-  - name: omitted_flash_fraction
-    dtype: float
-    doc: Fraction of flashes/image presentations that were omitted
+    doc: Volume of water (in mL) delivered as an automatic reward
   - name: stimulus
     dtype: text
     doc: Stimulus type
+  - name: reward_volume
+    dtype: float
+    doc: Volume of water (in mL) delivered as reward
+  - name: response_window_sec
+    dtype: text
+    shape:
+    - 2
+    doc: The lower and upper bound (in seconds) for a randomly chosen time window
+      where subject response influences trial outcome
+  - name: n_stimulus_frames
+    dtype: int
+    doc: Total number of stimuli frames
+  - name: session_type
+    dtype: text
+    doc: Stage of behavioral task
+  - name: omitted_flash_fraction
+    dtype: float
+    doc: Fraction of flashes/image presentations that were omitted
 - neurodata_type_def: BehaviorSubject
   neurodata_type_inc: Subject
   doc: Metadata for an AIBS behavior or behavior + ophys subject
@@ -49,6 +49,9 @@ groups:
   - name: reporter_line
     dtype: text
     doc: Reporter line of subject
+  - name: age
+    dtype: text
+    doc: Age code of the specimen donor/subject
   - name: driver_line
     dtype: text
     shape:
@@ -58,56 +61,56 @@ groups:
   neurodata_type_inc: LabMetaData
   doc: Metadata for behavior and behavior + ophys experiments
   attributes:
-  - name: behavior_session_uuid
-    dtype: text
-    doc: MTrain record for session, also called foraging_id
   - name: equipment_name
     dtype: text
     doc: Name of behavior or optical physiology experiment rig
-  - name: session_type
-    dtype: text
-    doc: Experimental session description
-  - name: behavior_session_id
-    dtype: int
-    doc: The unique ID for the behavior session
   - name: stimulus_frame_rate
     dtype: float
     doc: Frame rate (frames/second) of the visual_stimulus from the monitor
+  - name: behavior_session_id
+    dtype: int
+    doc: The unique ID for the behavior session
+  - name: behavior_session_uuid
+    dtype: text
+    doc: MTrain record for session, also called foraging_id
+  - name: session_type
+    dtype: text
+    doc: Experimental session description
 - neurodata_type_def: OphysBehaviorMetadata
   neurodata_type_inc: BehaviorMetadata
   doc: Metadata for behavior + ophys experiments
   attributes:
-  - name: experiment_container_id
-    dtype: int
-    doc: Container ID for the container that contains this ophys session
-  - name: behavior_session_id
-    dtype: int
-    doc: The unique ID for the behavior session
   - name: behavior_session_uuid
     dtype: text
     doc: MTrain record for session, also called foraging_id
-  - name: equipment_name
-    dtype: text
-    doc: Name of behavior or optical physiology experiment rig
   - name: session_type
     dtype: text
     doc: Experimental session description
-  - name: field_of_view_width
+  - name: equipment_name
+    dtype: text
+    doc: Name of behavior or optical physiology experiment rig
+  - name: stimulus_frame_rate
+    dtype: float
+    doc: Frame rate (frames/second) of the visual_stimulus from the monitor
+  - name: behavior_session_id
     dtype: int
-    doc: Width of optical physiology imaging plane in pixels
-  - name: ophys_session_id
-    dtype: int
-    doc: Unique ID for the ophys session
-  - name: field_of_view_height
-    dtype: int
-    doc: Height of optical physiology imaging plane in pixels
+    doc: The unique ID for the behavior session
   - name: imaging_plane_group_count
     dtype: int
     doc: The total number of plane groups collected in a session for a mesoscope experiment.
       Will be 0 if the scope did not capture multiple concurrent imaging planes.
+  - name: ophys_session_id
+    dtype: int
+    doc: Unique ID for the ophys session
   - name: ophys_experiment_id
     dtype: int
     doc: Unique ID for the ophys experiment (aka imaging plane)
+  - name: field_of_view_height
+    dtype: int
+    doc: Height of optical physiology imaging plane in pixels
+  - name: experiment_container_id
+    dtype: int
+    doc: Container ID for the container that contains this ophys session
   - name: imaging_depth
     dtype: int
     doc: Depth (microns) below the cortical surface targeted for two-photon acquisition
@@ -115,9 +118,9 @@ groups:
     dtype: int
     doc: A numeric index which indicates the order that an imaging plane was acquired
       for a mesoscope experiment. Will be -1 for non-mesoscope data
-  - name: stimulus_frame_rate
-    dtype: float
-    doc: Frame rate (frames/second) of the visual_stimulus from the monitor
+  - name: field_of_view_width
+    dtype: int
+    doc: Width of optical physiology imaging plane in pixels
 - neurodata_type_def: OphysEyeTrackingRigMetadata
   neurodata_type_inc: NWBDataInterface
   doc: Metadata for ophys experiment rig
@@ -126,6 +129,28 @@ groups:
     dtype: text
     doc: Description of rig
   datasets:
+  - name: led_position
+    dtype: float
+    dims:
+    - 3
+    shape:
+    - null
+    doc: position of LED (x, y, z)
+    attributes:
+    - name: unit_of_measurement
+      dtype: text
+      doc: Unit of measurement for the data
+  - name: monitor_position
+    dtype: float
+    dims:
+    - 3
+    shape:
+    - null
+    doc: position of monitor (x, y, z)
+    attributes:
+    - name: unit_of_measurement
+      dtype: text
+      doc: Unit of measurement for the data
   - name: monitor_rotation
     dtype: float
     dims:
@@ -148,17 +173,6 @@ groups:
     - name: unit_of_measurement
       dtype: text
       doc: Unit of measurement for the data
-  - name: led_position
-    dtype: float
-    dims:
-    - 3
-    shape:
-    - null
-    doc: position of LED (x, y, z)
-    attributes:
-    - name: unit_of_measurement
-      dtype: text
-      doc: Unit of measurement for the data
   - name: camera_rotation
     dtype: float
     dims:
@@ -166,17 +180,6 @@ groups:
     shape:
     - null
     doc: rotation of camera (x, y, z)
-    attributes:
-    - name: unit_of_measurement
-      dtype: text
-      doc: Unit of measurement for the data
-  - name: monitor_position
-    dtype: float
-    dims:
-    - 3
-    shape:
-    - null
-    doc: position of monitor (x, y, z)
     attributes:
     - name: unit_of_measurement
       dtype: text

--- a/allensdk/test/brain_observatory/behavior/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/conftest.py
@@ -157,7 +157,8 @@ def behavior_only_metadata_fixture():
         "stimulus_frame_rate": 60.0,
         "equipment_name": 'my_device',
         "sex": 'M',
-        "age_in_days": 'P139'
+        "age_in_days": 139,
+        "age": "P139"
     }
 
 
@@ -189,7 +190,8 @@ def metadata_fixture():
         "field_of_view_height": 4,
         "equipment_name": 'my_device',
         "sex": 'M',
-        "age_in_days": 'P139',
+        "age_in_days": 139,
+        "age": "P139",
         "imaging_plane_group": None,
         "imaging_plane_group_count": 0
     }
@@ -219,7 +221,8 @@ def partial_metadata_fixture():
         "field_of_view_height": 4,
         "equipment_name": 'my_device',
         "sex": 'M',
-        "age_in_days": 'P139',
+        "age_in_days": 139,
+        "age": "P139",
         "imaging_plane_group": None,
         "imaging_plane_group_count": 0
     }
@@ -340,7 +343,8 @@ def session_data():
         "rigid_motion_transform_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/processed/789359614_rigid_motion_transform.csv",  # noqa: E501
         "segmentation_mask_image_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/processed/ophys_cell_segmentation_run_789410052/maxInt_masks.tif",  # noqa: E501
         "sex": "F",
-        "age_in_days": "P139",
+        "age_in_days": 139,
+        "age": "P139",
         "imaging_plane_group": None,
         "imaging_plane_group_count": 0
     }

--- a/allensdk/test/brain_observatory/behavior/test_behavior_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_metadata.py
@@ -432,6 +432,66 @@ def test_reporter_line_no_reporter_line(monkeypatch):
         assert metadata.reporter_line is None
 
 
+def test_age_in_days(monkeypatch):
+    """Test that age_in_days properly parsed from age"""
+    class MockExtractor:
+        def get_age(self):
+            return 'P123'
+    extractor = MockExtractor()
+
+    with monkeypatch.context() as ctx:
+        def dummy_init(self):
+            self._extractor = extractor
+
+        ctx.setattr(BehaviorMetadata,
+                    '__init__',
+                    dummy_init)
+
+        metadata = BehaviorMetadata()
+
+        assert metadata.age_in_days == 123
+
+
+def test_age_in_days_unkown_age(monkeypatch):
+    """Test age in days is None if age is unkown"""
+    class MockExtractor:
+        def get_age(self):
+            return 'unkown'
+    extractor = MockExtractor()
+
+    with monkeypatch.context() as ctx:
+        def dummy_init(self):
+            self._extractor = extractor
+
+        ctx.setattr(BehaviorMetadata,
+                    '__init__',
+                    dummy_init)
+
+        metadata = BehaviorMetadata()
+
+        assert metadata.age_in_days is None
+
+
+def test_age_in_days_invalid_age(monkeypatch):
+    """Test that age_in_days is None if age not prefixed with P"""
+    class MockExtractor:
+        def get_age(self):
+            return 'Q123'
+    extractor = MockExtractor()
+
+    with monkeypatch.context() as ctx:
+        def dummy_init(self):
+            self._extractor = extractor
+
+        ctx.setattr(BehaviorMetadata,
+                    '__init__',
+                    dummy_init)
+
+        metadata = BehaviorMetadata()
+
+        assert metadata.age_in_days is None
+
+
 @pytest.mark.parametrize("test_params, expected_warn_msg", [
     # Vanilla test case
     ({

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_session.py
@@ -122,7 +122,8 @@ def test_visbeh_ophys_data_set():
         'field_of_view_width': 447,
         'indicator': 'GCAMP6f',
         'equipment_name': 'CAM2P.5',
-        'age_in_days': 'P139',
+        'age_in_days': 139,
+        'age': 'P139',
         'sex': 'F',
         'imaging_plane_group': None,
         'project_code': 'VisualBehavior'


### PR DESCRIPTION
Now there are 2 properties on metadata:

`age` -- string version of age, ie P123
`age_in_days` -- numeric version, parsed from `age`

NWB saves `age`, but will load both