### PR TITLE
Use a simpler local cache organization for cloud cache

### DIFF
--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '2.9.0'
+__version__ = '2.10.0'
 
 
 try:

--- a/allensdk/api/cloud_cache/README.md
+++ b/allensdk/api/cloud_cache/README.md
@@ -44,6 +44,7 @@ The `manifest.json` files are structured like so
 ```
 
 {
+ "project_name" : my-project-name-string,
  "dataset_version" : dataset_version_string,
  "file_id_column": name_of_column_uniquely_identifying_files,
  "metadata_files":{

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -533,7 +533,7 @@ class S3CloudCache(CloudCacheBase):
                 with open(local_path, 'wb') as out_file:
                     for chunk in response['Body'].iter_chunks():
                         out_file.write(chunk)
-                pbar.update(response["ContentLength"])
+                        pbar.update(len(chunk))
 
             n_iter += 1
             if n_iter > max_iter:

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -187,7 +187,7 @@ class CloudCacheBase(ABC):
         with io.BytesIO() as stream:
             self._download_manifest(manifest_name, stream)
             self._manifest = Manifest(
-                cache_dir=self.cache_dir,
+                cache_dir=self._cache_dir,
                 json_input=stream
             )
 
@@ -396,6 +396,7 @@ class S3CloudCache(CloudCacheBase):
 
     def __init__(self, cache_dir, bucket_name, project_name):
         self._manifest = None
+        self._cache_dir = cache_dir
         self._bucket_name = bucket_name
         self._project_name = project_name
         self._manifest_file_names = self._list_all_manifests()

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -188,7 +188,7 @@ class CloudCacheBase(ABC):
             self._download_manifest(manifest_name, stream)
             self._manifest = Manifest(
                 cache_dir=self.cache_dir,
-                input_json=stream
+                json_input=stream
             )
 
     def _file_exists(self, file_attributes: CacheFileAttributes) -> bool:
@@ -395,7 +395,7 @@ class S3CloudCache(CloudCacheBase):
     """
 
     def __init__(self, cache_dir, bucket_name, project_name):
-        self._manifest = Manifest(cache_dir)
+        self._manifest = None
         self._bucket_name = bucket_name
         self._project_name = project_name
         self._manifest_file_names = self._list_all_manifests()

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -35,7 +35,8 @@ class CloudCacheBase(ABC):
     _bucket_name = None
 
     def __init__(self, cache_dir, project_name):
-        self._manifest = Manifest(cache_dir)
+        self._manifest = None
+        self._cache_dir = cache_dir
         self._project_name = project_name
         self._manifest_file_names = self._list_all_manifests()
 
@@ -185,7 +186,10 @@ class CloudCacheBase(ABC):
 
         with io.BytesIO() as stream:
             self._download_manifest(manifest_name, stream)
-            self._manifest.load(stream)
+            self._manifest = Manifest(
+                cache_dir=self.cache_dir,
+                input_json=stream
+            )
 
     def _file_exists(self, file_attributes: CacheFileAttributes) -> bool:
         """

--- a/allensdk/api/cloud_cache/manifest.py
+++ b/allensdk/api/cloud_cache/manifest.py
@@ -114,7 +114,7 @@ class Manifest(object):
         # relative_paths from remote start with the project name which
         # we want to remove since we already specified a project directory
         relative_path = relative_path_from_url(remote_path)
-        shaved_rel_path = relative_path.lstrip(f"{self._project_name}/")
+        shaved_rel_path = "/".join(relative_path.split("/")[1:])
 
         local_path = project_dir / shaved_rel_path
 

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -17,8 +17,11 @@ from allensdk import __version__ as sdk_version
 
 # [min inclusive, max exclusive)
 COMPATIBILITY = {
-        "pipeline_versions": {
-            "2.9.0": {"AllenSDK": ["2.9.0", "3.0.0"]}}}
+    "pipeline_versions": {
+        "2.9.0": {"AllenSDK": ["2.9.0", "3.0.0"]},
+        "2.10.0": {"AllenSDK": ["2.10.0", "3.0.0"]}
+    }
+}
 
 
 class BehaviorCloudCacheVersionException(Exception):

--- a/allensdk/test/api/cloud_cache/test_full_process.py
+++ b/allensdk/test/api/cloud_cache/test_full_process.py
@@ -141,6 +141,7 @@ def test_full_cache_system(tmpdir):
 
     manifest_1 = {}
     manifest_1['manifest_version'] = 'A'
+    manifest_1['project_name'] = "project-A1"
     manifest_1['metadata_file_id_column_name'] = 'file_id'
     manifest_1['data_pipeline'] = 'placeholder'
     data_files_1 = {}
@@ -162,6 +163,7 @@ def test_full_cache_system(tmpdir):
 
     manifest_2 = {}
     manifest_2['manifest_version'] = 'B'
+    manifest_2['project_name'] = "project-B2"
     manifest_2['metadata_file_id_column_name'] = 'file_id'
     manifest_2['data_pipeline'] = 'placeholder'
     data_files_2 = {}

--- a/allensdk/test/api/cloud_cache/test_manifest.py
+++ b/allensdk/test/api/cloud_cache/test_manifest.py
@@ -1,98 +1,44 @@
 import pytest
 import json
-import io
 import pathlib
 from allensdk.internal.core.lims_utilities import safe_system_path
 from allensdk.api.cloud_cache.manifest import Manifest
 from allensdk.api.cloud_cache.file_attributes import CacheFileAttributes  # noqa: E501
 
 
-def test_constructor():
+@pytest.fixture
+def meta_json_path(tmpdir):
+    jpath = tmpdir / "somejson.json"
+    d = {
+            "project_name": "X",
+            "manifest_version": "Y",
+            "metadata_file_id_column_name": "Z",
+            "data_pipeline": "ZA",
+            "metadata_files": ["ZB", "ZC", "ZD"],
+            "data_files": {"AB": "ab", "BC": "bc", "CD": "cd"}}
+    with open(jpath, "w") as f:
+        json.dump(d, f)
+    yield jpath
+
+
+def test_constructor(meta_json_path):
     """
     Make sure that the Manifest class __init__ runs and
     raises an error if you give it an unexpected cache_dir
     """
-    _ = Manifest('my/cache/dir')
-    _ = Manifest(pathlib.Path('my/other/cache/dir'))
-    with pytest.raises(ValueError) as context:
-        _ = Manifest(1234.2)
-    msg = "cache_dir must be either a str or a pathlib.Path; "
-    msg += "got <class 'float'>"
-    assert context.value.args[0] == msg
+    Manifest('my/cache/dir', meta_json_path)
+    Manifest(pathlib.Path('my/other/cache/dir'), meta_json_path)
+    with pytest.raises(ValueError, match=r"cache_dir must be either a str.*"):
+        Manifest(1234.2, meta_json_path)
 
 
-def test_load(tmpdir):
-    """
-    Bare bones check to verify that Manifest.load can be run and that it
-    will raise the correct error when the JSONized manifest is not a dict
-    """
-
-    good_manifest = {}
-    good_manifest['manifest_version'] = 'A'
-    good_manifest['metadata_file_id_column_name'] = 'file_id'
-    metadata_files = {}
-    metadata_files['z.txt'] = []
-    metadata_files['x.txt'] = []
-    metadata_files['y.txt'] = []
-    good_manifest['metadata_files'] = metadata_files
-    good_manifest['data_pipeline'] = 'placeholder'
-
-    mfest = Manifest(pathlib.Path(tmpdir) / 'my/cache/dir')
-
-    with io.StringIO() as stream:
-        stream.write(json.dumps(good_manifest))
-        stream.seek(0)
-
-        mfest.load(stream)
-
-    assert mfest.version == 'A'
-    assert mfest.metadata_file_names == ['x.txt', 'y.txt', 'z.txt']
-    assert mfest._cache_dir == pathlib.Path(str(tmpdir)+'/my/cache/dir')
-
-    del stream
-
-    # test that you can load a new manifest.json into the same Manifest
-    good_manifest = {}
-    good_manifest['manifest_version'] = 'B'
-    good_manifest['metadata_file_id_column_name'] = 'file_id'
-    metadata_files = {}
-    metadata_files['n.txt'] = []
-    metadata_files['k.txt'] = []
-    metadata_files['u.txt'] = []
-    good_manifest['metadata_files'] = metadata_files
-    good_manifest['data_pipeline'] = 'placeholder'
-
-    with io.StringIO() as stream:
-        stream.write(json.dumps(good_manifest))
-        stream.seek(0)
-
-        mfest.load(stream)
-
-    assert mfest.version == 'B'
-    assert mfest.metadata_file_names == ['k.txt', 'n.txt', 'u.txt']
-
-    del stream
-
-    # test that an error is raised when manifest.json is not a dict
-    bad_manifest = ['a', 'b', 'c']
-    with io.StringIO() as stream:
-        stream.write(json.dumps(bad_manifest))
-        stream.seek(0)
-        with pytest.raises(ValueError) as context:
-            mfest.load(stream)
-
-    msg = "Expected to deserialize manifest into a dict; "
-    msg += "instead got <class 'list'>"
-    assert context.value.args[0] == msg
-
-
-def test_create_file_attributes():
+def test_create_file_attributes(meta_json_path):
     """
     Test that Manifest._create_file_attributes correctly
     handles input parameters (this is mostly a test of
     local_path generation)
     """
-    mfest = Manifest('/my/cache/dir')
+    mfest = Manifest('/my/cache/dir', meta_json_path)
     attr = mfest._create_file_attributes('http://my.url.com/path/to/file.txt',
                                          '12345',
                                          'aaabbbcccddd')
@@ -101,17 +47,13 @@ def test_create_file_attributes():
     assert attr.url == 'http://my.url.com/path/to/file.txt'
     assert attr.version_id == '12345'
     assert attr.file_hash == 'aaabbbcccddd'
-    expected_path = '/my/cache/dir/aaabbbcccddd/path/to/file.txt'
+    expected_path = '/my/cache/dir/X-Y/to/file.txt'
     assert attr.local_path == pathlib.Path(expected_path).resolve()
 
 
-def test_metadata_file_attributes():
-    """
-    Test that Manifest.metadata_file_attributes returns the
-    correct CacheFileAttributes object and raises the correct
-    error when you ask for a metadata file that does not exist
-    """
-
+@pytest.fixture
+def manifest_for_metadata(tmpdir):
+    jpath = tmpdir / "a_manifest.json"
     manifest = {}
     metadata_files = {}
     metadata_files['a.txt'] = {'url': 'http://my.url.com/path/to/a.txt',
@@ -122,21 +64,29 @@ def test_metadata_file_attributes():
                                'file_hash': 'fghijk'}
 
     manifest['metadata_files'] = metadata_files
+    manifest['project_name'] = "some-project"
     manifest['manifest_version'] = '000'
     manifest['metadata_file_id_column_name'] = 'file_id'
     manifest['data_pipeline'] = 'placeholder'
+    with open(jpath, "w") as f:
+        json.dump(manifest, f)
+    yield jpath
 
-    mfest = Manifest('/my/cache/dir/')
-    with io.StringIO() as stream:
-        stream.write(json.dumps(manifest))
-        stream.seek(0)
-        mfest.load(stream)
+
+def test_metadata_file_attributes(manifest_for_metadata):
+    """
+    Test that Manifest.metadata_file_attributes returns the
+    correct CacheFileAttributes object and raises the correct
+    error when you ask for a metadata file that does not exist
+    """
+
+    mfest = Manifest('/my/cache/dir/', manifest_for_metadata)
 
     a_obj = mfest.metadata_file_attributes('a.txt')
     assert a_obj.url == 'http://my.url.com/path/to/a.txt'
     assert a_obj.version_id == '12345'
     assert a_obj.file_hash == 'abcde'
-    expected = safe_system_path('/my/cache/dir/abcde/path/to/a.txt')
+    expected = safe_system_path('/my/cache/dir/some-project-000/to/a.txt')
     expected = pathlib.Path(expected).resolve()
     assert a_obj.local_path == expected
 
@@ -144,7 +94,7 @@ def test_metadata_file_attributes():
     assert b_obj.url == 'http://my.other.url.com/different/path/to/b.txt'
     assert b_obj.version_id == '67890'
     assert b_obj.file_hash == 'fghijk'
-    expected = safe_system_path('/my/cache/dir/fghijk/different/path/to/b.txt')
+    expected = safe_system_path('/my/cache/dir/some-project-000/path/to/b.txt')
     expected = pathlib.Path(expected).resolve()
     assert b_obj.local_path == expected
 
@@ -157,45 +107,48 @@ def test_metadata_file_attributes():
     assert msg in context.value.args[0]
 
 
-def test_data_file_attributes():
-    """
-    Test that Manifest.data_file_attributes returns the correct
-    CacheFileAttributes object and raises the correct error when
-    you ask for a data file that does not exist
-    """
+@pytest.fixture
+def manifest_with_data(tmpdir):
+    jpath = tmpdir / "manifest_with files.json"
     manifest = {}
     manifest['metadata_files'] = {}
     manifest['manifest_version'] = '0'
+    manifest['project_name'] = "myproject"
     manifest['metadata_file_id_column_name'] = 'file_id'
     manifest['data_pipeline'] = 'placeholder'
     data_files = {}
-    data_files['a'] = {'url': 'http://my.url.com/path/to/a.nwb',
+    data_files['a'] = {'url': 'http://my.url.com/myproject/path/to/a.nwb',
                        'version_id': '12345',
                        'file_hash': 'abcde'}
     data_files['b'] = {'url': 'http://my.other.url.com/different/path/b.nwb',
                        'version_id': '67890',
                        'file_hash': 'fghijk'}
     manifest['data_files'] = data_files
+    with open(jpath, "w") as f:
+        json.dump(manifest, f)
+    yield jpath
 
-    mfest = Manifest('/my/cache/dir')
 
-    with io.StringIO() as stream:
-        stream.write(json.dumps(manifest))
-        stream.seek(0)
-        mfest.load(stream)
+def test_data_file_attributes(manifest_with_data):
+    """
+    Test that Manifest.data_file_attributes returns the correct
+    CacheFileAttributes object and raises the correct error when
+    you ask for a data file that does not exist
+    """
+    mfest = Manifest('/my/cache/dir', manifest_with_data)
 
     a_obj = mfest.data_file_attributes('a')
-    assert a_obj.url == 'http://my.url.com/path/to/a.nwb'
+    assert a_obj.url == 'http://my.url.com/myproject/path/to/a.nwb'
     assert a_obj.version_id == '12345'
     assert a_obj.file_hash == 'abcde'
-    expected = safe_system_path('/my/cache/dir/abcde/path/to/a.nwb')
+    expected = safe_system_path('/my/cache/dir/myproject-0/path/to/a.nwb')
     assert a_obj.local_path == pathlib.Path(expected).resolve()
 
     b_obj = mfest.data_file_attributes('b')
     assert b_obj.url == 'http://my.other.url.com/different/path/b.nwb'
     assert b_obj.version_id == '67890'
     assert b_obj.file_hash == 'fghijk'
-    expected = safe_system_path('/my/cache/dir/fghijk/different/path/b.nwb')
+    expected = safe_system_path('/my/cache/dir/myproject-0/path/b.nwb')
     assert b_obj.local_path == pathlib.Path(expected).resolve()
 
     with pytest.raises(ValueError) as context:
@@ -204,156 +157,16 @@ def test_data_file_attributes():
     assert msg in context.value.args[0]
 
 
-def test_loading_two_manifests():
-    """
-    Test that Manifest behaves correctly after re-running load() on
-    a different manifest
-    """
-
-    # create two manifests, meant to represents different versions
-    # of the same dataset
-
-    manifest_1 = {}
-    metadata_1 = {}
-    metadata_1['metadata_a.csv'] = {'url': 'http://aaa.com/path/to/a.csv',
-                                    'version_id': '12345',
-                                    'file_hash': 'abcde'}
-    metadata_1['metadata_b.csv'] = {'url': 'http://bbb.com/other/path/b.csv',
-                                    'version_id': '67890',
-                                    'file_hash': 'fghijk'}
-    manifest_1['metadata_files'] = metadata_1
-    manifest_1['data_pipeline'] = 'placeholder'
-    data_1 = {}
-    data_1['c'] = {'url': 'http://ccc.com/third/path/c.csv',
-                   'version_id': '11121',
-                   'file_hash': 'lmnopq'}
-    data_1['d'] = {'url': 'http://ddd.com/fourth/path/d.csv',
-                   'version_id': '31415',
-                   'file_hash': 'rstuvw'}
-
-    manifest_1['data_files'] = data_1
-    manifest_1['manifest_version'] = '1'
-    manifest_1['metadata_file_id_column_name'] = 'file_id'
-
-    manifest_2 = {}
-    metadata_2 = {}
-    metadata_2['metadata_a.csv'] = {'url': 'http://aaa.com/path/to/a.csv',
-                                    'version_id': '161718',
-                                    'file_hash': 'xyzab'}
-    metadata_2['metadata_f.csv'] = {'url': 'http://fff.com/fifth/path/f.csv',
-                                    'version_id': '192021',
-                                    'file_hash': 'cdefghi'}
-    manifest_2['metadata_files'] = metadata_2
-    manifest_2['data_pipeline'] = 'placeholder'
-    data_2 = {}
-    data_2['c'] = {'url': 'http://ccc.com/third/path/c.csv',
-                   'version_id': '222324',
-                   'file_hash': 'jklmnop'}
-    data_2['g'] = {'url': 'http://ggg.com/sixth/path/g.csv',
-                   'version_id': '25262728',
-                   'file_hash': 'qrstuvwxy'}
-
-    manifest_2['data_files'] = data_2
-    manifest_2['manifest_version'] = '2'
-    manifest_2['metadata_file_id_column_name'] = 'file_id'
-
-    mfest = Manifest('/my/cache/dir')
-
-    # load the first version of the manifest and check results
-
-    with io.StringIO() as stream_1:
-
-        stream_1.write(json.dumps(manifest_1))
-        stream_1.seek(0)
-        mfest.load(stream_1)
-
-    assert mfest.version == '1'
-    assert mfest.metadata_file_names == ['metadata_a.csv', 'metadata_b.csv']
-
-    m_obj = mfest.metadata_file_attributes('metadata_a.csv')
-    assert m_obj.url == 'http://aaa.com/path/to/a.csv'
-    assert m_obj.version_id == '12345'
-    assert m_obj.file_hash == 'abcde'
-    expected = safe_system_path('/my/cache/dir/abcde/path/to/a.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    m_obj = mfest.metadata_file_attributes('metadata_b.csv')
-    assert m_obj.url == 'http://bbb.com/other/path/b.csv'
-    assert m_obj.version_id == '67890'
-    assert m_obj.file_hash == 'fghijk'
-    expected = safe_system_path('/my/cache/dir/fghijk/other/path/b.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    d_obj = mfest.data_file_attributes('c')
-    assert d_obj.url == 'http://ccc.com/third/path/c.csv'
-    assert d_obj.version_id == '11121'
-    assert d_obj.file_hash == 'lmnopq'
-    expected = '/my/cache/dir/lmnopq/third/path/c.csv'
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    d_obj = mfest.data_file_attributes('d')
-    assert d_obj.url == 'http://ddd.com/fourth/path/d.csv'
-    assert d_obj.version_id == '31415'
-    assert d_obj.file_hash == 'rstuvw'
-    expected = safe_system_path('/my/cache/dir/rstuvw/fourth/path/d.csv')
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    # now load the second manifest and make sure that everything
-    # changes accordingly
-
-    with io.StringIO() as stream_2:
-        stream_2.write(json.dumps(manifest_2))
-        stream_2.seek(0)
-
-        mfest.load(stream_2)
-
-    assert mfest.version == '2'
-    assert mfest.metadata_file_names == ['metadata_a.csv', 'metadata_f.csv']
-
-    m_obj = mfest.metadata_file_attributes('metadata_a.csv')
-    assert m_obj.url == 'http://aaa.com/path/to/a.csv'
-    assert m_obj.version_id == '161718'
-    assert m_obj.file_hash == 'xyzab'
-    expected = safe_system_path('/my/cache/dir/xyzab/path/to/a.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    m_obj = mfest.metadata_file_attributes('metadata_f.csv')
-    assert m_obj.url == 'http://fff.com/fifth/path/f.csv'
-    assert m_obj.version_id == '192021'
-    assert m_obj.file_hash == 'cdefghi'
-    expected = safe_system_path('/my/cache/dir/cdefghi/fifth/path/f.csv')
-    assert m_obj.local_path == pathlib.Path(expected).resolve()
-
-    with pytest.raises(ValueError):
-        _ = mfest.metadata_file_attributes('metadata_b.csv')
-
-    d_obj = mfest.data_file_attributes('c')
-    assert d_obj.url == 'http://ccc.com/third/path/c.csv'
-    assert d_obj.version_id == '222324'
-    assert d_obj.file_hash == 'jklmnop'
-    expected = safe_system_path('/my/cache/dir/jklmnop/third/path/c.csv')
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    d_obj = mfest.data_file_attributes('g')
-    assert d_obj.url == 'http://ggg.com/sixth/path/g.csv'
-    assert d_obj.version_id == '25262728'
-    assert d_obj.file_hash == 'qrstuvwxy'
-    expected = safe_system_path('/my/cache/dir/qrstuvwxy/sixth/path/g.csv')
-    assert d_obj.local_path == pathlib.Path(expected).resolve()
-
-    with pytest.raises(ValueError):
-        _ = mfest.data_file_attributes('d')
-
-
-def test_file_attribute_errors():
+def test_file_attribute_errors(meta_json_path):
     """
     Test that Manifest raises the correct error if you try to get file
     attributes before loading a manifest.json
     """
-    mfest = Manifest("/my/cache/dir")
-    with pytest.raises(RuntimeError) as context:
-        _ = mfest.metadata_file_attributes('some_file.txt')
-    assert 'cannot retrieve metadata_file_attributes' in context.value.args[0]
-    with pytest.raises(RuntimeError) as context:
-        _ = mfest.data_file_attributes('other_file.txt')
-    assert 'cannot retrieve data_file_attributes' in context.value.args[0]
+    mfest = Manifest("/my/cache/dir", meta_json_path)
+    with pytest.raises(ValueError,
+                       match=r".* not in self.metadata_file_names"):
+        mfest.metadata_file_attributes('some_file.txt')
+
+    with pytest.raises(ValueError,
+                       match=r".* not a data file listed in manifest"):
+        mfest.data_file_attributes('other_file.txt')

--- a/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
+++ b/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
@@ -1,10 +1,10 @@
 import re
-import io
 import json
 from allensdk.api.cloud_cache.cloud_cache import CloudCacheBase
+from allensdk.api.cloud_cache.manifest import Manifest
 
 
-def test_windows_path_to_isilon(monkeypatch):
+def test_windows_path_to_isilon(monkeypatch, tmpdir):
     """
     This test is just meant to verify on Windows CI instances
     that, if a path to the `/allen/` shared file store is used as
@@ -17,6 +17,7 @@ def test_windows_path_to_isilon(monkeypatch):
     manifest_1 = {'manifest_version': '1',
                   'metadata_file_id_column_name': 'file_id',
                   'data_pipeline': 'placeholder',
+                  'project_name': 'my-project',
                   'metadata_files': {'a.csv': {'url': 'http://www.junk.com/path/to/a.csv',  # noqa: E501
                                                'version_id': '1111',
                                                'file_hash': 'abcde'},
@@ -27,12 +28,9 @@ def test_windows_path_to_isilon(monkeypatch):
                                             'version_id': '1111',
                                             'file_hash': 'lmnopqrst'}}
                   }
-
-    def dummy_load_manifest(self):
-        with io.StringIO() as stream:
-            stream.write(json.dumps(manifest_1))
-            stream.seek(0)
-            self._manifest.load(stream)
+    manifest_path = tmpdir / "manifest.json"
+    with open(manifest_path, "w") as f:
+        json.dump(manifest_1, f)
 
     def dummy_file_exists(self, m):
         return True
@@ -58,15 +56,11 @@ def test_windows_path_to_isilon(monkeypatch):
                 pass
 
         ctx.setattr(TestCloudCache,
-                    'load_manifest',
-                    dummy_load_manifest)
-
-        ctx.setattr(TestCloudCache,
                     '_file_exists',
                     dummy_file_exists)
 
         cache = TestCloudCache(cache_dir, 'proj')
-        cache.load_manifest()
+        cache._manifest = Manifest(cache_dir, json_input=manifest_path)
 
         m_path = cache.metadata_path('a.csv')
         assert bad_windows_pattern.match(str(m_path)) is None


### PR DESCRIPTION
1) This commit makes the allensdk.api.cloud_cache.manifest.Manifest
   class use a simpler local cache directory organization. Previously the
   the scheme looked something like:

   {cache_dir}/{blake2b_version_hash}/{relative_path}

   Because the blake2b version hash is 128 characters long and
   completely incomprehensible, this was deemed not friendly for
   end users.

   The new organization will look something like:

   {cache_dir}/{project_name}-{manifest_version}/{modified_relative_path}

   Because the convention of the data release tool has the
   {relative_path} start with the {project_name}, the project
   name needs to be removed before using the {relative_path}.

2) This commit also does a light refactor of the Manifest()
   class. Previously it contained a `load()` method, but a better
   organization is to have the Manifest class accept a json_input
   as an __init__ parameter so that each manifest instance is
   concerned with only 1 manifest.json file.


TODO:
- [ ] I know tests are currently failing
- [ ] Update and fix tests
- [ ] allensdk/api/cloud_cache/README.md still needs a lot more edits to be up to date