### PR TITLE
adds python 3.9 build to docker

### DIFF
--- a/docker/anaconda3/Dockerfile
+++ b/docker/anaconda3/Dockerfile
@@ -24,3 +24,6 @@ RUN conda create -y --name py37 python=3.7 ipykernel \
 
 RUN conda create -y --name py38 python=3.8 ipykernel \
     && conda clean --index-cache --tarballs
+
+RUN conda create -y --name py39 python=3.9 ipykernel \
+    && conda clean --index-cache --tarballs


### PR DESCRIPTION
adds a python 3.9 conda env to the docker build. Bamboo uses the image from this build (built by bamboo, stored in on-prem artifactory) to run the bamboo tests of AllenSDK.