### PR TITLE
add docstring for behavior_session.task_parameters

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -526,33 +526,39 @@ class BehaviorSession(LazyPropertyMixin):
             A dictionary containing parameters used to define the task runtime
             behavior.
                 auto_reward_volume: (float)
-                    Volume of auto rewards in ml 
+                    Volume of auto rewards in ml.
                 blank_duration_sec : (list of floats)
-                    Duration in seconds of inter stimulus interval
-                    Inter-stimulus interval chosen as a uniform random value between the range defined by the two values
-                    Values are ignored if `stimulus_duration_sec` is null
+                    Duration in seconds of inter stimulus interval.
+                    Inter-stimulus interval chosen as a uniform random value.
+                    between the range defined by the two values.
+                    Values are ignored if `stimulus_duration_sec` is null.
                 response_window_sec: (list of floats)
-                    Range of period following an image change, in seconds, where mouse response influences trial outcome
-                    First value represents response window start
-                    Second value represents response window end
-                    Values represent time before display lag is accounted for and applied
+                    Range of period following an image change, in seconds,
+                    where mouse response influences trial outcome.
+                    First value represents response window start.
+                    Second value represents response window end.
+                    Values represent time before display lag is
+                    accounted for and applied.
                 n_stimulus_frames: (int)
-                    Total number of visual stimulus frames presented during a behavior session 
+                    Total number of visual stimulus frames presented during
+                    a behavior session.
                 task: (string)
-                    Type of visual stimulus task
+                    Type of visual stimulus task.
                 session_type: (string)
-                    Visual stimulus type run during behavior session 
+                    Visual stimulus type run during behavior session.
                 omitted_flash_fraction: (float)
-                    Probability that a stimulus image presentations is omitted. 
-                    Change stimuli, and the stimulus immediately preceding the change, are never omitted.
+                    Probability that a stimulus image presentations is omitted.
+                    Change stimuli, and the stimulus immediately preceding the
+                    change, are never omitted.
                 stimulus_distribution: (string)
-                    Distribution for drawing change times. Either 'exponential' or 'geometric'
+                    Distribution for drawing change times.
+                    Either 'exponential' or 'geometric'.
                 stimulus_duration_sec: (float)
-                    Duration in seconds of each stimulus image presentation 
+                    Duration in seconds of each stimulus image presentation
                 reward_volume: (float)
-                    Volume of earned water reward in ml
+                    Volume of earned water reward in ml.
                 stimulus: (string)
-                    Stimulus type ('gratings' or 'images')
+                    Stimulus type ('gratings' or 'images').
 
         """
         return self._task_parameters

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -525,6 +525,35 @@ class BehaviorSession(LazyPropertyMixin):
         dict
             A dictionary containing parameters used to define the task runtime
             behavior.
+                auto_reward_volume: (float)
+                    Volume of auto rewards in ml 
+                blank_duration_sec : (list of floats)
+                    Duration in seconds of inter stimulus interval
+                    Inter-stimulus interval chosen as a uniform random value between the range defined by the two values
+                    Values are ignored if `stimulus_duration_sec` is null
+                response_window_sec: (list of floats)
+                    Range of period following an image change, in seconds, where mouse response influences trial outcome
+                    First value represents response window start
+                    Second value represents response window end
+                    Values represent time before display lag is accounted for and applied
+                n_stimulus_frames: (int)
+                    Total number of visual stimulus frames presented during a behavior session 
+                task: (string)
+                    Type of visual stimulus task
+                session_type: (string)
+                    Visual stimulus type run during behavior session 
+                omitted_flash_fraction: (float)
+                    Probability that a stimulus image presentations is omitted. 
+                    Change stimuli, and the stimulus immediately preceding the change, are never omitted.
+                stimulus_distribution: (string)
+                    Distribution for drawing change times. Either 'exponential' or 'geometric'
+                stimulus_duration_sec: (float)
+                    Duration in seconds of each stimulus image presentation 
+                reward_volume: (float)
+                    Volume of earned water reward in ml
+                stimulus: (string)
+                    Stimulus type ('gratings' or 'images')
+
         """
         return self._task_parameters
 


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
Adding a docstring for behavior_session.task_parameters

# Addresses:
https://github.com/AllenInstitute/AllenSDK/issues/2049
Specifically, for `blank_duration_sec`, it specifies "Values are ignored if `stimulus_duration_sec` is null"

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [X] Documentation Change

# Solution:
adds docstring

# Changes:
adds docstring to behavior_session.task_parameters

# Validation:
Here is result of calling help on 
![image](https://user-images.githubusercontent.com/19944442/112394768-7cc4a580-8cba-11eb-8c21-0e10e6cf24b8.png)


# Checklist
- [X] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [X] My code is unit tested and does not decrease test coverage
- [X] I have performed a self review of my own code
- [X] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [X] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [X] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
I didn't include the the issue number in my commit header. Can I fix that post hoc?
