### PR TITLE
Write NWB methods fail properly when file doesn't exist

### DIFF
--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
@@ -48,7 +48,8 @@ def write_behavior_nwb(session_data, nwb_filepath):
         os.rename(nwb_filepath_inprogress, nwb_filepath)
         return {'output_path': nwb_filepath}
     except Exception as e:
-        os.rename(nwb_filepath_inprogress, nwb_filepath_error)
+        if os.path.isfile(nwb_filepath_inprogress):
+            os.rename(nwb_filepath_inprogress, nwb_filepath_error)
         raise e
 
 

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -53,7 +53,8 @@ def write_behavior_ophys_nwb(session_data: dict,
         os.rename(nwb_filepath_inprogress, nwb_filepath)
         return {'output_path': nwb_filepath}
     except Exception as e:
-        os.rename(nwb_filepath_inprogress, nwb_filepath_error)
+        if os.path.isfile(nwb_filepath_inprogress):
+            os.rename(nwb_filepath_inprogress, nwb_filepath_error)
         raise e
 
 

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -91,33 +91,4 @@ def main():
 
 
 if __name__ == "__main__":
-
-    # input_dict = {'log_level':'DEBUG',
-    #               'session_data': {'ophys_experiment_id': 789359614,
-    #                                 'surface_2p_pixel_size_um': 0.78125,
-    #                                 "max_projection_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/processed/ophys_cell_segmentation_run_789410052/maxInt_a13a.png",
-    #                                 "sync_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/789220000_sync.h5",
-    #                                 "rig_name": "CAM2P.5",
-    #                                 "movie_width": 447,
-    #                                 "movie_height": 512,
-    #                                 "container_id": 814796558,
-    #                                 "targeted_structure": "VISp",
-    #                                 "targeted_depth": 375,
-    #                                 "stimulus_name": "Unknown",
-    #                                 "date_of_acquisition": '2018-11-30 23:28:37',
-    #                                 "reporter_line": ["Ai93(TITL-GCaMP6f)"],
-    #                                 "driver_line": ['Camk2a-tTA', 'Slc17a7-IRES2-Cre'],
-    #                                 "external_specimen_name": 416369,
-    #                                 "full_genotype": "Slc17a7-IRES2-Cre/wt;Camk2a-tTA/wt;Ai93(TITL-GCaMP6f)/wt",
-    #                                 "behavior_stimulus_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/behavior_session_789295700/789220000.pkl",
-    #                                 "dff_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/789359614_dff.h5",
-    #                                 "ophys_cell_segmentation_run_id": 789410052,
-    #                                 "cell_specimen_table_dict": json.load(open('/home/nicholasc/projects/allensdk/allensdk/test/brain_observatory/behavior/cell_specimen_table_789359614.json', 'r')),
-    #                                 "demix_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/demix/789359614_demixed_traces.h5",
-    #                                 "average_intensity_projection_image_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/processed/ophys_cell_segmentation_run_789410052/avgInt_a1X.png",
-    #                                 "rigid_motion_transform_file": "/allen/programs/braintv/production/visualbehavior/prod0/specimen_756577249/ophys_session_789220000/ophys_experiment_789359614/processed/789359614_rigid_motion_transform.csv",
-    #                                 },
-    #                 'output_path': 'tmp.nwb'}
-    # json.dump(input_dict, open('dev.json', 'w'))
-
     main()

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -1,18 +1,21 @@
 import math
+import mock
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from pathlib import Path
 import pynwb
 import pytest
 
+import allensdk
 import allensdk.brain_observatory.nwb as nwb
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
     BehaviorNwbApi)
 from allensdk.brain_observatory.behavior.stimulus_processing import \
     StimulusTemplate, get_stimulus_templates
 
-from allensdk.brain_observatory.behavior.write_behavior_nwb.__main__ import write_behavior_nwb  # noqa: E501
+from allensdk.brain_observatory.behavior.write_behavior_nwb.__main__ import \
+    write_behavior_nwb  # noqa: E501
 
 
 # pytest fixtures:
@@ -245,14 +248,22 @@ def test_add_task_parameters_stim_nan(nwbfile, roundtrip,
 
 def test_write_behavior_nwb_no_file():
     """
-        This function is intended to test the code in the except block
-        of the write_behavior_nwb method. To get there, we simply pass
-        None for the session_data parameter which will cause a TypeError
-        when the try block attempts to subscript it.
+        This function is testing the fail condition of the write_behavior_nwb
+        method. The main functionality of the write_behavior_nwb method occurs
+        in a try block, and in the case that an exception is raised there is
+        functionality in the except block to check if any partial output 
+        exists, and if so rename that file to have a .error suffix before 
+        raising the previously mentioned exception.
 
-        If this function is ever meaningfully changed in implementation,
-        this method of getting to the except block may no longer work and
-        this test will need updating.
+        This test is checking the case where that partial output does not
+        exist. In this case we still want to have the original exception
+        returned and avoid a FileNotFound error.
+
+        To ensure that we enter the except block, a value of None is passed
+        for the session_data argument. This will cause a TypeError when
+        write_behavior_nwb tries to subscript this variable. We are checking
+        that, even though no partial output exists, we still get this
+        TypeError raised.
     """
     with pytest.raises(TypeError) as err:
         write_behavior_nwb(
@@ -263,11 +274,45 @@ def test_write_behavior_nwb_no_file():
     assert 'TypeError' in str(err.type)
 
 def test_write_behavior_nwb_with_file(tmpdir):
-    fake_nwb = Path(tmpdir) / ''
-    
-    write_behavior_nwb(
-        session_data=None,
-        nwb_filepath=''
-    )
+    """
+        This function is testing the fail condition of the write_behavior_nwb
+        method. The main functionality of the write_behavior_nwb method occurs
+        in a try block, and in the case that an exception is raised there is
+        functionality in the except block to check if any partial output 
+        exists, and if so rename that file to have a .error suffix before 
+        raising the previously mentioned exception.
 
-    assert 'TypeError' in str(err.type)
+        This test is checking the case where a partial output file does
+        exist. In this case we still want to have the original exception
+        returned and avoid a FileNotFound error, but also check that a new 
+        file with the .error suffix exists.
+
+        To ensure that we enter the except block, a value of None is passed
+        for the session_data argument. This will cause a TypeError when
+        write_behavior_nwb tries to subscript this variable. To get the 
+        partial output file to exist, we simply create a Path object and
+        call the .touch method.
+
+        This test also patched the os.remove method to do nothing. This is
+        necessary because the write_behavior_nwb method checks for any
+        existing output and removes it before running.
+    """
+    # Create the dummy .nwb file
+    fake_nwb_fp = Path(tmpdir) / 'fake_nwb.nwb'
+    Path(str(fake_nwb_fp) + '.inprogress').touch()
+    
+    def mock_os_remove(fp):
+        pass
+    
+    # Patch the os.remove method to do nothing
+    with mock.patch('os.remove', side_effects=mock_os_remove):
+        with pytest.raises(TypeError) as err:
+            write_behavior_nwb(
+                session_data=None,
+                nwb_filepath=str(fake_nwb_fp)
+            )
+
+            # Check that the new .error file exists, and that we
+            # still get the expected exception
+            assert Path(str(fake_nwb_fp) + '.error').exists()
+            assert 'TypeError' in str(err.type)

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -2,6 +2,7 @@ import math
 
 import numpy as np
 import pandas as pd
+from pathlib import Path
 import pynwb
 import pytest
 
@@ -242,7 +243,7 @@ def test_add_task_parameters_stim_nan(nwbfile, roundtrip,
             assert val == task_parameters_obt[key]
 
 
-def test_write_behavior_nwb():
+def test_write_behavior_nwb_no_file():
     """
         This function is intended to test the code in the except block
         of the write_behavior_nwb method. To get there, we simply pass
@@ -259,4 +260,14 @@ def test_write_behavior_nwb():
             nwb_filepath=''
         )
     
+    assert 'TypeError' in str(err.type)
+
+def test_write_behavior_nwb_with_file(tmpdir):
+    fake_nwb = Path(tmpdir) / ''
+    
+    write_behavior_nwb(
+        session_data=None,
+        nwb_filepath=''
+    )
+
     assert 'TypeError' in str(err.type)

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -264,7 +264,7 @@ def test_write_behavior_nwb_no_file():
         that, even though no partial output exists, we still get this
         TypeError raised.
     """
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError):
         write_behavior_nwb(
             session_data=None,
             nwb_filepath=''
@@ -304,7 +304,7 @@ def test_write_behavior_nwb_with_file(tmpdir):
 
     # Patch the os.remove method to do nothing
     with mock.patch('os.remove', side_effects=mock_os_remove):
-        with pytest.raises(TypeError) as err:
+        with pytest.raises(TypeError):
             write_behavior_nwb(
                 session_data=None,
                 nwb_filepath=str(fake_nwb_fp)

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pynwb
 import pytest
 
-import allensdk
 import allensdk.brain_observatory.nwb as nwb
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
     BehaviorNwbApi)
@@ -251,8 +250,8 @@ def test_write_behavior_nwb_no_file():
         This function is testing the fail condition of the write_behavior_nwb
         method. The main functionality of the write_behavior_nwb method occurs
         in a try block, and in the case that an exception is raised there is
-        functionality in the except block to check if any partial output 
-        exists, and if so rename that file to have a .error suffix before 
+        functionality in the except block to check if any partial output
+        exists, and if so rename that file to have a .error suffix before
         raising the previously mentioned exception.
 
         This test is checking the case where that partial output does not
@@ -270,26 +269,27 @@ def test_write_behavior_nwb_no_file():
             session_data=None,
             nwb_filepath=''
         )
-    
+
     assert 'TypeError' in str(err.type)
+
 
 def test_write_behavior_nwb_with_file(tmpdir):
     """
         This function is testing the fail condition of the write_behavior_nwb
         method. The main functionality of the write_behavior_nwb method occurs
         in a try block, and in the case that an exception is raised there is
-        functionality in the except block to check if any partial output 
-        exists, and if so rename that file to have a .error suffix before 
+        functionality in the except block to check if any partial output
+        exists, and if so rename that file to have a .error suffix before
         raising the previously mentioned exception.
 
         This test is checking the case where a partial output file does
         exist. In this case we still want to have the original exception
-        returned and avoid a FileNotFound error, but also check that a new 
+        returned and avoid a FileNotFound error, but also check that a new
         file with the .error suffix exists.
 
         To ensure that we enter the except block, a value of None is passed
         for the session_data argument. This will cause a TypeError when
-        write_behavior_nwb tries to subscript this variable. To get the 
+        write_behavior_nwb tries to subscript this variable. To get the
         partial output file to exist, we simply create a Path object and
         call the .touch method.
 
@@ -300,10 +300,10 @@ def test_write_behavior_nwb_with_file(tmpdir):
     # Create the dummy .nwb file
     fake_nwb_fp = Path(tmpdir) / 'fake_nwb.nwb'
     Path(str(fake_nwb_fp) + '.inprogress').touch()
-    
+
     def mock_os_remove(fp):
         pass
-    
+
     # Patch the os.remove method to do nothing
     with mock.patch('os.remove', side_effects=mock_os_remove):
         with pytest.raises(TypeError) as err:

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -270,8 +270,6 @@ def test_write_behavior_nwb_no_file():
             nwb_filepath=''
         )
 
-    assert 'TypeError' in str(err.type)
-
 
 def test_write_behavior_nwb_with_file(tmpdir):
     """
@@ -315,4 +313,3 @@ def test_write_behavior_nwb_with_file(tmpdir):
             # Check that the new .error file exists, and that we
             # still get the expected exception
             assert Path(str(fake_nwb_fp) + '.error').exists()
-            assert 'TypeError' in str(err.type)

--- a/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_behavior_nwb.py
@@ -11,6 +11,8 @@ from allensdk.brain_observatory.behavior.session_apis.data_io import (
 from allensdk.brain_observatory.behavior.stimulus_processing import \
     StimulusTemplate, get_stimulus_templates
 
+from allensdk.brain_observatory.behavior.write_behavior_nwb.__main__ import write_behavior_nwb  # noqa: E501
+
 
 # pytest fixtures:
 # nwbfile: test.brain_observatory.conftest
@@ -238,3 +240,23 @@ def test_add_task_parameters_stim_nan(nwbfile, roundtrip,
                 assert math.isnan(val)
         else:
             assert val == task_parameters_obt[key]
+
+
+def test_write_behavior_nwb():
+    """
+        This function is intended to test the code in the except block
+        of the write_behavior_nwb method. To get there, we simply pass
+        None for the session_data parameter which will cause a TypeError
+        when the try block attempts to subscript it.
+
+        If this function is ever meaningfully changed in implementation,
+        this method of getting to the except block may no longer work and
+        this test will need updating.
+    """
+    with pytest.raises(TypeError) as err:
+        write_behavior_nwb(
+            session_data=None,
+            nwb_filepath=''
+        )
+    
+    assert 'TypeError' in str(err.type)

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -11,8 +11,8 @@ import pytest
 import allensdk.brain_observatory.nwb as nwb
 from allensdk.brain_observatory.behavior.session_apis.data_io import (
     BehaviorOphysNwbApi)
-from allensdk.test.brain_observatory.behavior.test_eye_tracking_processing import \
-    create_refined_eye_tracking_df  # noqa: E501
+from allensdk.test.brain_observatory.behavior.test_eye_tracking_processing import (  # noqa: E501
+    create_refined_eye_tracking_df)
 
 from allensdk.brain_observatory.behavior.write_nwb.__main__ import \
     write_behavior_ophys_nwb  # noqa: E501
@@ -398,7 +398,7 @@ def test_add_events(tmp_path, nwbfile, roundtripper, roundtrip,
 def test_write_behavior_ophys_nwb_no_file():
     """
         This function is testing the fail condition of the
-        write_behavior_ophys_nwb method. The main functionality of the 
+        write_behavior_ophys_nwb method. The main functionality of the
         write_behavior_ophys_nwb method occurs in a try block, and in the
         case that an exception is raised there is functionality in the except
         block to check if any partial output exists, and if so rename that
@@ -421,13 +421,14 @@ def test_write_behavior_ophys_nwb_no_file():
             nwb_filepath='',
             skip_eye_tracking=True
         )
-    
+
     assert 'TypeError' in str(err.type)
+
 
 def test_write_behavior_ophys_nwb_with_file(tmpdir):
     """
         This function is testing the fail condition of the
-        write_behavior_ophys_nwb method. The main functionality of the 
+        write_behavior_ophys_nwb method. The main functionality of the
         write_behavior_ophys_nwb method occurs in a try block, and in the
         case that an exception is raised there is functionality in the except
         block to check if any partial output exists, and if so rename that
@@ -436,12 +437,12 @@ def test_write_behavior_ophys_nwb_with_file(tmpdir):
 
         This test is checking the case where a partial output file does
         exist. In this case we still want to have the original exception
-        returned and avoid a FileNotFound error, but also check that a new 
+        returned and avoid a FileNotFound error, but also check that a new
         file with the .error suffix exists.
 
         To ensure that we enter the except block, a value of None is passed
         for the session_data argument. This will cause a TypeError when
-        write_behavior_ophys_nwb tries to subscript this variable. To get the 
+        write_behavior_ophys_nwb tries to subscript this variable. To get the
         partial output file to exist, we simply create a Path object and
         call the .touch method.
 
@@ -452,10 +453,10 @@ def test_write_behavior_ophys_nwb_with_file(tmpdir):
     # Create the dummy .nwb file
     fake_nwb_fp = Path(tmpdir) / 'fake_nwb.nwb'
     Path(str(fake_nwb_fp) + '.inprogress').touch()
-    
+
     def mock_os_remove(fp):
         pass
-    
+
     # Patch the os.remove method to do nothing
     with mock.patch('os.remove', side_effects=mock_os_remove):
         with pytest.raises(TypeError) as err:
@@ -469,4 +470,3 @@ def test_write_behavior_ophys_nwb_with_file(tmpdir):
             # still get the expected exception
             assert Path(str(fake_nwb_fp) + '.error').exists()
             assert 'TypeError' in str(err.type)
-

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -411,9 +411,9 @@ def test_write_behavior_ophys_nwb_no_file():
 
         To ensure that we enter the except block, a value of None is passed
         for the session_data argument. This will cause a TypeError when
-        write_behavior_ophys_nwb tries to subscript this variable. We are checking
-        that, even though no partial output exists, we still get this
-        TypeError raised.
+        write_behavior_ophys_nwb tries to subscript this variable. We are
+        checking that, even though no partial output exists, we still get
+        this TypeError raised.
     """
     with pytest.raises(TypeError) as err:
         write_behavior_ophys_nwb(

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -422,8 +422,6 @@ def test_write_behavior_ophys_nwb_no_file():
             skip_eye_tracking=True
         )
 
-    assert 'TypeError' in str(err.type)
-
 
 def test_write_behavior_ophys_nwb_with_file(tmpdir):
     """
@@ -469,4 +467,3 @@ def test_write_behavior_ophys_nwb_with_file(tmpdir):
             # Check that the new .error file exists, and that we
             # still get the expected exception
             assert Path(str(fake_nwb_fp) + '.error').exists()
-            assert 'TypeError' in str(err.type)

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -415,7 +415,7 @@ def test_write_behavior_ophys_nwb_no_file():
         checking that, even though no partial output exists, we still get
         this TypeError raised.
     """
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError):
         write_behavior_ophys_nwb(
             session_data=None,
             nwb_filepath='',
@@ -457,7 +457,7 @@ def test_write_behavior_ophys_nwb_with_file(tmpdir):
 
     # Patch the os.remove method to do nothing
     with mock.patch('os.remove', side_effects=mock_os_remove):
-        with pytest.raises(TypeError) as err:
+        with pytest.raises(TypeError):
             write_behavior_ophys_nwb(
                 session_data=None,
                 nwb_filepath=str(fake_nwb_fp),

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -12,6 +12,8 @@ from allensdk.brain_observatory.behavior.session_apis.data_io import (
 from allensdk.test.brain_observatory.behavior.test_eye_tracking_processing import \
     create_refined_eye_tracking_df  # noqa: E501
 
+from allensdk.brain_observatory.behavior.write_nwb.__main__ import write_behavior_ophys_nwb  # noqa: E501
+
 
 @pytest.fixture
 def rig_geometry():
@@ -388,3 +390,24 @@ def test_add_events(tmp_path, nwbfile, roundtripper, roundtrip,
     obtained = obt.get_events()
 
     pd.testing.assert_frame_equal(obtained, events, check_like=True)
+
+
+def test_write_behavior_ophys_nwb():
+    """
+        This function is intended to test the code in the except block
+        of the write_behavior_ophys_nwb method. To get there, we simply pass
+        None for the session_data parameter which will cause a TypeError
+        when the try block attempts to subscript it.
+
+        If this function is ever meaningfully changed in implementation,
+        this method of getting to the except block may no longer work and
+        this test will need updating.
+    """
+    with pytest.raises(TypeError) as err:
+        write_behavior_ophys_nwb(
+            session_data=None,
+            nwb_filepath='',
+            skip_eye_tracking=True
+        )
+    
+    assert 'TypeError' in str(err.type)

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -1,4 +1,6 @@
 import math
+import mock
+from pathlib import Path
 import warnings
 
 import numpy as np
@@ -12,7 +14,8 @@ from allensdk.brain_observatory.behavior.session_apis.data_io import (
 from allensdk.test.brain_observatory.behavior.test_eye_tracking_processing import \
     create_refined_eye_tracking_df  # noqa: E501
 
-from allensdk.brain_observatory.behavior.write_nwb.__main__ import write_behavior_ophys_nwb  # noqa: E501
+from allensdk.brain_observatory.behavior.write_nwb.__main__ import \
+    write_behavior_ophys_nwb  # noqa: E501
 
 
 @pytest.fixture
@@ -392,16 +395,25 @@ def test_add_events(tmp_path, nwbfile, roundtripper, roundtrip,
     pd.testing.assert_frame_equal(obtained, events, check_like=True)
 
 
-def test_write_behavior_ophys_nwb():
+def test_write_behavior_ophys_nwb_no_file():
     """
-        This function is intended to test the code in the except block
-        of the write_behavior_ophys_nwb method. To get there, we simply pass
-        None for the session_data parameter which will cause a TypeError
-        when the try block attempts to subscript it.
+        This function is testing the fail condition of the
+        write_behavior_ophys_nwb method. The main functionality of the 
+        write_behavior_ophys_nwb method occurs in a try block, and in the
+        case that an exception is raised there is functionality in the except
+        block to check if any partial output exists, and if so rename that
+        file to have a .error suffix before raising the previously
+        mentioned exception.
 
-        If this function is ever meaningfully changed in implementation,
-        this method of getting to the except block may no longer work and
-        this test will need updating.
+        This test is checking the case where that partial output does not
+        exist. In this case we still want to have the original exception
+        returned and avoid a FileNotFound error.
+
+        To ensure that we enter the except block, a value of None is passed
+        for the session_data argument. This will cause a TypeError when
+        write_behavior_ophys_nwb tries to subscript this variable. We are checking
+        that, even though no partial output exists, we still get this
+        TypeError raised.
     """
     with pytest.raises(TypeError) as err:
         write_behavior_ophys_nwb(
@@ -411,3 +423,50 @@ def test_write_behavior_ophys_nwb():
         )
     
     assert 'TypeError' in str(err.type)
+
+def test_write_behavior_ophys_nwb_with_file(tmpdir):
+    """
+        This function is testing the fail condition of the
+        write_behavior_ophys_nwb method. The main functionality of the 
+        write_behavior_ophys_nwb method occurs in a try block, and in the
+        case that an exception is raised there is functionality in the except
+        block to check if any partial output exists, and if so rename that
+        file to have a .error suffix before raising the previously
+        mentioned exception.
+
+        This test is checking the case where a partial output file does
+        exist. In this case we still want to have the original exception
+        returned and avoid a FileNotFound error, but also check that a new 
+        file with the .error suffix exists.
+
+        To ensure that we enter the except block, a value of None is passed
+        for the session_data argument. This will cause a TypeError when
+        write_behavior_ophys_nwb tries to subscript this variable. To get the 
+        partial output file to exist, we simply create a Path object and
+        call the .touch method.
+
+        This test also patched the os.remove method to do nothing. This is
+        necessary because the write_behavior_nwb method checks for any
+        existing output and removes it before running.
+    """
+    # Create the dummy .nwb file
+    fake_nwb_fp = Path(tmpdir) / 'fake_nwb.nwb'
+    Path(str(fake_nwb_fp) + '.inprogress').touch()
+    
+    def mock_os_remove(fp):
+        pass
+    
+    # Patch the os.remove method to do nothing
+    with mock.patch('os.remove', side_effects=mock_os_remove):
+        with pytest.raises(TypeError) as err:
+            write_behavior_ophys_nwb(
+                session_data=None,
+                nwb_filepath=str(fake_nwb_fp),
+                skip_eye_tracking=True
+            )
+
+            # Check that the new .error file exists, and that we
+            # still get the expected exception
+            assert Path(str(fake_nwb_fp) + '.error').exists()
+            assert 'TypeError' in str(err.type)
+


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
This was a bug that would occur inside the `except` block of both of the `write_*_nwb` methods. They try to rename a file to have a `.error` suffix before raising the error that caused the `except` to trigger. However if the file didn't exist then this would raise a totally different error.

# Addresses:
Addresses issue [#1892](https://github.com/AllenInstitute/AllenSDK/issues/1892)

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
I wrapped that one line of code into an `if` statement just checking that the file exists before renaming it. I also added one test for each of these methods where I pass it  bad input to cause a `TypeError` to raise, to the methods will enter the `except` block, and raise the proper error (in this case, a `TypeError`, as opposed to the `FileNotFound` it would raise before).



# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests
