### PR TITLE
2008 project cloud api

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '2.9.0'
+__version__ = '2.10.0'
 
 
 try:

--- a/allensdk/api/cloud_cache/README.md
+++ b/allensdk/api/cloud_cache/README.md
@@ -44,6 +44,7 @@ The `manifest.json` files are structured like so
 ```
 
 {
+ "project_name" : my-project-name-string,
  "dataset_version" : dataset_version_string,
  "file_id_column": name_of_column_uniquely_identifying_files,
  "metadata_files":{

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -5,6 +5,7 @@ import io
 import pathlib
 import pandas as pd
 import boto3
+import semver
 from botocore import UNSIGNED
 from botocore.client import Config
 from allensdk.internal.core.lims_utilities import safe_system_path
@@ -44,6 +45,17 @@ class CloudCacheBase(ABC):
         with this dataset
         """
         raise NotImplementedError()
+
+    @property
+    def latest_manifest_file(self) -> str:
+        vstrs = [s.split(".json")[0].split("_v")[-1]
+                 for s in self.manifest_file_names]
+        versions = [semver.VersionInfo.parse(v) for v in vstrs]
+        imax = versions.index(max(versions))
+        return self.manifest_file_names[imax]
+
+    def load_latest_manifest(self):
+        self.load_manifest(self.latest_manifest_file)
 
     @abstractmethod
     def _download_manifest(self,

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -48,6 +48,16 @@ class CloudCacheBase(ABC):
 
     @property
     def latest_manifest_file(self) -> str:
+        """parses available manifest files for semver string
+        and returns the latest one
+        self.manifest_file_names are assumed to be of the form
+        '<anything>_v<semver_str>.json'
+
+        Returns
+        -------
+        str
+            the filename whose semver string is the latest one
+        """
         vstrs = [s.split(".json")[0].split("_v")[-1]
                  for s in self.manifest_file_names]
         versions = [semver.VersionInfo.parse(v) for v in vstrs]

--- a/allensdk/api/cloud_cache/manifest.py
+++ b/allensdk/api/cloud_cache/manifest.py
@@ -12,13 +12,22 @@ class Manifest(object):
     A class for loading and manipulating the online manifest.json associated
     with a dataset release
 
+    Each Manifest instance should represent the data for 1 and only 1
+    manifest.json file.
+
     Parameters
     ----------
     cache_dir: str or pathlib.Path
         The path to the directory where local copies of files will be stored
+    json_input:
+        A ''.read()''-supporting file-like object containing
+        a JSON document to be deserialized (i.e. same as the
+        first argument to json.load)
     """
 
-    def __init__(self, cache_dir: Union[str, pathlib.Path]):
+    def __init__(self,
+                 cache_dir: Union[str, pathlib.Path],
+                 json_input):
         if isinstance(cache_dir, str):
             self._cache_dir = pathlib.Path(cache_dir).resolve()
         elif isinstance(cache_dir, pathlib.Path):
@@ -28,10 +37,27 @@ class Manifest(object):
                              "or a pathlib.Path; "
                              f"got {type(cache_dir)}")
 
-        self._data: Dict[str, Any] = None
-        self._version: str = None
-        self._file_id_column: str = None
-        self._metadata_file_names: List[str] = None
+        self._data: Dict[str, Any] = json.load(json_input)
+        if not isinstance(self._data, dict):
+            raise ValueError("Expected to deserialize manifest into a dict; "
+                             f"instead got {type(self._data)}")
+        self._project_name: str = self._data["project_name"]
+        self._version: str = self._data['manifest_version']
+        self._file_id_column: str = self._data['metadata_file_id_column_name']
+        self._data_pipeline: str = self._data["data_pipeline"]
+
+        self._metadata_file_names: List[str] = [
+            file_name for file_name in self._data['metadata_files']
+        ]
+        self._metadata_file_names.sort()
+
+    @property
+    def project_name(self):
+        """
+        The name of the project whose data and metadata files this
+        manifest tracks.
+        """
+        return self._project_name
 
     @property
     def version(self):
@@ -53,30 +79,7 @@ class Manifest(object):
         """
         List of metadata file names associated with this dataset
         """
-        return copy.deepcopy(self._metadata_file_names)
-
-    def load(self, json_input):
-        """
-        Load a manifest.json
-
-        Parameters
-        ----------
-        json_input:
-            A ''.read()''-supporting file-like object containing
-            a JSON document to be deserialized (i.e. same as the
-            first argument to json.load)
-        """
-        self._data = json.load(json_input)
-        if not isinstance(self._data, dict):
-            raise ValueError("Expected to deserialize manifest into a dict; "
-                             f"instead got {type(self._data)}")
-        self._data = copy.deepcopy(self._data)
-        self._version = self._data['manifest_version']
-        self._file_id_column = self._data['metadata_file_id_column_name']
-        self._data_pipeline = self._data["data_pipeline"]
-        self._metadata_file_names = [file_name for file_name
-                                     in self._data['metadata_files']]
-        self._metadata_file_names.sort()
+        return self._metadata_file_names
 
     def _create_file_attributes(self,
                                 remote_path: str,
@@ -100,9 +103,20 @@ class Manifest(object):
         CacheFileAttributes
         """
 
-        local_dir = self._cache_dir / file_hash
+        # Paths should be built like:
+        # {cache_dir} / {project_name}-{manifest_version} / relative_path
+        # Ex: my_cache_dir/visual-behavior-ophys-1.0.0/behavior_sessions/etc...
+
+        project_dir_name = f"{self._project_name}-{self._version}"
+        project_dir = self._cache_dir / project_dir_name
+
+        # The convention of the data release tool is to have all
+        # relative_paths from remote start with the project name which
+        # we want to remove since we already specified a project directory
         relative_path = relative_path_from_url(remote_path)
-        local_path = local_dir / relative_path
+        shaved_rel_path = "/".join(relative_path.split("/")[1:])
+
+        local_path = project_dir / shaved_rel_path
 
         obj = CacheFileAttributes(remote_path,
                                   version_id,

--- a/allensdk/api/cloud_cache/manifest.py
+++ b/allensdk/api/cloud_cache/manifest.py
@@ -70,10 +70,10 @@ class Manifest(object):
         if not isinstance(self._data, dict):
             raise ValueError("Expected to deserialize manifest into a dict; "
                              f"instead got {type(self._data)}")
-
-        self._version = copy.deepcopy(self._data['manifest_version'])
-        self._file_id_column = copy.deepcopy(self._data['metadata_file_id_column_name'])  # noqa: E501
-
+        self._data = copy.deepcopy(self._data)
+        self._version = self._data['manifest_version']
+        self._file_id_column = self._data['metadata_file_id_column_name']
+        self._data_pipeline = self._data["data_pipeline"]
         self._metadata_file_names = [file_name for file_name
                                      in self._data['metadata_files']]
         self._metadata_file_names.sort()

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -110,6 +110,28 @@ class VisualBehaviorOphysProjectCache(Cache):
     def from_s3_cache(cls, cache_dir: Union[str, Path],
                       bucket_name: str,
                       project_name: str) -> "VisualBehaviorOphysProjectCache":
+        """instantiates this object with a connection to an s3 bucket and/or
+        a local cache related to that bucket.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        bucket_name: str
+            for example, if bucket URI is 's3://mybucket' this value should be
+            'mybucket'
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        Returns
+        -------
+        VisualBehaviorOphysProjectCache instance
+
+        """
         fetch_api = BehaviorProjectCloudApi.from_s3_cache(
                 cache_dir, bucket_name, project_name)
         return cls(fetch_api=fetch_api)

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -47,7 +47,8 @@ class VisualBehaviorOphysProjectCache(Cache):
 
     def __init__(
             self,
-            fetch_api: Optional[BehaviorProjectLimsApi] = None,
+            fetch_api: Optional[Union[BehaviorProjectLimsApi,
+                                      BehaviorProjectCloudApi]] = None,
             fetch_tries: int = 2,
             manifest: Optional[Union[str, Path]] = None,
             version: Optional[str] = None,

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -108,8 +108,9 @@ class VisualBehaviorOphysProjectCache(Cache):
 
     @classmethod
     def from_s3_cache(cls, cache_dir: Union[str, Path],
-                      bucket_name: str,
-                      project_name: str) -> "VisualBehaviorOphysProjectCache":
+                      bucket_name: str = "visual-behavior-ophys-data",
+                      project_name: str = "visual-behavior-ophys"
+                      ) -> "VisualBehaviorOphysProjectCache":
         """instantiates this object with a connection to an s3 bucket and/or
         a local cache related to that bucket.
 

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -108,9 +108,10 @@ class VisualBehaviorOphysProjectCache(Cache):
 
     @classmethod
     def from_s3_cache(cls, cache_dir: Union[str, Path],
-                      bucket_name: str) -> "VisualBehaviorOphysProjectCache":
+                      bucket_name: str,
+                      project_name: str) -> "VisualBehaviorOphysProjectCache":
         fetch_api = BehaviorProjectCloudApi.from_s3_cache(
-                cache_dir, bucket_name)
+                cache_dir, bucket_name, project_name)
         return cls(fetch_api=fetch_api)
 
     @classmethod
@@ -200,6 +201,8 @@ class VisualBehaviorOphysProjectCache(Cache):
             Whether to include behavior data
         :rtype: pd.DataFrame
         """
+        if isinstance(self.fetch_api, BehaviorProjectCloudApi):
+            return self.fetch_api.get_session_table()
         if self.cache:
             path = self.get_cache_path(None, self.OPHYS_SESSIONS_KEY)
             ophys_sessions = one_file_call_caching(
@@ -244,6 +247,8 @@ class VisualBehaviorOphysProjectCache(Cache):
         :param as_df: whether to return as df or as SessionsTable
         :rtype: pd.DataFrame
         """
+        if isinstance(self.fetch_api, BehaviorProjectCloudApi):
+            return self.fetch_api.get_experiment_table()
         if self.cache:
             path = self.get_cache_path(None, self.OPHYS_EXPERIMENTS_KEY)
             experiments = one_file_call_caching(
@@ -280,6 +285,8 @@ class VisualBehaviorOphysProjectCache(Cache):
         :type suppress: list of str
         :rtype: pd.DataFrame
         """
+        if isinstance(self.fetch_api, BehaviorProjectCloudApi):
+            return self.fetch_api.get_behavior_only_session_table()
         if self.cache:
             path = self.get_cache_path(None, self.BEHAVIOR_SESSIONS_KEY)
             sessions = one_file_call_caching(

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -12,7 +12,7 @@ from allensdk.brain_observatory.behavior.behavior_project_cache.tables \
     .sessions_table import \
     SessionsTable
 from allensdk.brain_observatory.behavior.project_apis.data_io import (
-    BehaviorProjectLimsApi)
+    BehaviorProjectLimsApi, BehaviorProjectCloudApi)
 from allensdk.api.warehouse_cache.caching_utilities import \
     one_file_call_caching, call_caching
 from allensdk.brain_observatory.behavior.behavior_project_cache.tables \
@@ -105,6 +105,13 @@ class VisualBehaviorOphysProjectCache(Cache):
         self.fetch_api = fetch_api
         self.fetch_tries = fetch_tries
         self.logger = logging.getLogger(self.__class__.__name__)
+
+    @classmethod
+    def from_s3_cache(cls, cache_dir: Union[str, Path],
+                      bucket_name: str) -> "VisualBehaviorOphysProjectCache":
+        fetch_api = BehaviorProjectCloudApi.from_s3_cache(
+                cache_dir, bucket_name)
+        return cls(fetch_api=fetch_api)
 
     @classmethod
     def from_lims(cls, manifest: Optional[Union[str, Path]] = None,

--- a/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
+++ b/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
@@ -47,21 +47,21 @@ class BehaviorProjectBase(ABC):
 
     @abstractmethod
     def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
+        """ Download a template for the natural movie stimulus. This is the
+        actual movie that was shown during the recording session.
+        :param number: identifier for this scene
+        :type number: int
+        :returns: An iterable yielding an npy file as bytes
+        """
+        pass
+
+    @abstractmethod
+    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
         """Download a template for the natural scene stimulus. This is the
         actual image that was shown during the recording session.
         :param number: idenfifier for this movie (note that this is an int,
             so to get the template for natural_movie_three should pass 3)
         :type number: int
         :returns: iterable yielding a tiff file as bytes
-        """
-        pass
-
-    @abstractmethod
-    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
-        actual movie that was shown during the recording session.
-        :param number: identifier for this scene
-        :type number: int
-        :returns: An iterable yielding an npy file as bytes
         """
         pass

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/__init__.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/__init__.py
@@ -1,1 +1,2 @@
 from allensdk.brain_observatory.behavior.project_apis.data_io.behavior_project_lims_api import BehaviorProjectLimsApi  # noqa: F401, E501
+from allensdk.brain_observatory.behavior.project_apis.data_io.behavior_project_cloud_api import BehaviorProjectCloudApi  # noqa: F401, E501

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -91,16 +91,17 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         -------
         BehaviorOphysExperiment
         """
-        #row = self._session_table.query(
-        #        f"ophys_session_id=={ophys_session_id}")
-        #if row.shape[0] != 1:
-        #    raise RuntimeError("The behavior_session_table should have "
-        #                       "1 and only 1 entry for a given "
-        #                       f"ophys_session_id. For {ophys_session_id} "
-        #                       f" there are {row.shape[0]} entries.")
-        #data_path = self.cache.download_data(row.data_file_id.values[0])
-        #return BehaviorOphysExperiment.from_nwb_path(str(data_path))
-        pass
+        row = self._experiment_table.query(
+                f"ophys_experiment_id=={ophys_experiment_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_ophys_experiment_table should "
+                               "have 1 and only 1 entry for a given "
+                               f"ophys_experiment_id. For "
+                               f"{ophys_experiment_id} "
+                               f" there are {row.shape[0]} entries.")
+        row = row.squeeze()
+        data_path = self.cache.download_data(str(int(row.file_id)))
+        return BehaviorOphysExperiment.from_nwb_path(str(data_path))
 
     def _get_session_table(self):
         session_table_path = self.cache.download_metadata(

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -97,7 +97,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
                                f"{behavior_session_id} "
                                f" there are {row.shape[0]} entries.")
         row = row.squeeze()
-        has_file_id = not pd.isna(row.file_id)
+        has_file_id = not pd.isna(row[self.cache.file_id_column])
         if not has_file_id:
             # some entries in this table represent ophys sessions
             # which have a many-to-one mapping between nwb files
@@ -110,7 +110,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
             oeid = ast.literal_eval(row.ophys_experiment_id)[0]
             row = self._experiment_table.query(
                 f"ophys_experiment_id=={oeid}").squeeze()
-        data_path = self.cache.download_data(str(int(row.file_id)))
+        data_path = self.cache.download_data(
+                str(int(row[self.cache.file_id_column])))
         return BehaviorSession.from_nwb_path(str(data_path))
 
     def get_behavior_ophys_experiment(self, ophys_experiment_id: int
@@ -136,7 +137,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
                                f"{ophys_experiment_id} "
                                f" there are {row.shape[0]} entries.")
         row = row.squeeze()
-        data_path = self.cache.download_data(str(int(row.file_id)))
+        data_path = self.cache.download_data(
+                str(int(row[self.cache.file_id_column])))
         return BehaviorOphysExperiment.from_nwb_path(str(data_path))
 
     def _get_session_table(self) -> pd.DataFrame:

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -271,20 +271,20 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         return self._experiment_table
 
     def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
+        """ Download a template for the natural movie stimulus. This is the
+        actual movie that was shown during the recording session.
+        :param number: identifier for this scene
+        :type number: int
+        :returns: An iterable yielding an npy file as bytes
+        """
+        raise NotImplementedError()
+
+    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
         """Download a template for the natural scene stimulus. This is the
         actual image that was shown during the recording session.
         :param number: idenfifier for this movie (note that this is an int,
             so to get the template for natural_movie_three should pass 3)
         :type number: int
         :returns: iterable yielding a tiff file as bytes
-        """
-        raise NotImplementedError()
-
-    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
-        actual movie that was shown during the recording session.
-        :param number: identifier for this scene
-        :type number: int
-        :returns: An iterable yielding an npy file as bytes
         """
         raise NotImplementedError()

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -17,9 +17,11 @@ from allensdk import __version__ as sdk_version
 
 # [min inclusive, max exclusive)
 COMPATIBILITY = {
-        "pipeline_versions": {
-            "2.9.0": {"AllenSDK": ["2.9.0", "3.0.0"]},
-            "2.10.0": {"AllenSDK": ["2.9.0", "3.0.0"]}}}
+    "pipeline_versions": {
+        "2.9.0": {"AllenSDK": ["2.9.0", "3.0.0"]},
+        "2.10.0": {"AllenSDK": ["2.10.0", "3.0.0"]}
+    }
+}
 
 
 class BehaviorCloudCacheVersionException(Exception):

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -62,12 +62,20 @@ def version_check(pipeline_versions: List[Dict[str, str]],
         raise BehaviorCloudCacheVersionException(
                 f"no version compatibility listed for {pipeline_version}")
     version_limits = compatibility["pipeline_versions"][pipeline_version]
-    pver = sdk_version
     smin = semver.VersionInfo.parse(version_limits["AllenSDK"][0])
     smax = semver.VersionInfo.parse(version_limits["AllenSDK"][1])
-    if (pver < smin) | (pver >= smax):
+    if (sdk_version < smin) | (sdk_version >= smax):
         raise BehaviorCloudCacheVersionException(
-                f"expected {smin} <= {pipeline_version} < {smax}")
+            f"""
+            The version of the visual-behavior-ophys data files (specified
+            in path_to_users_current_release_manifest) requires that your
+            AllenSDK version be >={smin} and <{smax}.
+            Your version of AllenSDK is: {sdk_version}.
+            If you want to use the specified manifest to retrieve data, please
+            upgrade or downgrade AllenSDK to the range specified.
+            If you just want to get the latest version of visual-behavior-ophys
+            data please upgrade to the latest AllenSDK version and try this
+            process again.""")
 
 
 class BehaviorProjectCloudApi(BehaviorProjectBase):

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -1,0 +1,141 @@
+import pandas as pd
+from typing import Iterable, Union
+from pathlib import Path
+import logging
+
+from allensdk.brain_observatory.behavior.project_apis.abcs import (
+    BehaviorProjectBase)
+from allensdk.brain_observatory.behavior.behavior_session import (
+    BehaviorSession)
+from allensdk.brain_observatory.behavior.behavior_ophys_session import (
+    BehaviorOphysExperiment)
+from allensdk.api.cloud_cache.cloud_cache import S3CloudCache
+
+
+class BehaviorProjectCloudApi(BehaviorProjectBase):
+    """API for downloading data released on S3
+     and returning tables.
+    """
+    def __init__(self, cache: S3CloudCache):
+        """
+        the passed cache should already have had `cache.load_manifest()`
+        executed. With this satisfied, the attributes
+          - metadata_file_names
+          - file_id_column
+        are populated
+        """
+        expected_metadata = set(["behavior_session_table.csv",
+                                 "ophys_session_table.csv",
+                                 "ophys_experiment_table.csv"])
+        self.cache = cache
+        if cache._manifest.metadata_file_names is None:
+            raise RuntimeError("S3CloudCache object has no metadata "
+                               "file names. BehaviorProjectCloudApi "
+                               "expects a S3CloudCache passed which "
+                               "has already run load_manifest()")
+        cache_metadata = set(cache._manifest.metadata_file_names)
+        if cache_metadata != expected_metadata:
+            raise RuntimeError("expected S3CloudCache object to have "
+                               f"metadata file names: {expected_metadata} "
+                               f"but it has {cache_metadata}")
+        self.logger = logging.getLogger("BehaviorProjectCloudApi")
+        self._get_session_table()
+        self._get_behavior_only_session_table()
+        self._get_experiment_table()
+
+    @staticmethod
+    def from_s3_cache(cache_dir: Union[str, Path],
+                      bucket_name: str) -> "BehaviorProjectCloudApi":
+        cache = S3CloudCache(cache_dir, bucket_name)
+        cache.load_latest_manifest()
+        return BehaviorProjectCloudApi(cache)
+
+    def get_behavior_only_session_data(
+            self, behavior_session_id: int) -> BehaviorSession:
+        """get a BehaviorSession by specifying behavior_session_id
+        Parameters
+        ----------
+        behavior_session_id: int
+            the id of the behavior_session
+        Returns
+        -------
+        BehaviorSession
+        """
+        row = self._behavior_only_session_table.query(
+                f"behavior_session_id=={behavior_session_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_only_session_table should have "
+                               "1 and only 1 entry for a given "
+                               "behavior_session_id. For "
+                               f"{behavior_session_id} "
+                               f" there are {row.shape[0]} entries.")
+        data_path = self.cache.download_data(row.data_file_id.values[0])
+        return BehaviorSession.from_nwb_path(str(data_path))
+
+    def get_session_data(self, ophys_session_id: int
+                         ) -> BehaviorOphysExperiment:
+        """get a BehaviorOphysExperiment by specifying session_id
+        Parameters
+        ----------
+        ophys_session_id: int
+            the id of the ophys_session
+        Returns
+        -------
+        BehaviorOphysExperiment
+        """
+        row = self._session_table.query(
+                f"ophys_session_id=={ophys_session_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_session_table should have "
+                               "1 and only 1 entry for a given "
+                               f"ophys_session_id. For {ophys_session_id} "
+                               f" there are {row.shape[0]} entries.")
+        data_path = self.cache.download_data(row.data_file_id.values[0])
+        return BehaviorOphysExperiment.from_nwb_path(str(data_path))
+
+    def _get_session_table(self):
+        session_table_path = self.cache.download_metadata(
+                "ophys_session_table.csv")
+        self._session_table = pd.read_csv(session_table_path)
+
+    def get_session_table(self) -> pd.DataFrame:
+        """Return a pd.Dataframe table with all ophys_session_ids and relevant
+        metadata."""
+        return self._session_table
+
+    def _get_behavior_only_session_table(self):
+        session_table_path = self.cache.download_metadata(
+                "behavior_session_table.csv")
+        self._behavior_only_session_table = pd.read_csv(session_table_path)
+
+    def get_behavior_only_session_table(self) -> pd.DataFrame:
+        """Return a pd.Dataframe table with all ophys_session_ids and relevant
+        metadata."""
+        return self._behavior_only_session_table
+
+    def _get_experiment_table(self):
+        experiment_table_path = self.cache.download_metadata(
+                "ophys_experiment_table.csv")
+        self._experiment_table = pd.read_csv(experiment_table_path)
+
+    def get_experiment_table(self):
+        return self._experiment_table
+
+    def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
+        """Download a template for the natural scene stimulus. This is the
+        actual image that was shown during the recording session.
+        :param number: idenfifier for this movie (note that this is an int,
+            so to get the template for natural_movie_three should pass 3)
+        :type number: int
+        :returns: iterable yielding a tiff file as bytes
+        """
+        raise NotImplementedError()
+
+    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
+        """ Download a template for the natural movie stimulus. This is the
+        actual movie that was shown during the recording session.
+        :param number: identifier for this scene
+        :type number: int
+        :returns: An iterable yielding an npy file as bytes
+        """
+        raise NotImplementedError()

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -7,7 +7,7 @@ from allensdk.brain_observatory.behavior.project_apis.abcs import (
     BehaviorProjectBase)
 from allensdk.brain_observatory.behavior.behavior_session import (
     BehaviorSession)
-from allensdk.brain_observatory.behavior.behavior_ophys_session import (
+from allensdk.brain_observatory.behavior.behavior_ophys_experiment import (
     BehaviorOphysExperiment)
 from allensdk.api.cloud_cache.cloud_cache import S3CloudCache
 
@@ -45,12 +45,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
     @staticmethod
     def from_s3_cache(cache_dir: Union[str, Path],
-                      bucket_name: str) -> "BehaviorProjectCloudApi":
-        cache = S3CloudCache(cache_dir, bucket_name)
+                      bucket_name: str,
+                      project_name: str) -> "BehaviorProjectCloudApi":
+        cache = S3CloudCache(cache_dir, bucket_name, project_name)
         cache.load_latest_manifest()
         return BehaviorProjectCloudApi(cache)
 
-    def get_behavior_only_session_data(
+    def get_behavior_session(
             self, behavior_session_id: int) -> BehaviorSession:
         """get a BehaviorSession by specifying behavior_session_id
         Parameters
@@ -61,37 +62,39 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         -------
         BehaviorSession
         """
-        row = self._behavior_only_session_table.query(
-                f"behavior_session_id=={behavior_session_id}")
-        if row.shape[0] != 1:
-            raise RuntimeError("The behavior_only_session_table should have "
-                               "1 and only 1 entry for a given "
-                               "behavior_session_id. For "
-                               f"{behavior_session_id} "
-                               f" there are {row.shape[0]} entries.")
-        data_path = self.cache.download_data(row.data_file_id.values[0])
-        return BehaviorSession.from_nwb_path(str(data_path))
+        #row = self._behavior_only_session_table.query(
+        #        f"behavior_session_id=={behavior_session_id}")
+        #if row.shape[0] != 1:
+        #    raise RuntimeError("The behavior_only_session_table should have "
+        #                       "1 and only 1 entry for a given "
+        #                       "behavior_session_id. For "
+        #                       f"{behavior_session_id} "
+        #                       f" there are {row.shape[0]} entries.")
+        #data_path = self.cache.download_data(row.data_file_id.values[0])
+        #return BehaviorSession.from_nwb_path(str(data_path))
+        pass
 
-    def get_session_data(self, ophys_session_id: int
-                         ) -> BehaviorOphysExperiment:
-        """get a BehaviorOphysExperiment by specifying session_id
+    def get_behavior_ophys_experiment(self, ophys_experiment_id: int
+                                      ) -> BehaviorOphysExperiment:
+        """get a BehaviorOphysExperiment by specifying ophys_experiment_id
         Parameters
         ----------
-        ophys_session_id: int
-            the id of the ophys_session
+        ophys_experiment_id: int
+            the id of the ophys_experiment
         Returns
         -------
         BehaviorOphysExperiment
         """
-        row = self._session_table.query(
-                f"ophys_session_id=={ophys_session_id}")
-        if row.shape[0] != 1:
-            raise RuntimeError("The behavior_session_table should have "
-                               "1 and only 1 entry for a given "
-                               f"ophys_session_id. For {ophys_session_id} "
-                               f" there are {row.shape[0]} entries.")
-        data_path = self.cache.download_data(row.data_file_id.values[0])
-        return BehaviorOphysExperiment.from_nwb_path(str(data_path))
+        #row = self._session_table.query(
+        #        f"ophys_session_id=={ophys_session_id}")
+        #if row.shape[0] != 1:
+        #    raise RuntimeError("The behavior_session_table should have "
+        #                       "1 and only 1 entry for a given "
+        #                       f"ophys_session_id. For {ophys_session_id} "
+        #                       f" there are {row.shape[0]} entries.")
+        #data_path = self.cache.download_data(row.data_file_id.values[0])
+        #return BehaviorOphysExperiment.from_nwb_path(str(data_path))
+        pass
 
     def _get_session_table(self):
         session_table_path = self.cache.download_metadata(

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -200,8 +200,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         has_file_id = not pd.isna(row[self.cache.file_id_column])
         if not has_file_id:
             oeid = row.ophys_experiment_id[0]
-            row = self._experiment_table.query(
-                f"ophys_experiment_id=={oeid}").squeeze()
+            row = self._experiment_table.query(f"index=={oeid}")
         data_path = self.cache.download_data(
                 str(int(row[self.cache.file_id_column])))
         return BehaviorSession.from_nwb_path(str(data_path))
@@ -221,14 +220,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
         """
         row = self._experiment_table.query(
-                f"ophys_experiment_id=={ophys_experiment_id}")
+                f"index=={ophys_experiment_id}")
         if row.shape[0] != 1:
             raise RuntimeError("The behavior_ophys_experiment_table should "
                                "have 1 and only 1 entry for a given "
                                f"ophys_experiment_id. For "
                                f"{ophys_experiment_id} "
                                f" there are {row.shape[0]} entries.")
-        row = row.squeeze()
         data_path = self.cache.download_data(
                 str(int(row[self.cache.file_id_column])))
         return BehaviorOphysExperiment.from_nwb_path(str(data_path))
@@ -236,7 +234,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
     def _get_session_table(self) -> pd.DataFrame:
         session_table_path = self.cache.download_metadata(
                 "ophys_session_table")
-        self._session_table = literal_col_eval(pd.read_csv(session_table_path))
+        df = literal_col_eval(pd.read_csv(session_table_path))
+        self._session_table = df.set_index("ophys_session_id")
 
     def get_session_table(self) -> pd.DataFrame:
         """Return a pd.Dataframe table summarizing ophys_sessions
@@ -254,8 +253,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
     def _get_behavior_only_session_table(self):
         session_table_path = self.cache.download_metadata(
                 "behavior_session_table")
-        self._behavior_only_session_table = literal_col_eval(
-                pd.read_csv(session_table_path))
+        df = literal_col_eval(pd.read_csv(session_table_path))
+        self._behavior_only_session_table = df.set_index("behavior_session_id")
 
     def get_behavior_only_session_table(self) -> pd.DataFrame:
         """Return a pd.Dataframe table with both behavior-only
@@ -281,8 +280,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
     def _get_experiment_table(self):
         experiment_table_path = self.cache.download_metadata(
                 "ophys_experiment_table")
-        self._experiment_table = literal_col_eval(
-                pd.read_csv(experiment_table_path))
+        df = literal_col_eval(pd.read_csv(experiment_table_path))
+        self._experiment_table = df.set_index("ophys_experiment_id")
 
     def get_experiment_table(self):
         """returns a pd.DataFrame where each entry has a 1-to-1

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -24,9 +24,9 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
           - file_id_column
         are populated
         """
-        expected_metadata = set(["behavior_session_table.csv",
-                                 "ophys_session_table.csv",
-                                 "ophys_experiment_table.csv"])
+        expected_metadata = set(["behavior_session_table",
+                                 "ophys_session_table",
+                                 "ophys_experiment_table"])
         self.cache = cache
         if cache._manifest.metadata_file_names is None:
             raise RuntimeError("S3CloudCache object has no metadata "
@@ -98,7 +98,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
     def _get_session_table(self):
         session_table_path = self.cache.download_metadata(
-                "ophys_session_table.csv")
+                "ophys_session_table")
         self._session_table = pd.read_csv(session_table_path)
 
     def get_session_table(self) -> pd.DataFrame:
@@ -108,7 +108,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
     def _get_behavior_only_session_table(self):
         session_table_path = self.cache.download_metadata(
-                "behavior_session_table.csv")
+                "behavior_session_table")
         self._behavior_only_session_table = pd.read_csv(session_table_path)
 
     def get_behavior_only_session_table(self) -> pd.DataFrame:
@@ -118,7 +118,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
     def _get_experiment_table(self):
         experiment_table_path = self.cache.download_metadata(
-                "ophys_experiment_table.csv")
+                "ophys_experiment_table")
         self._experiment_table = pd.read_csv(experiment_table_path)
 
     def get_experiment_table(self):

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
@@ -567,20 +567,20 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
             "oe.id", release_files.index.tolist())
 
     def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
+        """ Download a template for the natural movie stimulus. This is the
+        actual movie that was shown during the recording session.
+        :param number: identifier for this scene
+        :type number: int
+        :returns: An iterable yielding an npy file as bytes
+        """
+        raise NotImplementedError()
+
+    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
         """Download a template for the natural scene stimulus. This is the
         actual image that was shown during the recording session.
         :param number: idenfifier for this movie (note that this is an int,
             so to get the template for natural_movie_three should pass 3)
         :type number: int
         :returns: iterable yielding a tiff file as bytes
-        """
-        raise NotImplementedError()
-
-    def get_natural_scene_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
-        actual movie that was shown during the recording session.
-        :param number: identifier for this scene
-        :type number: int
-        :returns: An iterable yielding an npy file as bytes
         """
         raise NotImplementedError()

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_nwb_api.py
@@ -37,6 +37,7 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._behavior_session_id = None
 
     def save(self, session_object):
 
@@ -120,7 +121,9 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
         return nwbfile
 
     def get_behavior_session_id(self) -> int:
-        return int(self.nwbfile.identifier)
+        if self._behavior_session_id is None:
+            self.get_metadata()
+        return self._behavior_session_id
 
     def get_running_acquisition_df(self) -> pd.DataFrame:
         """Get running speed acquisition data.
@@ -251,6 +254,7 @@ class BehaviorNwbApi(NwbApi, BehaviorBase):
         metadata_nwb_obj = self.nwbfile.lab_meta_data['metadata']
         data = OphysBehaviorMetadataSchema(
             exclude=['date_of_acquisition']).dump(metadata_nwb_obj)
+        self._behavior_session_id = data["behavior_session_id"]
 
         # Add pyNWB Subject metadata to behavior session metadata
         nwb_subject = self.nwbfile.subject

--- a/allensdk/test/api/cloud_cache/test_cache.py
+++ b/allensdk/test/api/cloud_cache/test_cache.py
@@ -81,6 +81,7 @@ def test_loading_manifest():
 
     manifest_1 = {'manifest_version': '1',
                   'metadata_file_id_column_name': 'file_id',
+                  'data_pipeline': 'placeholder',
                   'metadata_files': {'a.csv': {'url': 'http://www.junk.com',
                                                'version_id': '1111',
                                                'file_hash': 'abcde'},
@@ -90,6 +91,7 @@ def test_loading_manifest():
 
     manifest_2 = {'manifest_version': '2',
                   'metadata_file_id_column_name': 'file_id',
+                  'data_pipeline': 'placeholder',
                   'metadata_files': {'c.csv': {'url': 'http://www.absurd.com',
                                                'version_id': '3333',
                                                'file_hash': 'lmnop'},
@@ -431,6 +433,7 @@ def test_download_data(tmpdir):
                  'file_hash': true_checksum}
 
     manifest['data_files'] = {'only_data_file': data_file}
+    manifest['data_pipeline'] = 'placeholder'
 
     client.put_object(Bucket=test_bucket_name,
                       Key='proj/manifests/manifest_1.json',
@@ -501,6 +504,7 @@ def test_download_metadata(tmpdir):
                      'file_hash': true_checksum}
 
     manifest['metadata_files'] = {'metadata_file.csv': metadata_file}
+    manifest['data_pipeline'] = 'placeholder'
 
     client.put_object(Bucket=test_bucket_name,
                       Key='proj/manifests/manifest_1.json',
@@ -579,6 +583,7 @@ def test_metadata(tmpdir):
                      'file_hash': true_checksum}
 
     manifest['metadata_files'] = {'metadata_file.csv': metadata_file}
+    manifest['data_pipeline'] = 'placeholder'
 
     client.put_object(Bucket=test_bucket_name,
                       Key='proj/manifests/manifest_1.json',

--- a/allensdk/test/api/cloud_cache/test_full_process.py
+++ b/allensdk/test/api/cloud_cache/test_full_process.py
@@ -141,6 +141,7 @@ def test_full_cache_system(tmpdir):
 
     manifest_1 = {}
     manifest_1['manifest_version'] = 'A'
+    manifest_1['project_name'] = "project-A1"
     manifest_1['metadata_file_id_column_name'] = 'file_id'
     manifest_1['data_pipeline'] = 'placeholder'
     data_files_1 = {}
@@ -162,6 +163,7 @@ def test_full_cache_system(tmpdir):
 
     manifest_2 = {}
     manifest_2['manifest_version'] = 'B'
+    manifest_2['project_name'] = "project-B2"
     manifest_2['metadata_file_id_column_name'] = 'file_id'
     manifest_2['data_pipeline'] = 'placeholder'
     data_files_2 = {}

--- a/allensdk/test/api/cloud_cache/test_full_process.py
+++ b/allensdk/test/api/cloud_cache/test_full_process.py
@@ -142,6 +142,7 @@ def test_full_cache_system(tmpdir):
     manifest_1 = {}
     manifest_1['manifest_version'] = 'A'
     manifest_1['metadata_file_id_column_name'] = 'file_id'
+    manifest_1['data_pipeline'] = 'placeholder'
     data_files_1 = {}
     for k in ('data1', 'data2', 'data3'):
         obj = {}
@@ -162,6 +163,7 @@ def test_full_cache_system(tmpdir):
     manifest_2 = {}
     manifest_2['manifest_version'] = 'B'
     manifest_2['metadata_file_id_column_name'] = 'file_id'
+    manifest_2['data_pipeline'] = 'placeholder'
     data_files_2 = {}
     for k in ('data1', 'data2'):
         obj = {}

--- a/allensdk/test/api/cloud_cache/test_manifest.py
+++ b/allensdk/test/api/cloud_cache/test_manifest.py
@@ -35,6 +35,7 @@ def test_load(tmpdir):
     metadata_files['x.txt'] = []
     metadata_files['y.txt'] = []
     good_manifest['metadata_files'] = metadata_files
+    good_manifest['data_pipeline'] = 'placeholder'
 
     mfest = Manifest(pathlib.Path(tmpdir) / 'my/cache/dir')
 
@@ -59,6 +60,7 @@ def test_load(tmpdir):
     metadata_files['k.txt'] = []
     metadata_files['u.txt'] = []
     good_manifest['metadata_files'] = metadata_files
+    good_manifest['data_pipeline'] = 'placeholder'
 
     with io.StringIO() as stream:
         stream.write(json.dumps(good_manifest))
@@ -122,6 +124,7 @@ def test_metadata_file_attributes():
     manifest['metadata_files'] = metadata_files
     manifest['manifest_version'] = '000'
     manifest['metadata_file_id_column_name'] = 'file_id'
+    manifest['data_pipeline'] = 'placeholder'
 
     mfest = Manifest('/my/cache/dir/')
     with io.StringIO() as stream:
@@ -164,6 +167,7 @@ def test_data_file_attributes():
     manifest['metadata_files'] = {}
     manifest['manifest_version'] = '0'
     manifest['metadata_file_id_column_name'] = 'file_id'
+    manifest['data_pipeline'] = 'placeholder'
     data_files = {}
     data_files['a'] = {'url': 'http://my.url.com/path/to/a.nwb',
                        'version_id': '12345',
@@ -218,6 +222,7 @@ def test_loading_two_manifests():
                                     'version_id': '67890',
                                     'file_hash': 'fghijk'}
     manifest_1['metadata_files'] = metadata_1
+    manifest_1['data_pipeline'] = 'placeholder'
     data_1 = {}
     data_1['c'] = {'url': 'http://ccc.com/third/path/c.csv',
                    'version_id': '11121',
@@ -239,6 +244,7 @@ def test_loading_two_manifests():
                                     'version_id': '192021',
                                     'file_hash': 'cdefghi'}
     manifest_2['metadata_files'] = metadata_2
+    manifest_2['data_pipeline'] = 'placeholder'
     data_2 = {}
     data_2['c'] = {'url': 'http://ccc.com/third/path/c.csv',
                    'version_id': '222324',

--- a/allensdk/test/api/cloud_cache/test_manifest.py
+++ b/allensdk/test/api/cloud_cache/test_manifest.py
@@ -1,98 +1,44 @@
 import pytest
 import json
-import io
 import pathlib
 from allensdk.internal.core.lims_utilities import safe_system_path
 from allensdk.api.cloud_cache.manifest import Manifest
 from allensdk.api.cloud_cache.file_attributes import CacheFileAttributes  # noqa: E501
 
 
-def test_constructor():
+@pytest.fixture
+def meta_json_path(tmpdir):
+    jpath = tmpdir / "somejson.json"
+    d = {
+            "project_name": "X",
+            "manifest_version": "Y",
+            "metadata_file_id_column_name": "Z",
+            "data_pipeline": "ZA",
+            "metadata_files": ["ZB", "ZC", "ZD"],
+            "data_files": {"AB": "ab", "BC": "bc", "CD": "cd"}}
+    with open(jpath, "w") as f:
+        json.dump(d, f)
+    yield jpath
+
+
+def test_constructor(meta_json_path):
     """
     Make sure that the Manifest class __init__ runs and
     raises an error if you give it an unexpected cache_dir
     """
-    _ = Manifest('my/cache/dir')
-    _ = Manifest(pathlib.Path('my/other/cache/dir'))
-    with pytest.raises(ValueError) as context:
-        _ = Manifest(1234.2)
-    msg = "cache_dir must be either a str or a pathlib.Path; "
-    msg += "got <class 'float'>"
-    assert context.value.args[0] == msg
+    Manifest('my/cache/dir', meta_json_path)
+    Manifest(pathlib.Path('my/other/cache/dir'), meta_json_path)
+    with pytest.raises(ValueError, match=r"cache_dir must be either a str.*"):
+        Manifest(1234.2, meta_json_path)
 
 
-def test_load(tmpdir):
-    """
-    Bare bones check to verify that Manifest.load can be run and that it
-    will raise the correct error when the JSONized manifest is not a dict
-    """
-
-    good_manifest = {}
-    good_manifest['manifest_version'] = 'A'
-    good_manifest['metadata_file_id_column_name'] = 'file_id'
-    metadata_files = {}
-    metadata_files['z.txt'] = []
-    metadata_files['x.txt'] = []
-    metadata_files['y.txt'] = []
-    good_manifest['metadata_files'] = metadata_files
-    good_manifest['data_pipeline'] = 'placeholder'
-
-    mfest = Manifest(pathlib.Path(tmpdir) / 'my/cache/dir')
-
-    with io.StringIO() as stream:
-        stream.write(json.dumps(good_manifest))
-        stream.seek(0)
-
-        mfest.load(stream)
-
-    assert mfest.version == 'A'
-    assert mfest.metadata_file_names == ['x.txt', 'y.txt', 'z.txt']
-    assert mfest._cache_dir == pathlib.Path(str(tmpdir)+'/my/cache/dir')
-
-    del stream
-
-    # test that you can load a new manifest.json into the same Manifest
-    good_manifest = {}
-    good_manifest['manifest_version'] = 'B'
-    good_manifest['metadata_file_id_column_name'] = 'file_id'
-    metadata_files = {}
-    metadata_files['n.txt'] = []
-    metadata_files['k.txt'] = []
-    metadata_files['u.txt'] = []
-    good_manifest['metadata_files'] = metadata_files
-    good_manifest['data_pipeline'] = 'placeholder'
-
-    with io.StringIO() as stream:
-        stream.write(json.dumps(good_manifest))
-        stream.seek(0)
-
-        mfest.load(stream)
-
-    assert mfest.version == 'B'
-    assert mfest.metadata_file_names == ['k.txt', 'n.txt', 'u.txt']
-
-    del stream
-
-    # test that an error is raised when manifest.json is not a dict
-    bad_manifest = ['a', 'b', 'c']
-    with io.StringIO() as stream:
-        stream.write(json.dumps(bad_manifest))
-        stream.seek(0)
-        with pytest.raises(ValueError) as context:
-            mfest.load(stream)
-
-    msg = "Expected to deserialize manifest into a dict; "
-    msg += "instead got <class 'list'>"
-    assert context.value.args[0] == msg
-
-
-def test_create_file_attributes():
+def test_create_file_attributes(meta_json_path):
     """
     Test that Manifest._create_file_attributes correctly
     handles input parameters (this is mostly a test of
     local_path generation)
     """
-    mfest = Manifest('/my/cache/dir')
+    mfest = Manifest('/my/cache/dir', meta_json_path)
     attr = mfest._create_file_attributes('http://my.url.com/path/to/file.txt',
                                          '12345',
                                          'aaabbbcccddd')
@@ -101,17 +47,13 @@ def test_create_file_attributes():
     assert attr.url == 'http://my.url.com/path/to/file.txt'
     assert attr.version_id == '12345'
     assert attr.file_hash == 'aaabbbcccddd'
-    expected_path = '/my/cache/dir/aaabbbcccddd/path/to/file.txt'
+    expected_path = '/my/cache/dir/X-Y/to/file.txt'
     assert attr.local_path == pathlib.Path(expected_path).resolve()
 
 
-def test_metadata_file_attributes():
-    """
-    Test that Manifest.metadata_file_attributes returns the
-    correct CacheFileAttributes object and raises the correct
-    error when you ask for a metadata file that does not exist
-    """
-
+@pytest.fixture
+def manifest_for_metadata(tmpdir):
+    jpath = tmpdir / "a_manifest.json"
     manifest = {}
     metadata_files = {}
     metadata_files['a.txt'] = {'url': 'http://my.url.com/path/to/a.txt',
@@ -122,21 +64,29 @@ def test_metadata_file_attributes():
                                'file_hash': 'fghijk'}
 
     manifest['metadata_files'] = metadata_files
+    manifest['project_name'] = "some-project"
     manifest['manifest_version'] = '000'
     manifest['metadata_file_id_column_name'] = 'file_id'
     manifest['data_pipeline'] = 'placeholder'
+    with open(jpath, "w") as f:
+        json.dump(manifest, f)
+    yield jpath
 
-    mfest = Manifest('/my/cache/dir/')
-    with io.StringIO() as stream:
-        stream.write(json.dumps(manifest))
-        stream.seek(0)
-        mfest.load(stream)
+
+def test_metadata_file_attributes(manifest_for_metadata):
+    """
+    Test that Manifest.metadata_file_attributes returns the
+    correct CacheFileAttributes object and raises the correct
+    error when you ask for a metadata file that does not exist
+    """
+
+    mfest = Manifest('/my/cache/dir/', manifest_for_metadata)
 
     a_obj = mfest.metadata_file_attributes('a.txt')
     assert a_obj.url == 'http://my.url.com/path/to/a.txt'
     assert a_obj.version_id == '12345'
     assert a_obj.file_hash == 'abcde'
-    expected = safe_system_path('/my/cache/dir/abcde/path/to/a.txt')
+    expected = safe_system_path('/my/cache/dir/some-project-000/to/a.txt')
     expected = pathlib.Path(expected).resolve()
     assert a_obj.local_path == expected
 
@@ -144,7 +94,7 @@ def test_metadata_file_attributes():
     assert b_obj.url == 'http://my.other.url.com/different/path/to/b.txt'
     assert b_obj.version_id == '67890'
     assert b_obj.file_hash == 'fghijk'
-    expected = safe_system_path('/my/cache/dir/fghijk/different/path/to/b.txt')
+    expected = safe_system_path('/my/cache/dir/some-project-000/path/to/b.txt')
     expected = pathlib.Path(expected).resolve()
     assert b_obj.local_path == expected
 
@@ -157,45 +107,48 @@ def test_metadata_file_attributes():
     assert msg in context.value.args[0]
 
 
-def test_data_file_attributes():
-    """
-    Test that Manifest.data_file_attributes returns the correct
-    CacheFileAttributes object and raises the correct error when
-    you ask for a data file that does not exist
-    """
+@pytest.fixture
+def manifest_with_data(tmpdir):
+    jpath = tmpdir / "manifest_with files.json"
     manifest = {}
     manifest['metadata_files'] = {}
     manifest['manifest_version'] = '0'
+    manifest['project_name'] = "myproject"
     manifest['metadata_file_id_column_name'] = 'file_id'
     manifest['data_pipeline'] = 'placeholder'
     data_files = {}
-    data_files['a'] = {'url': 'http://my.url.com/path/to/a.nwb',
+    data_files['a'] = {'url': 'http://my.url.com/myproject/path/to/a.nwb',
                        'version_id': '12345',
                        'file_hash': 'abcde'}
     data_files['b'] = {'url': 'http://my.other.url.com/different/path/b.nwb',
                        'version_id': '67890',
                        'file_hash': 'fghijk'}
     manifest['data_files'] = data_files
+    with open(jpath, "w") as f:
+        json.dump(manifest, f)
+    yield jpath
 
-    mfest = Manifest('/my/cache/dir')
 
-    with io.StringIO() as stream:
-        stream.write(json.dumps(manifest))
-        stream.seek(0)
-        mfest.load(stream)
+def test_data_file_attributes(manifest_with_data):
+    """
+    Test that Manifest.data_file_attributes returns the correct
+    CacheFileAttributes object and raises the correct error when
+    you ask for a data file that does not exist
+    """
+    mfest = Manifest('/my/cache/dir', manifest_with_data)
 
     a_obj = mfest.data_file_attributes('a')
-    assert a_obj.url == 'http://my.url.com/path/to/a.nwb'
+    assert a_obj.url == 'http://my.url.com/myproject/path/to/a.nwb'
     assert a_obj.version_id == '12345'
     assert a_obj.file_hash == 'abcde'
-    expected = safe_system_path('/my/cache/dir/abcde/path/to/a.nwb')
+    expected = safe_system_path('/my/cache/dir/myproject-0/path/to/a.nwb')
     assert a_obj.local_path == pathlib.Path(expected).resolve()
 
     b_obj = mfest.data_file_attributes('b')
     assert b_obj.url == 'http://my.other.url.com/different/path/b.nwb'
     assert b_obj.version_id == '67890'
     assert b_obj.file_hash == 'fghijk'
-    expected = safe_system_path('/my/cache/dir/fghijk/different/path/b.nwb')
+    expected = safe_system_path('/my/cache/dir/myproject-0/path/b.nwb')
     assert b_obj.local_path == pathlib.Path(expected).resolve()
 
     with pytest.raises(ValueError) as context:
@@ -204,156 +157,16 @@ def test_data_file_attributes():
     assert msg in context.value.args[0]
 
 
-def test_loading_two_manifests():
-    """
-    Test that Manifest behaves correctly after re-running load() on
-    a different manifest
-    """
-
-    # create two manifests, meant to represents different versions
-    # of the same dataset
-
-    manifest_1 = {}
-    metadata_1 = {}
-    metadata_1['metadata_a.csv'] = {'url': 'http://aaa.com/path/to/a.csv',
-                                    'version_id': '12345',
-                                    'file_hash': 'abcde'}
-    metadata_1['metadata_b.csv'] = {'url': 'http://bbb.com/other/path/b.csv',
-                                    'version_id': '67890',
-                                    'file_hash': 'fghijk'}
-    manifest_1['metadata_files'] = metadata_1
-    manifest_1['data_pipeline'] = 'placeholder'
-    data_1 = {}
-    data_1['c'] = {'url': 'http://ccc.com/third/path/c.csv',
-                   'version_id': '11121',
-                   'file_hash': 'lmnopq'}
-    data_1['d'] = {'url': 'http://ddd.com/fourth/path/d.csv',
-                   'version_id': '31415',
-                   'file_hash': 'rstuvw'}
-
-    manifest_1['data_files'] = data_1
-    manifest_1['manifest_version'] = '1'
-    manifest_1['metadata_file_id_column_name'] = 'file_id'
-
-    manifest_2 = {}
-    metadata_2 = {}
-    metadata_2['metadata_a.csv'] = {'url': 'http://aaa.com/path/to/a.csv',
-                                    'version_id': '161718',
-                                    'file_hash': 'xyzab'}
-    metadata_2['metadata_f.csv'] = {'url': 'http://fff.com/fifth/path/f.csv',
-                                    'version_id': '192021',
-                                    'file_hash': 'cdefghi'}
-    manifest_2['metadata_files'] = metadata_2
-    manifest_2['data_pipeline'] = 'placeholder'
-    data_2 = {}
-    data_2['c'] = {'url': 'http://ccc.com/third/path/c.csv',
-                   'version_id': '222324',
-                   'file_hash': 'jklmnop'}
-    data_2['g'] = {'url': 'http://ggg.com/sixth/path/g.csv',
-                   'version_id': '25262728',
-                   'file_hash': 'qrstuvwxy'}
-
-    manifest_2['data_files'] = data_2
-    manifest_2['manifest_version'] = '2'
-    manifest_2['metadata_file_id_column_name'] = 'file_id'
-
-    mfest = Manifest('/my/cache/dir')
-
-    # load the first version of the manifest and check results
-
-    with io.StringIO() as stream_1:
-
-        stream_1.write(json.dumps(manifest_1))
-        stream_1.seek(0)
-        mfest.load(stream_1)
-
-    assert mfest.version == '1'
-    assert mfest.metadata_file_names == ['metadata_a.csv', 'metadata_b.csv']
-
-    m_obj = mfest.metadata_file_attributes('metadata_a.csv')
-    assert m_obj.url == 'http://aaa.com/path/to/a.csv'
-    assert m_obj.version_id == '12345'
-    assert m_obj.file_hash == 'abcde'
-    expected = safe_system_path('/my/cache/dir/abcde/path/to/a.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    m_obj = mfest.metadata_file_attributes('metadata_b.csv')
-    assert m_obj.url == 'http://bbb.com/other/path/b.csv'
-    assert m_obj.version_id == '67890'
-    assert m_obj.file_hash == 'fghijk'
-    expected = safe_system_path('/my/cache/dir/fghijk/other/path/b.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    d_obj = mfest.data_file_attributes('c')
-    assert d_obj.url == 'http://ccc.com/third/path/c.csv'
-    assert d_obj.version_id == '11121'
-    assert d_obj.file_hash == 'lmnopq'
-    expected = '/my/cache/dir/lmnopq/third/path/c.csv'
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    d_obj = mfest.data_file_attributes('d')
-    assert d_obj.url == 'http://ddd.com/fourth/path/d.csv'
-    assert d_obj.version_id == '31415'
-    assert d_obj.file_hash == 'rstuvw'
-    expected = safe_system_path('/my/cache/dir/rstuvw/fourth/path/d.csv')
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    # now load the second manifest and make sure that everything
-    # changes accordingly
-
-    with io.StringIO() as stream_2:
-        stream_2.write(json.dumps(manifest_2))
-        stream_2.seek(0)
-
-        mfest.load(stream_2)
-
-    assert mfest.version == '2'
-    assert mfest.metadata_file_names == ['metadata_a.csv', 'metadata_f.csv']
-
-    m_obj = mfest.metadata_file_attributes('metadata_a.csv')
-    assert m_obj.url == 'http://aaa.com/path/to/a.csv'
-    assert m_obj.version_id == '161718'
-    assert m_obj.file_hash == 'xyzab'
-    expected = safe_system_path('/my/cache/dir/xyzab/path/to/a.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    m_obj = mfest.metadata_file_attributes('metadata_f.csv')
-    assert m_obj.url == 'http://fff.com/fifth/path/f.csv'
-    assert m_obj.version_id == '192021'
-    assert m_obj.file_hash == 'cdefghi'
-    expected = safe_system_path('/my/cache/dir/cdefghi/fifth/path/f.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    with pytest.raises(ValueError):
-        _ = mfest.metadata_file_attributes('metadata_b.csv')
-
-    d_obj = mfest.data_file_attributes('c')
-    assert d_obj.url == 'http://ccc.com/third/path/c.csv'
-    assert d_obj.version_id == '222324'
-    assert d_obj.file_hash == 'jklmnop'
-    expected = safe_system_path('/my/cache/dir/jklmnop/third/path/c.csv')
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    d_obj = mfest.data_file_attributes('g')
-    assert d_obj.url == 'http://ggg.com/sixth/path/g.csv'
-    assert d_obj.version_id == '25262728'
-    assert d_obj.file_hash == 'qrstuvwxy'
-    expected = safe_system_path('/my/cache/dir/qrstuvwxy/sixth/path/g.csv')
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    with pytest.raises(ValueError):
-        _ = mfest.data_file_attributes('d')
-
-
-def test_file_attribute_errors():
+def test_file_attribute_errors(meta_json_path):
     """
     Test that Manifest raises the correct error if you try to get file
     attributes before loading a manifest.json
     """
-    mfest = Manifest("/my/cache/dir")
-    with pytest.raises(RuntimeError) as context:
-        _ = mfest.metadata_file_attributes('some_file.txt')
-    assert 'cannot retrieve metadata_file_attributes' in context.value.args[0]
-    with pytest.raises(RuntimeError) as context:
-        _ = mfest.data_file_attributes('other_file.txt')
-    assert 'cannot retrieve data_file_attributes' in context.value.args[0]
+    mfest = Manifest("/my/cache/dir", meta_json_path)
+    with pytest.raises(ValueError,
+                       match=r".* not in self.metadata_file_names"):
+        mfest.metadata_file_attributes('some_file.txt')
+
+    with pytest.raises(ValueError,
+                       match=r".* not a data file listed in manifest"):
+        mfest.data_file_attributes('other_file.txt')

--- a/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
+++ b/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
@@ -1,10 +1,10 @@
 import re
-import io
 import json
 from allensdk.api.cloud_cache.cloud_cache import CloudCacheBase
+from allensdk.api.cloud_cache.manifest import Manifest
 
 
-def test_windows_path_to_isilon(monkeypatch):
+def test_windows_path_to_isilon(monkeypatch, tmpdir):
     """
     This test is just meant to verify on Windows CI instances
     that, if a path to the `/allen/` shared file store is used as
@@ -17,6 +17,7 @@ def test_windows_path_to_isilon(monkeypatch):
     manifest_1 = {'manifest_version': '1',
                   'metadata_file_id_column_name': 'file_id',
                   'data_pipeline': 'placeholder',
+                  'project_name': 'my-project',
                   'metadata_files': {'a.csv': {'url': 'http://www.junk.com/path/to/a.csv',  # noqa: E501
                                                'version_id': '1111',
                                                'file_hash': 'abcde'},
@@ -27,12 +28,9 @@ def test_windows_path_to_isilon(monkeypatch):
                                             'version_id': '1111',
                                             'file_hash': 'lmnopqrst'}}
                   }
-
-    def dummy_load_manifest(self):
-        with io.StringIO() as stream:
-            stream.write(json.dumps(manifest_1))
-            stream.seek(0)
-            self._manifest.load(stream)
+    manifest_path = tmpdir / "manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump(manifest_1, f)
 
     def dummy_file_exists(self, m):
         return True
@@ -58,15 +56,11 @@ def test_windows_path_to_isilon(monkeypatch):
                 pass
 
         ctx.setattr(TestCloudCache,
-                    'load_manifest',
-                    dummy_load_manifest)
-
-        ctx.setattr(TestCloudCache,
                     '_file_exists',
                     dummy_file_exists)
 
         cache = TestCloudCache(cache_dir, 'proj')
-        cache.load_manifest()
+        cache._manifest = Manifest(cache_dir, json_input=manifest_path)
 
         m_path = cache.metadata_path('a.csv')
         assert bad_windows_pattern.match(str(m_path)) is None

--- a/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
+++ b/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
@@ -16,6 +16,7 @@ def test_windows_path_to_isilon(monkeypatch):
 
     manifest_1 = {'manifest_version': '1',
                   'metadata_file_id_column_name': 'file_id',
+                  'data_pipeline': 'placeholder',
                   'metadata_files': {'a.csv': {'url': 'http://www.junk.com/path/to/a.csv',  # noqa: E501
                                                'version_id': '1111',
                                                'file_hash': 'abcde'},

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
@@ -127,7 +127,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch):
                 {"pipeline_versions": {
                     "2.9.0": {"AllenSDK": ["2.9.1", "3.0.0"]}}},
                 cloudapi.BehaviorCloudCacheVersionException,
-                r"expected 2.9.1 <= 2.9.0 < 3.0.0"),
+                r".*version be >=2.9.1 and <3.0.0.*"),
             (
                 [{
                     "name": "AllenSDK",
@@ -136,7 +136,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch):
                 {"pipeline_versions": {
                     "2.9.0": {"AllenSDK": ["2.8.0", "2.9.0"]}}},
                 cloudapi.BehaviorCloudCacheVersionException,
-                r"expected 2.8.0 <= 2.9.0 < 2.9.0"),
+                r".*version be >=2.8.0 and <2.9.0.*"),
             (
                 [{
                     "name": "AllenSDK",

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
@@ -80,6 +80,8 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch):
 
     # behavior session table as expected
     bost = api.get_behavior_only_session_table()
+    assert bost.index.name == "behavior_session_id"
+    bost = bost.reset_index()
     ebost = expected["behavior_session_table"]
     for k in ["behavior_session_id", "file_id"]:
         pd.testing.assert_series_equal(bost[k], ebost[k])
@@ -89,6 +91,8 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch):
 
     # ophys session table as expected
     ost = api.get_session_table()
+    assert ost.index.name == "ophys_session_id"
+    ost = ost.reset_index()
     eost = expected["ophys_session_table"]
     for k in ["ophys_session_id"]:
         pd.testing.assert_series_equal(ost[k], eost[k])
@@ -97,8 +101,10 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch):
                     for i, j in zip(ost[k].values, eost[k].values)])
 
     # experiment table as expected
-    pd.testing.assert_frame_equal(api.get_experiment_table(),
-                                  expected["ophys_experiment_table"])
+    et = api.get_experiment_table()
+    assert et.index.name == "ophys_experiment_id"
+    et = et.reset_index()
+    pd.testing.assert_frame_equal(et, expected["ophys_experiment_table"])
 
     # get_behavior_session returns expected value
     # both directly and via experiment table

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
@@ -1,0 +1,106 @@
+import pytest
+import ast
+import pandas as pd
+from unittest.mock import MagicMock
+
+from allensdk.brain_observatory.behavior.project_apis.data_io import \
+        behavior_project_cloud_api as cloudapi
+
+
+class MockCache():
+    def __init__(self,
+                 behavior_session_table,
+                 ophys_session_table,
+                 ophys_experiment_table,
+                 cachedir):
+        self.file_id_column = "file_id"
+        self.session_table_path = cachedir / "session.csv"
+        self.behavior_session_table_path = cachedir / "behavior_session.csv"
+        self.ophys_experiment_table_path = cachedir / "ophys_experiment.csv"
+
+        ophys_session_table.to_csv(self.session_table_path, index=False)
+        behavior_session_table.to_csv(self.behavior_session_table_path,
+                                      index=False)
+        ophys_experiment_table.to_csv(self.ophys_experiment_table_path,
+                                      index=False)
+
+        self._manifest = MagicMock()
+        self._manifest.metadata_file_names = ["behavior_session_table",
+                                              "ophys_session_table",
+                                              "ophys_experiment_table"]
+
+    def download_metadata(self, mname):
+        mymap = {
+                "behavior_session_table": self.behavior_session_table_path,
+                "ophys_session_table": self.session_table_path,
+                "ophys_experiment_table": self.ophys_experiment_table_path}
+        return mymap[mname]
+
+    def download_data(self, idstr):
+        return idstr
+
+
+@pytest.fixture
+def mock_cache(request, tmpdir):
+    yield (MockCache(
+             request.param.get("behavior_session_table"),
+             request.param.get("ophys_session_table"),
+             request.param.get("ophys_experiment_table"),
+             tmpdir),
+           request.param)
+
+
+@pytest.mark.parametrize(
+        "mock_cache",
+        [
+            {
+                "behavior_session_table": pd.DataFrame({
+                    "behavior_session_id": [1, 2, 3, 4],
+                    "ophys_experiment_id": [4, 5, 6, [7, 8, 9]],
+                    "file_id": [4, 5, 6, None]}),
+                "ophys_session_table": pd.DataFrame({
+                    "ophys_session_id": [10, 11, 12, 13],
+                    "ophys_experiment_id": [4, 5, 6, [7, 8, 9]]}),
+                "ophys_experiment_table": pd.DataFrame({
+                    "ophys_experiment_id": [4, 5, 6, 7, 8, 9],
+                    "file_id": [4, 5, 6, 7, 8, 9]})},
+                ],
+        indirect=["mock_cache"])
+def test_BehaviorProjectCloudApi(mock_cache, monkeypatch):
+    mocked_cache, expected = mock_cache
+    api = cloudapi.BehaviorProjectCloudApi(mocked_cache)
+
+    # behavior session table as expected
+    bost = api.get_behavior_only_session_table()
+    ebost = expected["behavior_session_table"]
+    for k in ["behavior_session_id", "file_id"]:
+        pd.testing.assert_series_equal(bost[k], ebost[k])
+    for k in ["ophys_experiment_id"]:
+        assert all([ast.literal_eval(i) == j
+                    for i, j in zip(bost[k].values, ebost[k].values)])
+
+    # ophys session table as expected
+    ost = api.get_session_table()
+    eost = expected["ophys_session_table"]
+    for k in ["ophys_session_id"]:
+        pd.testing.assert_series_equal(ost[k], eost[k])
+    for k in ["ophys_experiment_id"]:
+        assert all([ast.literal_eval(i) == j
+                    for i, j in zip(ost[k].values, eost[k].values)])
+
+    # experiment table as expected
+    pd.testing.assert_frame_equal(api.get_experiment_table(),
+                                  expected["ophys_experiment_table"])
+
+    # get_behavior_session returns expected value
+    # both directly and via experiment table
+    def mock_nwb(nwb_path):
+        return nwb_path
+    monkeypatch.setattr(cloudapi.BehaviorSession, "from_nwb_path", mock_nwb)
+    assert api.get_behavior_session(2) == "5"
+    assert api.get_behavior_session(4) == "7"
+
+    # direct check only for ophys experiment
+    monkeypatch.setattr(cloudapi.BehaviorOphysExperiment,
+                        "from_nwb_path", mock_nwb)
+    assert api.get_behavior_ophys_experiment(8) == "8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ nest_asyncio==1.2.0
 tqdm>=4.27
 ndx-events<=0.2.0
 boto3==1.17.21
+semver


### PR DESCRIPTION
### New things
* `VisualBehaviorOphysProjectCache` has a new underlying cloud api option, accessible by `from_s3_cache`
* data-producing AllenSDK version checked against running SDK version.
* tests

### Modified things
* `cloud_cache` has utility to determine latest versioned manifest, and load it.
* `cloud_cache.manifest` now knows about `data_pipeline` entry in manifest.
* `cloud_cache` has download progress bars.
* `behavior_nwb_api` gets `behavior_session_id` from correct place when loading ophys nwb into `BehaviorSession`

### Example call
(replace `cache_dir` with personal value)
```
import allensdk.brain_observatory.behavior.behavior_project_cache as bpc
  
bc = bpc.VisualBehaviorOphysProjectCache.from_s3_cache(
        cache_dir="/home/danielk/tmp",
        bucket_name="single-mouse-prerelease",
        project_name="visual-behavior-ophys")

behavior_session_table = bc.get_behavior_session_table()
experiment_table = bc.get_experiment_table()
session_table = bc.get_session_table()

bs1 = bc.get_behavior_session(870987812)
bs2 = bc.get_behavior_session(956010809)
be1 = bc.get_behavior_ophys_experiment(958741232)
```
```
$ python check.py 
ophys_session_table.csv: 100%|███████████████████| 3.30k/3.30k [00:00<00:00, 72.2kMB/s]
behavior_session_table.csv: 100%|█████████████████| 20.3k/20.3k [00:00<00:00, 587kMB/s]
ophys_experiment_table.csv: 100%|█████████████████| 12.8k/12.8k [00:00<00:00, 245kMB/s]
session_870987812.nwb: 100%|█████████████████████| 51.7M/51.7M [00:04<00:00, 10.7MMB/s]
imaging_plane_956941841.nwb: 100%|█████████████████| 266M/266M [00:25<00:00, 10.3MMB/s]
imaging_plane_958741232.nwb: 100%|█████████████████| 243M/243M [00:23<00:00, 10.3MMB/s]
```
