### PR TITLE
Adds from_local_cache factory method

### DIFF
--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -76,8 +76,7 @@ class CloudCacheBase(ABC):
     def _download_manifest(self,
                            manifest_name: str):
         """
-        Download a manifest from the dataset into output_stream.
-        Reset output_stream to the beginning
+        Download a manifest from the dataset
 
         Parameters
         ----------

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -35,6 +35,9 @@ class CloudCacheBase(ABC):
     _bucket_name = None
 
     def __init__(self, cache_dir, project_name):
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir)
+
         self._manifest = None
         self._cache_dir = cache_dir
         self._project_name = project_name
@@ -71,8 +74,7 @@ class CloudCacheBase(ABC):
 
     @abstractmethod
     def _download_manifest(self,
-                           manifest_name: str,
-                           output_stream: io.BytesIO):
+                           manifest_name: str):
         """
         Download a manifest from the dataset into output_stream.
         Reset output_stream to the beginning
@@ -82,9 +84,6 @@ class CloudCacheBase(ABC):
         manifest_name: str
             The name of the manifest to load. Must be an element in
             self.manifest_file_names
-
-        output_stream: io.BytesIO
-            A byte stream into which to load the manifest
         """
         raise NotImplementedError()
 
@@ -184,11 +183,14 @@ class CloudCacheBase(ABC):
                              "for this dataset:\n"
                              f"{self.manifest_file_names}")
 
-        with io.BytesIO() as stream:
-            self._download_manifest(manifest_name, stream)
+        filepath = os.path.join(self._cache_dir, manifest_name)
+        if not os.path.exists(filepath):
+            self._download_manifest(manifest_name)
+
+        with open(filepath) as f:
             self._manifest = Manifest(
                 cache_dir=self._cache_dir,
-                json_input=stream
+                json_input=f
             )
 
     def _file_exists(self, file_attributes: CacheFileAttributes) -> bool:
@@ -396,10 +398,9 @@ class S3CloudCache(CloudCacheBase):
 
     def __init__(self, cache_dir, bucket_name, project_name):
         self._manifest = None
-        self._cache_dir = cache_dir
         self._bucket_name = bucket_name
-        self._project_name = project_name
-        self._manifest_file_names = self._list_all_manifests()
+
+        super().__init__(cache_dir=cache_dir, project_name=project_name)
 
     _s3_client = None
 
@@ -432,8 +433,7 @@ class S3CloudCache(CloudCacheBase):
         return output
 
     def _download_manifest(self,
-                           manifest_name: str,
-                           output_stream: io.BytesIO):
+                           manifest_name: str):
         """
         Download a manifest from the dataset
 
@@ -442,17 +442,17 @@ class S3CloudCache(CloudCacheBase):
         manifest_name: str
             The name of the manifest to load. Must be an element in
             self.manifest_file_names
-
-        output_stream: io.BytesIO
-            A byte stream into which to load the manifest
         """
 
         manifest_key = self.manifest_prefix + manifest_name
         response = self.s3_client.get_object(Bucket=self._bucket_name,
                                              Key=manifest_key)
-        for chunk in response['Body'].iter_chunks():
-            output_stream.write(chunk)
-        output_stream.seek(0)
+
+        filepath = os.path.join(self._cache_dir, manifest_name)
+
+        with open(filepath, 'wb') as f:
+            for chunk in response['Body'].iter_chunks():
+                f.write(chunk)
 
     def _download_file(self, file_attributes: CacheFileAttributes) -> bool:
         """
@@ -544,3 +544,29 @@ class S3CloudCache(CloudCacheBase):
         if pbar is not None:
             pbar.close()
         return None
+
+
+class LocalCache(CloudCacheBase):
+    """A class to handle accessing of data that has already been downloaded
+    locally
+
+    Parameters
+    ----------
+    cache_dir: str or pathlib.Path
+        Path to the directory where data will be stored on the local system
+
+    project_name: str
+        the name of the project this cache is supposed to access. This will
+        be the root directory for all files stored in the bucket.
+    """
+    def __init__(self, cache_dir, project_name):
+        super().__init__(cache_dir=cache_dir, project_name=project_name)
+
+    def _list_all_manifests(self) -> list:
+        return [x for x in os.listdir(self._cache_dir) if 'manifest' in x]
+
+    def _download_manifest(self, manifest_name: str):
+        raise NotImplementedError()
+
+    def _download_file(self, file_attributes: CacheFileAttributes) -> bool:
+        raise NotImplementedError()

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
 import os
 import copy
-import io
 import pathlib
 import pandas as pd
 import boto3
 import semver
 import tqdm
+import re
 from botocore import UNSIGNED
 from botocore.client import Config
 from allensdk.internal.core.lims_utilities import safe_system_path
@@ -560,7 +560,8 @@ class LocalCache(CloudCacheBase):
         super().__init__(cache_dir=cache_dir, project_name=project_name)
 
     def _list_all_manifests(self) -> list:
-        return [x for x in os.listdir(self._cache_dir) if 'manifest' in x]
+        return [x for x in os.listdir(self._cache_dir)
+                if re.fullmatch(".*_manifest_v.*.json", x)]
 
     def _download_manifest(self, manifest_name: str):
         raise NotImplementedError()

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -35,8 +35,7 @@ class CloudCacheBase(ABC):
     _bucket_name = None
 
     def __init__(self, cache_dir, project_name):
-        if not os.path.exists(cache_dir):
-            os.makedirs(cache_dir)
+        os.makedirs(cache_dir, exist_ok=True)
 
         self._manifest = None
         self._cache_dir = cache_dir
@@ -497,8 +496,7 @@ class S3CloudCache(CloudCacheBase):
 
         # using os here rather than pathlib because safe_system_path
         # returns a str
-        if not os.path.exists(local_dir):
-            os.makedirs(local_dir)
+        os.makedirs(local_dir, exist_ok=True)
         if not os.path.isdir(local_dir):
             raise RuntimeError(f"{local_dir}\n"
                                "is not a directory")

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -139,6 +139,31 @@ class VisualBehaviorOphysProjectCache(Cache):
         return cls(fetch_api=fetch_api)
 
     @classmethod
+    def from_local_cache(cls, cache_dir: Union[str, Path],
+                         project_name: str = "visual-behavior-ophys"
+                         ) -> "VisualBehaviorOphysProjectCache":
+        """instantiates this object with a local cache.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        Returns
+        -------
+        VisualBehaviorOphysProjectCache instance
+
+        """
+        fetch_api = BehaviorProjectCloudApi.from_local_cache(
+                cache_dir, project_name)
+        return cls(fetch_api=fetch_api)
+
+    @classmethod
     def from_lims(cls, manifest: Optional[Union[str, Path]] = None,
                   version: Optional[str] = None,
                   cache: bool = False,

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -379,4 +379,4 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
             raise FileNotFoundError(f'You started a cache without a '
                                     f'connection to s3 and {local_path} is '
                                     'not already on your system')
-        return
+        return local_path

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -11,7 +11,7 @@ from allensdk.brain_observatory.behavior.behavior_session import (
     BehaviorSession)
 from allensdk.brain_observatory.behavior.behavior_ophys_experiment import (
     BehaviorOphysExperiment)
-from allensdk.api.cloud_cache.cloud_cache import S3CloudCache
+from allensdk.api.cloud_cache.cloud_cache import S3CloudCache, LocalCache
 from allensdk import __version__ as sdk_version
 
 
@@ -110,9 +110,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
     skip_version_check: bool
         whether to skip the version checking of pipeline SDK version
         vs. running SDK version, which may raise Exceptions. (default=False)
-
+    local: bool
+        Whether to operate in local mode, where no data will be downloaded
+        and instead will be loaded from local
     """
-    def __init__(self, cache: S3CloudCache, skip_version_check: bool = False):
+    def __init__(self, cache: Union[S3CloudCache, LocalCache],
+                 skip_version_check: bool = False,
+                 local: bool = False):
         expected_metadata = set(["behavior_session_table",
                                  "ophys_session_table",
                                  "ophys_experiment_table"])
@@ -130,6 +134,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         if not skip_version_check:
             version_check(self.cache._manifest._data_pipeline)
         self.logger = logging.getLogger("BehaviorProjectCloudApi")
+        self._local = local
         self._get_session_table()
         self._get_behavior_only_session_table()
         self._get_experiment_table()
@@ -163,6 +168,30 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         cache = S3CloudCache(cache_dir, bucket_name, project_name)
         cache.load_latest_manifest()
         return BehaviorProjectCloudApi(cache)
+
+    @staticmethod
+    def from_local_cache(cache_dir: Union[str, Path],
+                         project_name: str) -> "BehaviorProjectCloudApi":
+        """instantiates this object with a local cache.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        Returns
+        -------
+        BehaviorProjectCloudApi instance
+
+        """
+        cache = LocalCache(cache_dir, project_name)
+        cache.load_latest_manifest()
+        return BehaviorProjectCloudApi(cache, local=True)
 
     def get_behavior_session(
             self, behavior_session_id: int) -> BehaviorSession:
@@ -203,8 +232,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         if not has_file_id:
             oeid = row.ophys_experiment_id[0]
             row = self._experiment_table.query(f"index=={oeid}")
-        data_path = self.cache.download_data(
-                str(int(row[self.cache.file_id_column])))
+        file_id = str(int(row[self.cache.file_id_column]))
+        data_path = self._get_data_path(file_id=file_id)
         return BehaviorSession.from_nwb_path(str(data_path))
 
     def get_behavior_ophys_experiment(self, ophys_experiment_id: int
@@ -229,13 +258,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
                                f"ophys_experiment_id. For "
                                f"{ophys_experiment_id} "
                                f" there are {row.shape[0]} entries.")
-        data_path = self.cache.download_data(
-                str(int(row[self.cache.file_id_column])))
+        file_id = str(int(row[self.cache.file_id_column]))
+        data_path = self._get_data_path(file_id=file_id)
         return BehaviorOphysExperiment.from_nwb_path(str(data_path))
 
-    def _get_session_table(self) -> pd.DataFrame:
-        session_table_path = self.cache.download_metadata(
-                "ophys_session_table")
+    def _get_session_table(self):
+        session_table_path = self._get_metadata_path(
+            fname="ophys_session_table")
         df = literal_col_eval(pd.read_csv(session_table_path))
         self._session_table = df.set_index("ophys_session_id")
 
@@ -253,8 +282,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         return self._session_table
 
     def _get_behavior_only_session_table(self):
-        session_table_path = self.cache.download_metadata(
-                "behavior_session_table")
+        session_table_path = self._get_metadata_path(
+            fname='behavior_session_table')
         df = literal_col_eval(pd.read_csv(session_table_path))
         self._behavior_only_session_table = df.set_index("behavior_session_id")
 
@@ -280,8 +309,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         return self._behavior_only_session_table
 
     def _get_experiment_table(self):
-        experiment_table_path = self.cache.download_metadata(
-                "ophys_experiment_table")
+        experiment_table_path = self._get_metadata_path(
+            fname="ophys_experiment_table")
         df = literal_col_eval(pd.read_csv(experiment_table_path))
         self._experiment_table = df.set_index("ophys_experiment_id")
 
@@ -316,3 +345,17 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         :returns: iterable yielding a tiff file as bytes
         """
         raise NotImplementedError()
+
+    def _get_metadata_path(self, fname: str):
+        if self._local:
+            path = self.cache.metadata_path(fname=fname)['local_path']
+        else:
+            path = self.cache.download_metadata(fname=fname)
+        return path
+
+    def _get_data_path(self, file_id: str):
+        if self._local:
+            data_path = self.cache.data_path(file_id=file_id)['local_path']
+        else:
+            data_path = self.cache.download_data(file_id=file_id)
+        return data_path

--- a/allensdk/test/api/cloud_cache/test_cache.py
+++ b/allensdk/test/api/cloud_cache/test_cache.py
@@ -11,7 +11,7 @@ from allensdk.api.cloud_cache.file_attributes import CacheFileAttributes  # noqa
 
 
 @mock_s3
-def test_list_all_manifests():
+def test_list_all_manifests(tmpdir):
     """
     Test that S3CloudCache.list_al_manifests() returns the correct result
     """
@@ -32,13 +32,13 @@ def test_list_all_manifests():
                       Key='junk.txt',
                       Body=b'123456')
 
-    cache = S3CloudCache('/my/cache/dir', test_bucket_name, 'proj')
+    cache = S3CloudCache(tmpdir, test_bucket_name, 'proj')
 
     assert cache.manifest_file_names == ['manifest_1.json', 'manifest_2.json']
 
 
 @mock_s3
-def test_list_all_manifests_many():
+def test_list_all_manifests_many(tmpdir):
     """
     Test the extreme case when there are more manifests than list_objects_v2
     can return at a time
@@ -59,7 +59,7 @@ def test_list_all_manifests_many():
                       Key='junk.txt',
                       Body=b'123456')
 
-    cache = S3CloudCache('/my/cache/dir', test_bucket_name, 'proj')
+    cache = S3CloudCache(tmpdir, test_bucket_name, 'proj')
 
     expected = list([f'manifest_{ii}.json' for ii in range(2000)])
     expected.sort()
@@ -67,7 +67,7 @@ def test_list_all_manifests_many():
 
 
 @mock_s3
-def test_loading_manifest():
+def test_loading_manifest(tmpdir):
     """
     Test loading manifests with S3CloudCache
     """
@@ -109,7 +109,7 @@ def test_loading_manifest():
                       Key='proj/manifests/manifest_2.csv',
                       Body=bytes(json.dumps(manifest_2), 'utf-8'))
 
-    cache = S3CloudCache('/my/cache/dir', test_bucket_name, 'proj')
+    cache = S3CloudCache(pathlib.Path(tmpdir), test_bucket_name, 'proj')
     cache.load_manifest('manifest_1.csv')
     assert cache._manifest._data == manifest_1
     assert cache.version == '1'
@@ -148,7 +148,7 @@ def test_file_exists(tmpdir):
     conn = boto3.resource('s3', region_name='us-east-1')
     conn.create_bucket(Bucket=test_bucket_name, ACL='public-read')
 
-    cache = S3CloudCache('my/cache/dir', test_bucket_name, 'proj')
+    cache = S3CloudCache(tmpdir, test_bucket_name, 'proj')
 
     # should be true
     good_attribute = CacheFileAttributes('http://silly.url.com',

--- a/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
+++ b/allensdk/test/api/cloud_cache/test_windows_isilon_paths.py
@@ -1,5 +1,7 @@
 import re
 import json
+from pathlib import Path
+
 from allensdk.api.cloud_cache.cloud_cache import CloudCacheBase
 from allensdk.api.cloud_cache.manifest import Manifest
 
@@ -12,7 +14,7 @@ def test_windows_path_to_isilon(monkeypatch, tmpdir):
     spurious C:/ prepended as in AllenSDK issue #1964
     """
 
-    cache_dir = '/allen/silly/cache/path'
+    cache_dir = Path(tmpdir)
 
     manifest_1 = {'manifest_version': '1',
                   'metadata_file_id_column_name': 'file_id',

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from allensdk.brain_observatory.behavior.project_apis.data_io import \
@@ -39,14 +40,18 @@ class MockCache():
         return file_id
 
     def metadata_path(self, fname):
+        local_path = self._metadata_name_path_map[fname]
         return {
-            'local_path': self._metadata_name_path_map[fname]
+            'local_path': local_path,
+            'exists': Path(local_path).exists()
         }
 
     def data_path(self, file_id):
         return {
-            'local_path': file_id
+            'local_path': file_id,
+            'exists': True
         }
+
 
 @pytest.fixture
 def mock_cache(request, tmpdir):


### PR DESCRIPTION
Adds ability to instantiate behavior_project_cache with `from_local_cache` factory method.

This doesn't require internet connection and will try to use local copies of data/metadata files.

without internet connection, assuming metadata and data files have already been downloaded into `cache_dir`:
```
bc = bpc.VisualBehaviorOphysProjectCache.from_local_cache(
        cache_dir="/tmp/test_project_cache",
        project_name="visual-behavior-ophys")

behavior_session_table = bc.get_behavior_session_table()
experiment_table = bc.get_experiment_table()
session_table = bc.get_session_table()

bs1 = bc.get_behavior_session(870987812)
bs2 = bc.get_behavior_session(956010809)
be1 = bc.get_behavior_ophys_experiment(958741232)
```