### PR TITLE
updates BehaviorProjectCache to use cloud

### DIFF
--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -5,6 +5,7 @@ import io
 import pathlib
 import pandas as pd
 import boto3
+import semver
 from botocore import UNSIGNED
 from botocore.client import Config
 from allensdk.internal.core.lims_utilities import safe_system_path
@@ -124,6 +125,17 @@ class CloudCacheBase(ABC):
         dataset
         """
         return copy.deepcopy(self._manifest_file_names)
+
+    @property
+    def latest_manifest_file(self) -> str:
+        vstrs = [s.split(".json")[0].split("_v")[-1]
+                 for s in self.manifest_file_names]
+        versions = [semver.VersionInfo.parse(v) for v in vstrs]
+        imax = versions.index(max(versions))
+        return self.manifest_file_names[imax]
+
+    def load_latest_manifest(self):
+        self.load_manifest(self.latest_manifest_file)
 
     def load_manifest(self, manifest_name: str):
         """

--- a/allensdk/brain_observatory/behavior/behavior_ophys_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_session.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pandas as pd
 from typing import Any
+import warnings
 
 from allensdk.brain_observatory.behavior.behavior_session import (
-    BehaviorSession)
+    BehaviorData)
 from allensdk.brain_observatory.session_api_utils import ParamsMixin
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
     BehaviorOphysNwbApi, BehaviorOphysLimsApi)
@@ -11,7 +12,7 @@ from allensdk.deprecated import legacy
 from allensdk.brain_observatory.behavior.image_api import Image, ImageApi
 
 
-class BehaviorOphysSession(BehaviorSession, ParamsMixin):
+class OphysExperimentAndBehaviorData(BehaviorData, ParamsMixin):
     """Represents data from a single Visual Behavior Ophys imaging session.
     Can be initialized with an api that fetches data, or by using class methods
     `from_lims` and `from_nwb_path`.
@@ -44,7 +45,7 @@ class BehaviorOphysSession(BehaviorSession, ParamsMixin):
             Number of time steps to use for convolution of ophys events
         """
 
-        BehaviorSession.__init__(self, api=api)
+        BehaviorData.__init__(self, api=api)
         ParamsMixin.__init__(self, ignore={'api'})
 
         # eye_tracking processing params
@@ -355,8 +356,11 @@ class BehaviorOphysSession(BehaviorSession, ParamsMixin):
         return self.cell_specimen_table[['cell_roi_id', 'roi_mask']]
 
 
-if __name__ == "__main__":
-
-    ophys_experiment_id = 789359614
-    session = BehaviorOphysSession.from_lims(ophys_experiment_id)
-    print(session.trials['reward_time'])
+class BehaviorOphysSession(OphysExperimentAndBehaviorData):
+    def __init__(self, **kwargs):
+        warnings.warn("BehaviorOphysSession is deprecated; use "
+                      "OphysExperimentAndBehaviorData.",
+                      DeprecationWarning,
+                      stacklevel=3)
+        super().__init__(**kwargs)
+    pass

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/__init__.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/__init__.py
@@ -1,2 +1,2 @@
 from allensdk.brain_observatory.behavior.behavior_project_cache.\
-    behavior_project_cache import BehaviorProjectCache  # noqa F401
+    behavior_project_cache import VisualBehaviorOphysProjectCache  # noqa F401

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -13,14 +13,15 @@ from allensdk.brain_observatory.behavior.behavior_project_cache.tables\
     SessionsTable
 from allensdk.brain_observatory.behavior.project_apis.data_io import (
     BehaviorProjectLimsApi)
-from allensdk.api.warehouse_cache.caching_utilities import one_file_call_caching, call_caching
+from allensdk.api.warehouse_cache.caching_utilities import (
+        one_file_call_caching, call_caching)
 from allensdk.brain_observatory.behavior.behavior_project_cache.tables\
     .ophys_sessions_table import \
     BehaviorOphysSessionsTable
 from allensdk.core.authentication import DbCredentials
 
 
-class BehaviorProjectCache(Cache):
+class VisualBehaviorOphysProjectCache(Cache):
 
     MANIFEST_VERSION = "0.0.1-alpha.3"
     OPHYS_SESSIONS_KEY = "ophys_sessions"
@@ -115,7 +116,8 @@ class BehaviorProjectCache(Cache):
                   mtrain_credentials: Optional[DbCredentials] = None,
                   host: Optional[str] = None,
                   scheme: Optional[str] = None,
-                  asynchronous: bool = True) -> "BehaviorProjectCache":
+                  asynchronous: bool = True
+                  ) -> "VisualBehaviorOphysProjectCache":
         """
         Construct a BehaviorProjectCache with a lims api. Use this method
         to create a  BehaviorProjectCache instance rather than calling

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -12,7 +12,7 @@ from allensdk.brain_observatory.behavior.behavior_project_cache.tables\
     .sessions_table import \
     SessionsTable
 from allensdk.brain_observatory.behavior.project_apis.data_io import (
-    BehaviorProjectLimsApi)
+    BehaviorProjectLimsApi, BehaviorProjectCloudApi)
 from allensdk.api.warehouse_cache.caching_utilities import (
         one_file_call_caching, call_caching)
 from allensdk.brain_observatory.behavior.behavior_project_cache.tables\
@@ -48,7 +48,8 @@ class VisualBehaviorOphysProjectCache(Cache):
 
     def __init__(
             self,
-            fetch_api: Optional[BehaviorProjectLimsApi] = None,
+            fetch_api: Optional[Union[BehaviorProjectLimsApi,
+                                      BehaviorProjectCloudApi]] = None,
             fetch_tries: int = 2,
             manifest: Optional[Union[str, Path]] = None,
             version: Optional[str] = None,
@@ -106,6 +107,13 @@ class VisualBehaviorOphysProjectCache(Cache):
         self.fetch_api = fetch_api
         self.fetch_tries = fetch_tries
         self.logger = logging.getLogger(self.__class__.__name__)
+
+    @classmethod
+    def from_s3_cache(cls, cache_dir: Union[str, Path],
+                      bucket_name: str) -> "VisualBehaviorOphysProjectCache":
+        fetch_api = BehaviorProjectCloudApi.from_s3_cache(
+                cache_dir, bucket_name)
+        return cls(fetch_api=fetch_api)
 
     @classmethod
     def from_lims(cls, manifest: Optional[Union[str, Path]] = None,

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 import numpy as np
 import inspect
+import warnings
 
 from allensdk.brain_observatory.behavior.metadata.behavior_metadata import \
     BehaviorMetadata
@@ -23,7 +24,7 @@ from allensdk.brain_observatory.behavior.dprime import (
 BehaviorDataApi = Type[BehaviorBase]
 
 
-class BehaviorSession(LazyPropertyMixin):
+class BehaviorData(LazyPropertyMixin):
     def __init__(self, api: Optional[BehaviorDataApi] = None):
         self.api = api
 
@@ -397,3 +398,12 @@ class BehaviorSession(LazyPropertyMixin):
     @metadata.setter
     def metadata(self, value):
         self._metadata = value
+
+
+class BehaviorSession(BehaviorData):
+    def __init__(self, **kwargs):
+        warnings.warn("BehaviorSession is deprecated; use BehaviorData.",
+                      DeprecationWarning,
+                      stacklevel=3)
+        super().__init__(**kwargs)
+    pass

--- a/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
+++ b/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
@@ -43,24 +43,3 @@ class BehaviorProjectBase(ABC):
         :rtype: pd.DataFrame
         """
         pass
-
-    @abstractmethod
-    def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
-        """Download a template for the natural scene stimulus. This is the
-        actual image that was shown during the recording session.
-        :param number: idenfifier for this movie (note that this is an int,
-            so to get the template for natural_movie_three should pass 3)
-        :type number: int
-        :returns: iterable yielding a tiff file as bytes
-        """
-        pass
-
-    @abstractmethod
-    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
-        actual movie that was shown during the recording session.
-        :param number: identifier for this scene
-        :type number: int
-        :returns: An iterable yielding an npy file as bytes
-        """
-        pass

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/__init__.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/__init__.py
@@ -1,1 +1,2 @@
 from allensdk.brain_observatory.behavior.project_apis.data_io.behavior_project_lims_api import BehaviorProjectLimsApi  # noqa: F401, E501
+from allensdk.brain_observatory.behavior.project_apis.data_io.behavior_project_cloud_api import BehaviorProjectCloudApi  # noqa: F401, E501

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -120,27 +120,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
     def _get_experiment_table(self):
         experiment_table_path = self.cache.download_metadata(
-                "behavior_session_table.csv")
+                "ophys_experiment_table.csv")
         self._experiment_table = pd.read_csv(experiment_table_path)
 
     def get_experiment_table(self):
         return self._experiment_table
-
-    def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
-        """Download a template for the natural scene stimulus. This is the
-        actual image that was shown during the recording session.
-        :param number: idenfifier for this movie (note that this is an int,
-            so to get the template for natural_movie_three should pass 3)
-        :type number: int
-        :returns: iterable yielding a tiff file as bytes
-        """
-        raise NotImplementedError()
-
-    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
-        actual movie that was shown during the recording session.
-        :param number: identifier for this scene
-        :type number: int
-        :returns: An iterable yielding an npy file as bytes
-        """
-        raise NotImplementedError()

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -1,0 +1,146 @@
+import pandas as pd
+from typing import Iterable, Union
+from pathlib import Path
+import logging
+
+from allensdk.brain_observatory.behavior.project_apis.abcs import (
+    BehaviorProjectBase)
+from allensdk.brain_observatory.behavior.behavior_session import (
+    BehaviorSession)
+from allensdk.brain_observatory.behavior.behavior_ophys_session import (
+    BehaviorOphysSession)
+from allensdk.api.cloud_cache.cloud_cache import S3CloudCache
+
+
+class BehaviorProjectCloudApi(BehaviorProjectBase):
+    """API for downloading data released on S3
+     and returning tables.
+    """
+    def __init__(self, cache: S3CloudCache):
+        """
+        the passed cache should already have had `cache.load_manifest()`
+        executed. With this satisfied, the attributes
+          - metadata_file_names
+          - file_id_column
+        are populated
+        """
+        expected_metadata = set(["behavior_session_table.csv",
+                                 "ophys_session_table.csv",
+                                 "ophys_experiment_table.csv"])
+        self.cache = cache
+        if cache._manifest.metadata_file_names is None:
+            raise RuntimeError("S3CloudCache object has no metadata "
+                               "file names. BehaviorProjectCloudApi "
+                               "expects a S3CloudCache passed which "
+                               "has already run load_manifest()")
+        cache_metadata = set(cache._manifest.metadata_file_names)
+        if cache_metadata != expected_metadata:
+            raise RuntimeError("expected S3CloudCache object to have "
+                               f"metadata file names: {expected_metadata} "
+                               f"but it has {cache_metadata}")
+        self.logger = logging.getLogger("BehaviorProjectCloudApi")
+        self._get_session_table()
+        self._get_behavior_only_session_table()
+        self._get_experiment_table()
+
+    @staticmethod
+    def from_s3_cache(cache_dir: Union[str, Path],
+                      bucket_name: str) -> "BehaviorProjectCloudApi":
+        cache = S3CloudCache(cache_dir, bucket_name)
+        cache.load_latest_manifest()
+        return BehaviorProjectCloudApi(cache)
+
+    def get_behavior_only_session_data(
+            self, behavior_session_id: int) -> BehaviorSession:
+        """get a BehaviorSession by specifying behavior_session_id
+
+        Parameters
+        ----------
+        behavior_session_id: int
+            the id of the behavior_session
+
+        Returns
+        -------
+        BehaviorSession
+
+        """
+        row = self._behavior_only_session_table.query(
+                f"behavior_session_id=={behavior_session_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_only_session_table should have "
+                               "1 and only 1 entry for a given "
+                               "behavior_session_id. For "
+                               f"{behavior_session_id} "
+                               f" there are {row.shape[0]} entries.")
+        data_path = self.cache.download_data(row.data_file_id.values[0])
+        return BehaviorSession.from_nwb_path(str(data_path))
+
+    def get_session_data(self, ophys_session_id: int) -> BehaviorOphysSession:
+        """get a BehaviorOphysSession by specifying session_id
+
+        Parameters
+        ----------
+        ophys_session_id: int
+            the id of the ophys_session
+
+        Returns
+        -------
+        BehaviorOphysSession
+
+        """
+        row = self._session_table.query(
+                f"ophys_session_id=={ophys_session_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_session_table should have "
+                               "1 and only 1 entry for a given "
+                               f"ophys_session_id. For {ophys_session_id} "
+                               f" there are {row.shape[0]} entries.")
+        data_path = self.cache.download_data(row.data_file_id.values[0])
+        return BehaviorOphysSession.from_nwb_path(str(data_path))
+
+    def _get_session_table(self):
+        session_table_path = self.cache.download_metadata(
+                "ophys_session_table.csv")
+        self._session_table = pd.read_csv(session_table_path)
+
+    def get_session_table(self) -> pd.DataFrame:
+        """Return a pd.Dataframe table with all ophys_session_ids and relevant
+        metadata."""
+        return self._session_table
+
+    def _get_behavior_only_session_table(self):
+        session_table_path = self.cache.download_metadata(
+                "behavior_session_table.csv")
+        self._behavior_only_session_table = pd.read_csv(session_table_path)
+
+    def get_behavior_only_session_table(self) -> pd.DataFrame:
+        """Return a pd.Dataframe table with all ophys_session_ids and relevant
+        metadata."""
+        return self._behavior_only_session_table
+
+    def _get_experiment_table(self):
+        experiment_table_path = self.cache.download_metadata(
+                "behavior_session_table.csv")
+        self._experiment_table = pd.read_csv(experiment_table_path)
+
+    def get_experiment_table(self):
+        return self._experiment_table
+
+    def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
+        """Download a template for the natural scene stimulus. This is the
+        actual image that was shown during the recording session.
+        :param number: idenfifier for this movie (note that this is an int,
+            so to get the template for natural_movie_three should pass 3)
+        :type number: int
+        :returns: iterable yielding a tiff file as bytes
+        """
+        raise NotImplementedError()
+
+    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
+        """ Download a template for the natural movie stimulus. This is the
+        actual movie that was shown during the recording session.
+        :param number: identifier for this scene
+        :type number: int
+        :returns: An iterable yielding an npy file as bytes
+        """
+        raise NotImplementedError()

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
@@ -492,22 +492,3 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         return (summary_tbl.merge(stimulus_names,
                                   on=["foraging_id"], how="left")
                 .set_index("behavior_session_id"))
-
-    def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
-        """Download a template for the natural scene stimulus. This is the
-        actual image that was shown during the recording session.
-        :param number: idenfifier for this movie (note that this is an int,
-            so to get the template for natural_movie_three should pass 3)
-        :type number: int
-        :returns: iterable yielding a tiff file as bytes
-        """
-        raise NotImplementedError()
-
-    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
-        actual movie that was shown during the recording session.
-        :param number: identifier for this scene
-        :type number: int
-        :returns: An iterable yielding an npy file as bytes
-        """
-        raise NotImplementedError()

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
@@ -6,7 +6,7 @@ import tempfile
 import logging
 
 from allensdk.brain_observatory.behavior.behavior_project_cache \
-    import BehaviorProjectCache
+    import VisualBehaviorOphysProjectCache
 
 
 @pytest.fixture
@@ -120,9 +120,9 @@ def mock_api(session_table, behavior_table, experiments_table):
 def TempdirBehaviorCache(mock_api, request):
     temp_dir = tempfile.TemporaryDirectory()
     manifest = os.path.join(temp_dir.name, "manifest.json")
-    yield BehaviorProjectCache(fetch_api=mock_api(),
-                               cache=request.param,
-                               manifest=manifest)
+    yield VisualBehaviorOphysProjectCache(fetch_api=mock_api(),
+                                          cache=request.param,
+                                          manifest=manifest)
     temp_dir.cleanup()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ nest_asyncio==1.2.0
 tqdm>=4.27
 ndx-events<=0.2.0
 boto3==1.17.21
+semver


### PR DESCRIPTION
### Load project cache from latest version of manifest
```
import allensdk.brain_observatory.behavior.behavior_project_cache as bpc
bc = bpc.VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir="/home/danielk/tmp", bucket_name="vba-2021-prototype")
```

### Load project cache with a prior version of manifest
```
import allensdk.brain_observatory.behavior.behavior_project_cache as bpc
import allensdk.api.cloud_cache.cloud_cache as cc
import allensdk.brain_observatory.behavior.project_apis.data_io.behavior_project_cloud_api as bpca

mycache = cc.S3CloudCache(cache_dir="/home/danielk/tmp", bucket_name="vba-2021-prototype")
mycache.manifest_file_names
Out[11]: ['manifest_v1.0.1.json', 'manifest_v1.0.2.json', 'manifest_v1.2.0.json']

mycache.load_manifest("manifest_v1.0.1.json")
bpcapi = bpca.BehaviorProjectCloudApi(mycache)
bc = bpc.VisualBehaviorOphysProjectCache(bpcapi)
```