### PR TITLE
rename 2 cache methods for tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [2.10.0] = TBD
+## [2.10.1] = 2021-03-23
+- changes name of BehaviorProjectCache to VisualBehaviorOphysProjectCache
+- changes VisualBehaviorOphysProjectCache method get_session_table() to get_ophys_session_table()
+- changes VisualBehaviorOphysProjectCache method get_experiment_table() to get_ophys_experiment_table()
+- VisualBehaviorOphysProjectCache is enabled to instantiate from_s3_cache() and from_local_cache()
 - Improvements to BehaviorProjectCache
 - Adds project metadata writer
 

--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '2.10.0'
+__version__ = '2.10.1'
 
 
 try:

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -227,7 +227,7 @@ class VisualBehaviorOphysProjectCache(Cache):
         return cls(fetch_api=fetch_api, manifest=manifest, version=version,
                    cache=cache, fetch_tries=fetch_tries)
 
-    def get_session_table(
+    def get_ophys_session_table(
             self,
             suppress: Optional[List[str]] = None,
             index_column: str = "ophys_session_id",
@@ -251,16 +251,16 @@ class VisualBehaviorOphysProjectCache(Cache):
         :rtype: pd.DataFrame
         """
         if isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            return self.fetch_api.get_session_table()
+            return self.fetch_api.get_ophys_session_table()
         if self.cache:
             path = self.get_cache_path(None, self.OPHYS_SESSIONS_KEY)
             ophys_sessions = one_file_call_caching(
                 path,
-                self.fetch_api.get_session_table,
+                self.fetch_api.get_ophys_session_table,
                 _write_json,
                 lambda path: _read_json(path, index_name='ophys_session_id'))
         else:
-            ophys_sessions = self.fetch_api.get_session_table()
+            ophys_sessions = self.fetch_api.get_ophys_session_table()
 
         if include_behavior_data:
             # Merge behavior data in
@@ -349,7 +349,7 @@ class VisualBehaviorOphysProjectCache(Cache):
                 get_behavior_only_session_table()
 
         if include_ophys_data:
-            ophys_session_table = self.get_session_table(
+            ophys_session_table = self.get_ophys_session_table(
                 suppress=suppress,
                 as_df=False,
                 include_behavior_data=False)

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -284,7 +284,7 @@ class VisualBehaviorOphysProjectCache(Cache):
             manifest_builder.add_path(key, **config)
         return manifest_builder
 
-    def get_experiment_table(
+    def get_ophys_experiment_table(
             self,
             suppress: Optional[List[str]] = None,
             as_df=True) -> Union[pd.DataFrame, SessionsTable]:
@@ -297,17 +297,17 @@ class VisualBehaviorOphysProjectCache(Cache):
         :rtype: pd.DataFrame
         """
         if isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            return self.fetch_api.get_experiment_table()
+            return self.fetch_api.get_ophys_experiment_table()
         if self.cache:
             path = self.get_cache_path(None, self.OPHYS_EXPERIMENTS_KEY)
             experiments = one_file_call_caching(
                 path,
-                self.fetch_api.get_experiment_table,
+                self.fetch_api.get_ophys_experiment_table,
                 _write_json,
                 lambda path: _read_json(path,
                                         index_name='ophys_experiment_id'))
         else:
-            experiments = self.fetch_api.get_experiment_table()
+            experiments = self.fetch_api.get_ophys_experiment_table()
 
         # Merge behavior data in
         behavior_sessions_table = self.get_behavior_session_table(
@@ -335,18 +335,17 @@ class VisualBehaviorOphysProjectCache(Cache):
         :rtype: pd.DataFrame
         """
         if isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            return self.fetch_api.get_behavior_only_session_table()
+            return self.fetch_api.get_behavior_session_table()
         if self.cache:
             path = self.get_cache_path(None, self.BEHAVIOR_SESSIONS_KEY)
             sessions = one_file_call_caching(
                 path,
-                self.fetch_api.get_behavior_only_session_table,
+                self.fetch_api.get_behavior_session_table,
                 _write_json,
                 lambda path: _read_json(path,
                                         index_name='behavior_session_id'))
         else:
-            sessions = self.fetch_api. \
-                get_behavior_only_session_table()
+            sessions = self.fetch_api.get_behavior_session_table()
 
         if include_ophys_data:
             ophys_session_table = self.get_ophys_session_table(

--- a/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
+++ b/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
@@ -21,7 +21,7 @@ class BehaviorProjectBase(ABC):
         pass
 
     @abstractmethod
-    def get_session_table(self) -> pd.DataFrame:
+    def get_ophys_session_table(self) -> pd.DataFrame:
         """Return a pd.Dataframe table with all ophys_session_ids and relevant
         metadata."""
         pass

--- a/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
+++ b/allensdk/brain_observatory/behavior/project_apis/abcs/behavior_project_base.py
@@ -38,7 +38,7 @@ class BehaviorProjectBase(ABC):
         pass
 
     @abstractmethod
-    def get_behavior_only_session_table(self) -> pd.DataFrame:
+    def get_behavior_session_table(self) -> pd.DataFrame:
         """Returns a pd.DataFrame table with all behavior session_ids to the
         user with additional metadata.
         :rtype: pd.DataFrame

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -136,8 +136,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         self.logger = logging.getLogger("BehaviorProjectCloudApi")
         self._local = local
         self._get_ophys_session_table()
-        self._get_behavior_only_session_table()
-        self._get_experiment_table()
+        self._get_behavior_session_table()
+        self._get_ophys_experiment_table()
 
     @staticmethod
     def from_s3_cache(cache_dir: Union[str, Path],
@@ -208,7 +208,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
 
         Notes
         -----
-        entries in the _behavior_only_session_table represent
+        entries in the _behavior_session_table represent
         (1) ophys_sessions which have a many-to-one mapping between nwb files
         and behavior sessions. (file_id is NaN)
         AND
@@ -219,10 +219,10 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         from the nwb file for the first-listed ophys_experiment.
 
         """
-        row = self._behavior_only_session_table.query(
+        row = self._behavior_session_table.query(
                 f"behavior_session_id=={behavior_session_id}")
         if row.shape[0] != 1:
-            raise RuntimeError("The behavior_only_session_table should have "
+            raise RuntimeError("The behavior_session_table should have "
                                "1 and only 1 entry for a given "
                                "behavior_session_id. For "
                                f"{behavior_session_id} "
@@ -231,7 +231,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         has_file_id = not pd.isna(row[self.cache.file_id_column])
         if not has_file_id:
             oeid = row.ophys_experiment_id[0]
-            row = self._experiment_table.query(f"index=={oeid}")
+            row = self._ophys_experiment_table.query(f"index=={oeid}")
         file_id = str(int(row[self.cache.file_id_column]))
         data_path = self._get_data_path(file_id=file_id)
         return BehaviorSession.from_nwb_path(str(data_path))
@@ -250,7 +250,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         BehaviorOphysExperiment
 
         """
-        row = self._experiment_table.query(
+        row = self._ophys_experiment_table.query(
                 f"index=={ophys_experiment_id}")
         if row.shape[0] != 1:
             raise RuntimeError("The behavior_ophys_experiment_table should "
@@ -281,13 +281,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         """
         return self._ophys_session_table
 
-    def _get_behavior_only_session_table(self):
+    def _get_behavior_session_table(self):
         session_table_path = self._get_metadata_path(
             fname='behavior_session_table')
         df = literal_col_eval(pd.read_csv(session_table_path))
-        self._behavior_only_session_table = df.set_index("behavior_session_id")
+        self._behavior_session_table = df.set_index("behavior_session_id")
 
-    def get_behavior_only_session_table(self) -> pd.DataFrame:
+    def get_behavior_session_table(self) -> pd.DataFrame:
         """Return a pd.Dataframe table with both behavior-only
         (BehaviorSession) and with-ophys (BehaviorOphysExperiment)
         sessions as entries.
@@ -299,22 +299,18 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         nwb path in cache.
         - In the second case, provides a critical mapping of
         behavior_session_id to a list of ophys_experiment_id(s)
-        which can be used to find file_id mappings in experiment_table
+        which can be used to find file_id mappings in ophys_experiment_table
         see method get_behavior_session()
-        - the BehaviorProjectCache calls this method through a method called
-        get_behavior_session_table. The name of this method is a legacy shared
-        with the behavior_project_lims_api and should be made consistent with
-        the BehaviorProjectCache calling method.
         """
-        return self._behavior_only_session_table
+        return self._behavior_session_table
 
-    def _get_experiment_table(self):
+    def _get_ophys_experiment_table(self):
         experiment_table_path = self._get_metadata_path(
             fname="ophys_experiment_table")
         df = literal_col_eval(pd.read_csv(experiment_table_path))
-        self._experiment_table = df.set_index("ophys_experiment_id")
+        self._ophys_experiment_table = df.set_index("ophys_experiment_id")
 
-    def get_experiment_table(self):
+    def get_ophys_experiment_table(self):
         """returns a pd.DataFrame where each entry has a 1-to-1
         relation with an ophys experiment (i.e. imaging plane)
 
@@ -325,7 +321,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         relation between nwb files and ophy experiments. See method
         get_behavior_ophys_experiment()
         """
-        return self._experiment_table
+        return self._ophys_experiment_table
 
     def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
         """ Download a template for the natural movie stimulus. This is the
@@ -361,7 +357,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         return data_path
 
     def _get_local_path(self, fname: Optional[str] = None, file_id:
-                                 Optional[str] = None):
+                        Optional[str] = None):
         if fname is None and file_id is None:
             raise ValueError('Must pass either fname or file_id')
 

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_cloud_api.py
@@ -135,7 +135,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
             version_check(self.cache._manifest._data_pipeline)
         self.logger = logging.getLogger("BehaviorProjectCloudApi")
         self._local = local
-        self._get_session_table()
+        self._get_ophys_session_table()
         self._get_behavior_only_session_table()
         self._get_experiment_table()
 
@@ -262,13 +262,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         data_path = self._get_data_path(file_id=file_id)
         return BehaviorOphysExperiment.from_nwb_path(str(data_path))
 
-    def _get_session_table(self):
+    def _get_ophys_session_table(self):
         session_table_path = self._get_metadata_path(
             fname="ophys_session_table")
         df = literal_col_eval(pd.read_csv(session_table_path))
-        self._session_table = df.set_index("ophys_session_id")
+        self._ophys_session_table = df.set_index("ophys_session_id")
 
-    def get_session_table(self) -> pd.DataFrame:
+    def get_ophys_session_table(self) -> pd.DataFrame:
         """Return a pd.Dataframe table summarizing ophys_sessions
         and associated metadata.
 
@@ -279,7 +279,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         'ophys_experiment_id' column (can be a list)
         and experiment_table
         """
-        return self._session_table
+        return self._ophys_session_table
 
     def _get_behavior_only_session_table(self):
         session_table_path = self._get_metadata_path(

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
@@ -330,7 +330,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         """
         return BehaviorOphysExperiment(BehaviorOphysLimsApi(ophys_experiment_id))
 
-    def _get_experiment_table(self) -> pd.DataFrame:
+    def _get_ophys_experiment_table(self) -> pd.DataFrame:
         """
         Helper function for easier testing.
         Return a pd.Dataframe table with all ophys_experiment_ids and relevant
@@ -373,7 +373,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         if self.data_release_date is not None:
             query += self._get_ophys_experiment_release_filter()
 
-        self.logger.debug(f"get_experiment_table query: \n{query}")
+        self.logger.debug(f"get_ophys_experiment_table query: \n{query}")
         return self.lims_engine.select(query)
 
     def _get_ophys_session_table(self) -> pd.DataFrame:
@@ -441,7 +441,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         """
         return BehaviorSession(BehaviorLimsApi(behavior_session_id))
 
-    def get_experiment_table(
+    def get_ophys_experiment_table(
             self,
             ophys_experiment_ids: Optional[List[int]] = None) -> pd.DataFrame:
         """Return a pd.Dataframe table with all ophys_experiment_ids and
@@ -458,9 +458,9 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
             to include
         :rtype: pd.DataFrame
         """
-        return self._get_experiment_table().set_index("ophys_experiment_id")
+        return self._get_ophys_experiment_table().set_index("ophys_experiment_id")
 
-    def get_behavior_only_session_table(self) -> pd.DataFrame:
+    def get_behavior_session_table(self) -> pd.DataFrame:
         """Returns a pd.DataFrame table with all behavior session_ids to the
         user with additional metadata.
 

--- a/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/project_apis/data_io/behavior_project_lims_api.py
@@ -376,7 +376,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         self.logger.debug(f"get_experiment_table query: \n{query}")
         return self.lims_engine.select(query)
 
-    def _get_session_table(self) -> pd.DataFrame:
+    def _get_ophys_session_table(self) -> pd.DataFrame:
         """Helper function for easier testing.
         Return a pd.Dataframe table with all ophys_session_ids and relevant
         metadata.
@@ -411,10 +411,10 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
 
         if self.data_release_date is not None:
             query += self._get_ophys_session_release_filter()
-        self.logger.debug(f"get_session_table query: \n{query}")
+        self.logger.debug(f"get_ophys_session_table query: \n{query}")
         return self.lims_engine.select(query)
 
-    def get_session_table(self) -> pd.DataFrame:
+    def get_ophys_session_table(self) -> pd.DataFrame:
         """Return a pd.Dataframe table with all ophys_session_ids and relevant
         metadata.
         Return columns: ophys_session_id, behavior_session_id,
@@ -426,7 +426,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         """
         # There is one ophys_session_id from 2018 that has multiple behavior
         # ids, causing duplicates -- drop all dupes for now; # TODO
-        table = (self._get_session_table()
+        table = (self._get_ophys_session_table()
                  .drop_duplicates(subset=["ophys_session_id"], keep=False)
                  .set_index("ophys_session_id"))
         return table

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
@@ -67,17 +67,14 @@ def mock_api(session_table, behavior_table, experiments_table):
         def get_ophys_session_table(self):
             return session_table
 
-        def get_behavior_only_session_table(self):
+        def get_behavior_session_table(self):
             return behavior_table
 
-        def get_experiment_table(self):
+        def get_ophys_experiment_table(self):
             return experiments_table
 
         def get_session_data(self, ophys_session_id):
             return ophys_session_id
-
-        def get_behavior_only_session_data(self, behavior_session_id):
-            return behavior_session_id
 
         def get_behavior_stage_parameters(self, foraging_ids):
             return {x: {} for x in foraging_ids}
@@ -130,7 +127,7 @@ def test_get_behavior_table(TempdirBehaviorCache, behavior_table):
 @pytest.mark.parametrize("TempdirBehaviorCache", [True, False], indirect=True)
 def test_get_experiments_table(TempdirBehaviorCache, experiments_table):
     cache = TempdirBehaviorCache
-    obtained = cache.get_experiment_table()
+    obtained = cache.get_ophys_experiment_table()
     if cache.cache:
         path = cache.manifest.path_info.get("ophys_experiments").get("spec")
         assert os.path.exists(path)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cache.py
@@ -64,7 +64,7 @@ def experiments_table():
 @pytest.fixture
 def mock_api(session_table, behavior_table, experiments_table):
     class MockApi:
-        def get_session_table(self):
+        def get_ophys_session_table(self):
             return session_table
 
         def get_behavior_only_session_table(self):
@@ -96,9 +96,9 @@ def TempdirBehaviorCache(mock_api, request):
 
 
 @pytest.mark.parametrize("TempdirBehaviorCache", [True, False], indirect=True)
-def test_get_session_table(TempdirBehaviorCache, session_table):
+def test_get_ophys_session_table(TempdirBehaviorCache, session_table):
     cache = TempdirBehaviorCache
-    obtained = cache.get_session_table()
+    obtained = cache.get_ophys_session_table()
     if cache.cache:
         path = cache.manifest.path_info.get("ophys_sessions").get("spec")
         assert os.path.exists(path)
@@ -148,7 +148,7 @@ def test_session_table_reads_from_cache(TempdirBehaviorCache, session_table,
                                         caplog):
     caplog.set_level(logging.INFO, logger="call_caching")
     cache = TempdirBehaviorCache
-    cache.get_session_table()
+    cache.get_ophys_session_table()
     expected_first = [
         ('call_caching', logging.INFO, 'Reading data from cache'),
         ('call_caching', logging.INFO, 'No cache file found.'),
@@ -162,7 +162,7 @@ def test_session_table_reads_from_cache(TempdirBehaviorCache, session_table,
         ('call_caching', logging.INFO, 'Reading data from cache')]
     assert expected_first == caplog.record_tuples
     caplog.clear()
-    cache.get_session_table()
+    cache.get_ophys_session_table()
     assert [expected_first[0], expected_first[-1]] == caplog.record_tuples
 
 
@@ -190,11 +190,11 @@ def test_behavior_table_reads_from_cache(TempdirBehaviorCache, behavior_table,
 
 
 @pytest.mark.parametrize("TempdirBehaviorCache", [True, False], indirect=True)
-def test_get_session_table_by_experiment(TempdirBehaviorCache):
+def test_get_ophys_session_table_by_experiment(TempdirBehaviorCache):
     expected = (pd.DataFrame({"ophys_session_id": [1, 1],
                               "ophys_experiment_id": [5, 6]})
                 .set_index("ophys_experiment_id"))
-    actual = TempdirBehaviorCache.get_session_table(
+    actual = TempdirBehaviorCache.get_ophys_session_table(
         index_column="ophys_experiment_id")[
         ["ophys_session_id"]]
     pd.testing.assert_frame_equal(expected, actual)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
@@ -110,7 +110,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch, local):
                     for i, j in zip(bost[k].values, ebost[k].values)])
 
     # ophys session table as expected
-    ost = api.get_session_table()
+    ost = api.get_ophys_session_table()
     assert ost.index.name == "ophys_session_id"
     ost = ost.reset_index()
     eost = expected["ophys_session_table"]

--- a/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_project_cloud_api.py
@@ -99,7 +99,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch, local):
                                                local=True)
 
     # behavior session table as expected
-    bost = api.get_behavior_only_session_table()
+    bost = api.get_behavior_session_table()
     assert bost.index.name == "behavior_session_id"
     bost = bost.reset_index()
     ebost = expected["behavior_session_table"]
@@ -121,7 +121,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch, local):
                     for i, j in zip(ost[k].values, eost[k].values)])
 
     # experiment table as expected
-    et = api.get_experiment_table()
+    et = api.get_ophys_experiment_table()
     assert et.index.name == "ophys_experiment_id"
     et = et.reset_index()
     pd.testing.assert_frame_equal(et, expected["ophys_experiment_table"])

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -91,9 +91,15 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
 
-What's New - 2.10.0
+What's New - 2.10.1
 -----------------------------------------------------------------------
+- changes name of BehaviorProjectCache to VisualBehaviorOphysProjectCache
+- changes VisualBehaviorOphysProjectCache method get_session_table() to get_ophys_session_table()
+- changes VisualBehaviorOphysProjectCache method get_experiment_table() to get_ophys_experiment_table()
+- VisualBehaviorOphysProjectCache is enabled to instantiate from_s3_cache() and from_local_cache()
 - Improvements to BehaviorProjectCache
+- Adds project metadata writer
+
 
 What's New - 2.9.0
 -----------------------------------------------------------------------


### PR DESCRIPTION
#### User-facing renames
* `get_session_table()` - > `get_ophys_session_table()`
* `get_experiment_table()` -> `get_ophys_experiment_table()`

#### internal renames
* eliminates some legacy `behavior_only_session...` in favor of `behavior_session...` to match user-facing methods and attributes.