### PR TITLE
Add end user convenience method for behavior session

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -88,8 +88,8 @@ class BehaviorSession(LazyPropertyMixin):
         """Convenience method for end-users to list attributes and methods
         that can be called to access data for a BehaviorSession.
 
-        NOTE: Because BehaviorExperiment inherits from BehaviorSession
-        this method was also be available there.
+        NOTE: Because BehaviorOphysExperiment inherits from BehaviorSession,
+        this method will also be available there.
 
         Returns
         -------

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -7,6 +7,7 @@ import inspect
 from allensdk.brain_observatory.behavior.metadata.behavior_metadata import \
     BehaviorMetadata
 from allensdk.core.lazy_property import LazyPropertyMixin
+from allensdk.brain_observatory.session_api_utils import ParamsMixin
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
     BehaviorLimsApi, BehaviorNwbApi)
 from allensdk.brain_observatory.behavior.session_apis.abcs.\
@@ -82,6 +83,36 @@ class BehaviorSession(LazyPropertyMixin):
         docs = [inspect.getdoc(m[1]) or "" for m in methods]
         method_names = [m[0] for m in methods]
         return list(zip(method_names, docs))
+
+    def list_data_attributes_and_methods(self) -> List[str]:
+        """Convenience method for end-users to list attributes and methods
+        that can be called to access data for a BehaviorSession.
+
+        NOTE: Because BehaviorExperiment inherits from BehaviorSession
+        this method was also be available there.
+
+        Returns
+        -------
+        List[str]
+            A list of attributes and methods that end-users can access or call
+            to get data.
+        """
+        attrs_and_methods_to_ignore: set = {
+            "api",
+            "from_lims",
+            "from_nwb_path",
+            "LazyProperty",
+            "list_api_methods",
+            "list_data_attributes_and_methods"
+        }
+        attrs_and_methods_to_ignore.update(dir(ParamsMixin))
+        attrs_and_methods_to_ignore.update(dir(LazyPropertyMixin))
+        class_dir = dir(self)
+        attrs_and_methods = [
+            r for r in class_dir
+            if (r not in attrs_and_methods_to_ignore and not r.startswith("_"))
+        ]
+        return attrs_and_methods
 
     # ========================= 'get' methods ==========================
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_experiment.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_experiment.py
@@ -250,3 +250,52 @@ def test_BehaviorOphysExperiment_property_data():
 
     assert dataset.ophys_session_id == 959458018
     assert dataset.ophys_experiment_id == 960410026
+
+
+def test_behavior_ophys_experiment_list_data_attributes_and_methods():
+    # Test that data related methods/attributes/properties for
+    # BehaviorOphysExperiment are returned properly.
+
+    # This test will need to be updated if:
+    # 1. Data being returned by class has changed
+    # 2. Inheritance of class has changed
+    expected = {
+        'average_projection',
+        'behavior_session_id',
+        'cache_clear',
+        'cell_specimen_table',
+        'corrected_fluorescence_traces',
+        'dff_traces',
+        'events',
+        'eye_tracking',
+        'eye_tracking_rig_geometry',
+        'get_cell_specimen_ids',
+        'get_cell_specimen_indices',
+        'get_dff_traces',
+        'get_performance_metrics',
+        'get_reward_rate',
+        'get_rolling_performance_df',
+        'get_segmentation_mask_image',
+        'licks',
+        'max_projection',
+        'metadata',
+        'motion_correction',
+        'ophys_experiment_id',
+        'ophys_session_id',
+        'ophys_timestamps',
+        'raw_running_speed',
+        'rewards',
+        'roi_masks',
+        'running_speed',
+        'segmentation_mask_image',
+        'stimulus_presentations',
+        'stimulus_templates',
+        'stimulus_timestamps',
+        'task_parameters',
+        'trials'
+    }
+
+    behavior_ophys_experiment = BehaviorOphysExperiment(api=MagicMock())
+    obt = behavior_ophys_experiment.list_data_attributes_and_methods()
+
+    assert any(expected ^ set(obt)) is False

--- a/allensdk/test/brain_observatory/behavior/test_behavior_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_session.py
@@ -1,5 +1,6 @@
 import logging
 
+from unittest.mock import MagicMock
 from allensdk.brain_observatory.behavior.behavior_session import (
     BehaviorSession)
 
@@ -66,3 +67,34 @@ class TestBehaviorSession:
         bs = SimpleBehaviorSession(api=DummyApiCache())
         bs.cache_clear()
         assert len(caplog.record_tuples) == 0
+
+
+def test_behavior_session_list_data_attributes_and_methods():
+    # Test that data related methods/attributes/properties for
+    # BehaviorSession are returned properly.
+
+    # This test will need to be updated if:
+    # 1. Data being returned by class has changed
+    # 2. Inheritance of class has changed
+    expected = {
+        'behavior_session_id',
+        'cache_clear',
+        'get_performance_metrics',
+        'get_reward_rate',
+        'get_rolling_performance_df',
+        'licks',
+        'metadata',
+        'raw_running_speed',
+        'rewards',
+        'running_speed',
+        'stimulus_presentations',
+        'stimulus_templates',
+        'stimulus_timestamps',
+        'task_parameters',
+        'trials'
+    }
+
+    behavior_session = BehaviorSession(api=MagicMock())
+    obt = behavior_session.list_data_attributes_and_methods()
+
+    assert any(expected ^ set(obt)) is False


### PR DESCRIPTION
This PR adds a convenience method to the BehaviorSession (and
by extension OphysExperiment) classes that lists only data
related properties and methods.

This will make it much easier for end users to determine
which properties and methods are data related and relevant to them.

Validation:
![image](https://user-images.githubusercontent.com/43766899/112233546-e3cd5600-8bf7-11eb-9d83-daebfe9c4ef0.png)
