### PR TITLE
extends CI test matrix to 3.8

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -44,7 +44,8 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "windows-latest", "ubuntu-latest"]
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.6", "3.7", "3.8"]
+      fail-fast: false
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.11.0] = TBD
+- python 3.8 compatibility
+
 ## [2.10.3] = 2021-04-23
 - Adds restriction to require hdmf version to be strictly less than 2.5.0 which accidentally introduced a major version breaking change
 

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -121,7 +121,7 @@ See the `mouse connectivity section <connectivity.html>`_ for more details.
 
 What's New - 2.11.0
 -----------------------------------------------------------------------
-- list updates here
+- python 3.8 compatibility
 
 
 What's New - 2.10.3

--- a/docker/anaconda3/Dockerfile
+++ b/docker/anaconda3/Dockerfile
@@ -22,7 +22,7 @@ RUN conda create -y --name py36 python=3.6 ipykernel \
 RUN conda create -y --name py37 python=3.7 ipykernel \
     && conda clean --index-cache --tarballs
 
-RUN conda create -y --name py38 python=3.8 ipykernel numpy h5py \
+RUN conda create -y --name py38 python=3.8 ipykernel numpy\
     && conda clean --index-cache --tarballs
 
 RUN conda create -y --name py39 python=3.9 ipykernel \

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,14 +14,14 @@ requests-toolbelt<1.0.0
 simplejson>=3.10.0,<4.0.0
 scikit-image>=0.14.0,<0.17.0
 scikit-build<1.0.0
-statsmodels==0.9.0
+statsmodels<=0.13.0
 simpleitk>=2.0.2,<3.0.0
 argschema<3.0.0
 marshmallow==3.0.0rc6
 glymur==0.8.19
 xarray<0.16.0
 pynwb>=1.3.2,<2.0.0
-tables==3.5.1 # pinning this because updates tend to not include wheels immediately
+tables>=3.6.0,<4.0.0
 seaborn<1.0.0
 aiohttp==3.7.4
 nest_asyncio==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.6', 
         'Programming Language :: Python :: 3.7', 
+        'Programming Language :: Python :: 3.8', 
         'Topic :: Scientific/Engineering :: Bio-Informatics'
         ])


### PR DESCRIPTION
* enables cloud CI tests for python 3.8
* updates pytables and statsmodels version requirements
* adds a numpy install to the anaconda3 dockerfile for python 3.8 to allow install of statsmodels.

In addition to CI tests passing below ( (3.6, 3.7, 3.8) x (windows, linux, mac) ), all three python versions are now passing on the [onprem build](http://bamboo.corp.alleninstitute.org/browse/IFR-AAG81-1) and the [onprem nightly build](http://bamboo.corp.alleninstitute.org/browse/IFR-ANG48-2)