### PR TITLE
update CloudCache to reflect bucket structure with project_name/

### DIFF
--- a/allensdk/api/cloud_cache/manifest.py
+++ b/allensdk/api/cloud_cache/manifest.py
@@ -71,8 +71,8 @@ class Manifest(object):
             raise ValueError("Expected to deserialize manifest into a dict; "
                              f"instead got {type(self._data)}")
 
-        self._version = copy.deepcopy(self._data['dataset_version'])
-        self._file_id_column = copy.deepcopy(self._data['file_id_column'])
+        self._version = copy.deepcopy(self._data['manifest_version'])
+        self._file_id_column = copy.deepcopy(self._data['metadata_file_id_column_name'])  # noqa: E501
 
         self._metadata_file_names = [file_name for file_name
                                      in self._data['metadata_files']]

--- a/allensdk/api/cloud_cache/utils.py
+++ b/allensdk/api/cloud_cache/utils.py
@@ -27,7 +27,7 @@ def bucket_name_from_url(url: str) -> Optional[str]:
     here
     https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
     """
-    s3_pattern = re.compile('\.s3[a-z,0-9,\-]*\.amazonaws.com')  # noqa: W605
+    s3_pattern = re.compile('\.s3[\.,a-z,0-9,\-]*\.amazonaws.com')  # noqa: W605, E501
     url_params = url_parse.urlparse(url)
     raw_location = url_params.netloc
     s3_match = s3_pattern.search(raw_location)

--- a/allensdk/test/api/cloud_cache/test_manifest.py
+++ b/allensdk/test/api/cloud_cache/test_manifest.py
@@ -28,8 +28,8 @@ def test_load(tmpdir):
     """
 
     good_manifest = {}
-    good_manifest['dataset_version'] = 'A'
-    good_manifest['file_id_column'] = 'file_id'
+    good_manifest['manifest_version'] = 'A'
+    good_manifest['metadata_file_id_column_name'] = 'file_id'
     metadata_files = {}
     metadata_files['z.txt'] = []
     metadata_files['x.txt'] = []
@@ -52,8 +52,8 @@ def test_load(tmpdir):
 
     # test that you can load a new manifest.json into the same Manifest
     good_manifest = {}
-    good_manifest['dataset_version'] = 'B'
-    good_manifest['file_id_column'] = 'file_id'
+    good_manifest['manifest_version'] = 'B'
+    good_manifest['metadata_file_id_column_name'] = 'file_id'
     metadata_files = {}
     metadata_files['n.txt'] = []
     metadata_files['k.txt'] = []
@@ -120,8 +120,8 @@ def test_metadata_file_attributes():
                                'file_hash': 'fghijk'}
 
     manifest['metadata_files'] = metadata_files
-    manifest['dataset_version'] = '000'
-    manifest['file_id_column'] = 'file_id'
+    manifest['manifest_version'] = '000'
+    manifest['metadata_file_id_column_name'] = 'file_id'
 
     mfest = Manifest('/my/cache/dir/')
     with io.StringIO() as stream:
@@ -162,8 +162,8 @@ def test_data_file_attributes():
     """
     manifest = {}
     manifest['metadata_files'] = {}
-    manifest['dataset_version'] = '0'
-    manifest['file_id_column'] = 'file_id'
+    manifest['manifest_version'] = '0'
+    manifest['metadata_file_id_column_name'] = 'file_id'
     data_files = {}
     data_files['a'] = {'url': 'http://my.url.com/path/to/a.nwb',
                        'version_id': '12345',
@@ -227,8 +227,8 @@ def test_loading_two_manifests():
                    'file_hash': 'rstuvw'}
 
     manifest_1['data_files'] = data_1
-    manifest_1['dataset_version'] = '1'
-    manifest_1['file_id_column'] = 'file_id'
+    manifest_1['manifest_version'] = '1'
+    manifest_1['metadata_file_id_column_name'] = 'file_id'
 
     manifest_2 = {}
     metadata_2 = {}
@@ -248,8 +248,8 @@ def test_loading_two_manifests():
                    'file_hash': 'qrstuvwxy'}
 
     manifest_2['data_files'] = data_2
-    manifest_2['dataset_version'] = '2'
-    manifest_2['file_id_column'] = 'file_id'
+    manifest_2['manifest_version'] = '2'
+    manifest_2['metadata_file_id_column_name'] = 'file_id'
 
     mfest = Manifest('/my/cache/dir')
 

--- a/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
+++ b/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
@@ -14,8 +14,8 @@ def test_windows_path_to_isilon(monkeypatch):
 
     cache_dir = '/allen/silly/cache/path'
 
-    manifest_1 = {'dataset_version': '1',
-                  'file_id_column': 'file_id',
+    manifest_1 = {'manifest_version': '1',
+                  'metadata_file_id_column_name': 'file_id',
                   'metadata_files': {'a.csv': {'url': 'http://www.junk.com/path/to/a.csv',  # noqa: E501
                                                'version_id': '1111',
                                                'file_hash': 'abcde'},
@@ -64,7 +64,7 @@ def test_windows_path_to_isilon(monkeypatch):
                     '_file_exists',
                     dummy_file_exists)
 
-        cache = TestCloudCache(cache_dir)
+        cache = TestCloudCache(cache_dir, 'proj')
         cache.load_manifest()
 
         m_path = cache.metadata_path('a.csv')


### PR DESCRIPTION
This updates the implementation of CloudCache and the supporting classes to reflect the fact that the data upload tool sets up the bucket root directory to be `project_name/`

This should make it possible to use the AllenSDK CloudCache to validate the results of the data upload tool during development.