### PR TITLE
Fix get_performance_metrics() dictionary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [2.10.2] = TBD
 - update documentation to support visual behavior data release
+- Fixes a bug with the dictionary returned by BehaviorSession get get_performance_metrics() method
+- Adds docstrings to the BehaviorSession get_performance_metrics(), get_rolling_performance_df(), and get_reward_rate() methods
 
 ## [2.10.1] = 2021-03-23
 - changes name of BehaviorProjectCache to VisualBehaviorOphysProjectCache

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -170,8 +170,12 @@ class BehaviorSession(LazyPropertyMixin):
             self.trials.correct_reject.sum()
         performance_metrics['auto_rewarded_trial_count'] = \
             self.trials.auto_rewarded.sum()
-        performance_metrics['rewarded_trial_count'] = \
-            self.trials.reward_time.apply(lambda x: not np.isnan(x)).sum()
+        # Although 'rewarded_trial_count' will currently have the same value as
+        # 'hit_trial_count', in the future there may be variants of the
+        # task where rewards are withheld. In that case the
+        # 'rewarded_trial_count' will be smaller than (and different from)
+        # the 'hit_trial_count'.
+        performance_metrics['rewarded_trial_count'] = self.trials.hit.sum()
         performance_metrics['total_reward_count'] = len(self.rewards)
         performance_metrics['total_reward_volume'] = self.rewards.volume.sum()
 

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -93,14 +93,16 @@ See the `mouse connectivity section <connectivity.html>`_ for more details.
 
 What's New - 2.10.2
 -----------------------------------------------------------------------
-- update documentation to support visual behavior data release
+- Update documentation to support visual behavior data release
+- Fixes a bug with the dictionary returned by BehaviorSession get get_performance_metrics() method
+- Adds docstrings to the BehaviorSession get_performance_metrics(), get_rolling_performance_df(), and get_reward_rate() methods
 
 
 What's New - 2.10.1
 -----------------------------------------------------------------------
-- changes name of BehaviorProjectCache to VisualBehaviorOphysProjectCache
-- changes VisualBehaviorOphysProjectCache method get_session_table() to get_ophys_session_table()
-- changes VisualBehaviorOphysProjectCache method get_experiment_table() to get_ophys_experiment_table()
+- Changes name of BehaviorProjectCache to VisualBehaviorOphysProjectCache
+- Changes VisualBehaviorOphysProjectCache method get_session_table() to get_ophys_session_table()
+- Changes VisualBehaviorOphysProjectCache method get_experiment_table() to get_ophys_experiment_table()
 - VisualBehaviorOphysProjectCache is enabled to instantiate from_s3_cache() and from_local_cache()
 - Improvements to BehaviorProjectCache
 - Adds project metadata writer


### PR DESCRIPTION
This PR aims to address: #2017 

Validation:
![image](https://user-images.githubusercontent.com/43766899/112226966-24bf6d80-8bec-11eb-932c-03e37c03aa0c.png)


TODO:

- [x] Wait for descriptions of different dictionary fields from @DowntonCrabby
- [x] Still need a description for `get_reward_rate()` method