### PR TITLE
use dataframe.at to assign np.NaN to likely blinks

### DIFF
--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_ophys_nwb_api.py
@@ -270,9 +270,9 @@ class BehaviorOphysNwbApi(BehaviorNwbApi, BehaviorOphysBase):
             dilation_frames=dilation_frames)
 
         eye_tracking_data["likely_blink"] = likely_blinks
-        eye_tracking_data["eye_area"][likely_blinks] = np.nan
-        eye_tracking_data["pupil_area"][likely_blinks] = np.nan
-        eye_tracking_data["cr_area"][likely_blinks] = np.nan
+        eye_tracking_data.at[likely_blinks, "eye_area"] = np.nan
+        eye_tracking_data.at[likely_blinks, "pupil_area"] = np.nan
+        eye_tracking_data.at[likely_blinks, "cr_area"] = np.nan
 
         return eye_tracking_data
 


### PR DESCRIPTION
applies Marina's prescribed fix to issue #2027 

I validated it by running Doug's script without the fix and saving the eye tracking df to a csv. I then ran the script with the fix and verified that I got the same csv out.