### PR TITLE
Prevent warnings when loading sync files

### DIFF
--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -20,6 +20,7 @@ from typing import Union, Sequence, Optional
 import h5py as h5
 import numpy as np
 
+import warnings
 import logging
 logger = logging.getLogger(__name__)
 
@@ -115,11 +116,11 @@ class Dataset(object):
             if deprecated_keys:
                 warnings.warn((f"The loaded sync file contains the "
                                f"following deprecated line label keys: "
-                               f"{deprecated_keys}. Consider updating the sync "
-                               f"file line labels."), stacklevel=2)
+                               f"{deprecated_keys}. Consider updating the "
+                               f"sync file line labels."), stacklevel=2)
         else:
-            warnings.warn((f"The loaded sync file has no line labels and may "
-                           f"not be valid."), stacklevel=2)
+            warnings.warn(("The loaded sync file has no line labels and may "
+                           "not be valid."), stacklevel=2)
 
     def _process_times(self):
         """

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -90,12 +90,18 @@ class Dataset(object):
     FRAME_KEYS = ('frames', 'stim_vsync')
     PHOTODIODE_KEYS = ('photodiode', 'stim_photodiode')
     OPTOGENETIC_STIMULATION_KEYS = ("LED_sync", "opto_trial")
-    EYE_TRACKING_KEYS = ("eye_frame_received",  # Expected eye tracking line label after 3/27/2020
-                         "cam2_exposure",  # clocks eye tracking frame pulses (port 0, line 9)
-                         "eyetracking",  # previous line label for eye tracking (prior to ~ Oct. 2018)
-                         "eye_tracking")  # An undocumented, but possible eye tracking line label
-    BEHAVIOR_TRACKING_KEYS = ("beh_frame_received",  # Expected behavior line label after 3/27/2020
-                              "cam1_exposure",  # clocks behavior tracking frame pulses (port 0, line 8)
+    EYE_TRACKING_KEYS = ("eye_frame_received",  # Expected eye tracking
+                                                # line label after 3/27/2020
+                         # clocks eye tracking frame pulses (port 0, line 9)
+                         "cam2_exposure",
+                         # previous line label for eye tracking
+                         # (prior to ~ Oct. 2018)
+                         "eyetracking",
+                         "eye_tracking")  # An undocumented, but possible eye tracking line label  # NOQA E114
+    BEHAVIOR_TRACKING_KEYS = ("beh_frame_received",  # Expected behavior line label after 3/27/2020  # NOQA E127
+                                                    # clocks behavior tracking frame # NOQA E127
+                                                    # pulses (port 0, line 8)
+                              "cam1_exposure",
                               "behavior_monitoring")
 
     DEPRECATED_KEYS = {"cam2_exposure",
@@ -106,10 +112,12 @@ class Dataset(object):
 
     def __init__(self, path, sync_line_label_deprecation_warning=False):
         '''
-        sync_line_label_deprecation_warning: (bool) if True, warns about deprecated lines in sync file
+        sync_line_label_deprecation_warning: (bool) if True,
+        warns about deprecated lines in sync file
         '''
         self.dfile = self.load(path)
-        self._check_line_labels(sync_line_label_deprecation_warning=sync_line_label_deprecation_warning)
+        self._check_line_labels(
+            sync_line_label_deprecation_warning=sync_line_label_deprecation_warning)  # NOQA E501
 
     def _check_line_labels(self, sync_line_label_deprecation_warning):
         if hasattr(self, "line_labels"):
@@ -117,10 +125,10 @@ class Dataset(object):
             if deprecated_keys and sync_line_label_deprecation_warning:
                 warnings.warn((f"The loaded sync file contains the "
                                f"following deprecated line label keys: "
-                               f"{deprecated_keys}. Consider updating the sync "
+                               f"{deprecated_keys}. Consider updating the sync "  # NOQA E501
                                f"file line labels."), stacklevel=2)
         else:
-            warnings.warn((f"The loaded sync file has no line labels and may "
+            warnings.warn((f"The loaded sync file has no line labels and may "  # NOQA F541
                            f"not be valid."), stacklevel=2)
 
     def _process_times(self):
@@ -149,7 +157,8 @@ class Dataset(object):
             Path to hdf5 file.
 
         """
-        self.dfile = h5.File(path, 'r')  # MG edit 3/15 removed 'r' because some sync files were unable to load
+        self.dfile = h5.File(
+            path, 'r')  # MG edit 3/15 removed 'r' because some sync files were unable to load  # NOQA E501
         self.meta_data = eval(self.dfile['meta'][()])
         self.line_labels = self.meta_data['line_labels']
         self.times = self._process_times()
@@ -323,34 +332,34 @@ class Dataset(object):
         return self.get_all_times(units)[np.where(changes == 1)]
 
     def get_edges(
-        self, 
-        kind: str, 
-        keys: Union[str, Sequence[str]], 
-        units: str = "seconds", 
+        self,
+        kind: str,
+        keys: Union[str, Sequence[str]],
+        units: str = "seconds",
         permissive: bool = False
     ) -> Optional[np.ndarray]:
         """ Utility function for extracting edge times from a line
 
         Parameters
         ----------
-        kind : One of "rising", "falling", or "all". Should this method return 
-            timestamps for rising, falling or both edges on the appropriate 
+        kind : One of "rising", "falling", or "all". Should this method return
+            timestamps for rising, falling or both edges on the appropriate
             line
-        keys : These will be checked in sequence. Timestamps will be returned 
+        keys : These will be checked in sequence. Timestamps will be returned
             for the first which is present in the line labels
-        units : one of "seconds", "samples", or "indices". The returned 
+        units : one of "seconds", "samples", or "indices". The returned
             "time"stamps will be given in these units.
         raise_missing : If True and no matching line is found, a KeyError will
             be raised
 
         Returns
         -------
-        An array of edge times. If raise_missing is False and none of the keys 
+        An array of edge times. If raise_missing is False and none of the keys
             were found, returns None.
 
         Raises
         ------
-        KeyError : none of the provided keys were found among this dataset's 
+        KeyError : none of the provided keys were found among this dataset's
             line labels
 
         """
@@ -417,9 +426,9 @@ class Dataset(object):
 
         """
         source_edges = getattr(self,
-                               "get_{}_edges".format(source_edge.lower()))(source.lower(), units="samples")
+                               "get_{}_edges".format(source_edge.lower()))(source.lower(), units="samples")  # NOQA E501
         target_edges = getattr(self,
-                               "get_{}_edges".format(target_edge.lower()))(target.lower(), units="samples")
+                               "get_{}_edges".format(target_edge.lower()))(target.lower(), units="samples")  # NOQA E501
         indices = np.searchsorted(target_edges, source_edges, side="right")
         if direction.lower() == "previous":
             indices[np.where(indices != 0)] -= 1
@@ -432,7 +441,8 @@ class Dataset(object):
         elif units in ['sec', 'seconds', 'second']:
             return target_edges[indices] / self.sample_freq
         else:
-            raise KeyError("Invalid units.  Try 'seconds', 'samples' or 'indices'")
+            raise KeyError(
+                "Invalid units.  Try 'seconds', 'samples' or 'indices'")
 
     def get_analog_channel(self,
                            channel,
@@ -457,8 +467,10 @@ class Dataset(object):
 
         """
         if isinstance(channel, str):
-            channel_index = self.analog_meta_data['analog_labels'].index(channel)
-            channel = self.analog_meta_data['analog_channels'].index(channel_index)
+            channel_index = self.analog_meta_data['analog_labels'].index(
+                channel)
+            channel = self.analog_meta_data['analog_channels'].index(
+                channel_index)
 
         if "analog_data" in self.dfile.keys():
             dset = self.dfile['analog_data']

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -104,14 +104,17 @@ class Dataset(object):
                        "cam1_exposure",
                        "behavior_monitoring"}
 
-    def __init__(self, path):
+    def __init__(self, path, sync_line_label_deprecation_warning=False):
+        '''
+        sync_line_label_deprecation_warning: (bool) if True, warns about deprecated lines in sync file
+        '''
         self.dfile = self.load(path)
-        self._check_line_labels()
+        self._check_line_labels(sync_line_label_deprecation_warning=sync_line_label_deprecation_warning)
 
-    def _check_line_labels(self):
+    def _check_line_labels(self, sync_line_label_deprecation_warning):
         if hasattr(self, "line_labels"):
             deprecated_keys = set(self.line_labels) & self.DEPRECATED_KEYS
-            if deprecated_keys:
+            if deprecated_keys and sync_line_label_deprecation_warning:
                 warnings.warn((f"The loaded sync file contains the "
                                f"following deprecated line label keys: "
                                f"{deprecated_keys}. Consider updating the sync "

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -20,7 +20,6 @@ from typing import Union, Sequence, Optional
 import h5py as h5
 import numpy as np
 
-import warnings
 import logging
 logger = logging.getLogger(__name__)
 

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -103,14 +103,23 @@ class Dataset(object):
                               "cam1_exposure",
                               "behavior_monitoring")
 
-    DEPRECATED_KEYS = {"cam2_exposure",
-                       "eyetracking",
-                       "eye_tracking",
-                       "cam1_exposure",
-                       "behavior_monitoring"}
+    DEPRECATED_KEYS = {}
 
     def __init__(self, path):
         self.dfile = self.load(path)
+        self._check_line_labels()
+
+    def _check_line_labels(self):
+        if hasattr(self, "line_labels"):
+            deprecated_keys = set(self.line_labels) & self.DEPRECATED_KEYS
+            if deprecated_keys:
+                warnings.warn((f"The loaded sync file contains the "
+                               f"following deprecated line label keys: "
+                               f"{deprecated_keys}. Consider updating the sync "
+                               f"file line labels."), stacklevel=2)
+        else:
+            warnings.warn((f"The loaded sync file has no line labels and may "
+                           f"not be valid."), stacklevel=2)
 
     def _process_times(self):
         """

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -86,6 +86,12 @@ class Dataset(object):
     ...     logger.info(dset.meta_data)
     ...     dset.stats()
 
+    The sync file documentation from MPE can be found at
+    sharepoint > Instrumentation > Shared Documents > Sync_line_labels_discussion_2020-01-27-.xlsx  # NOQA E501
+    Direct link:
+    https://alleninstitute.sharepoint.com/:x:/s/Instrumentation/ES2bi1xJ3E9NupX-zQeXTlYBS2mVVySycfbCQhsD_jPMUw?e=Z9jCwH
+
+
     """
     FRAME_KEYS = ('frames', 'stim_vsync')
     PHOTODIODE_KEYS = ('photodiode', 'stim_photodiode')

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -110,26 +110,8 @@ class Dataset(object):
                        "cam1_exposure",
                        "behavior_monitoring"}
 
-    def __init__(self, path, sync_line_label_deprecation_warning=False):
-        '''
-        sync_line_label_deprecation_warning: (bool) if True,
-        warns about deprecated lines in sync file
-        '''
+    def __init__(self, path):
         self.dfile = self.load(path)
-        self._check_line_labels(
-            sync_line_label_deprecation_warning=sync_line_label_deprecation_warning)  # NOQA E501
-
-    def _check_line_labels(self, sync_line_label_deprecation_warning):
-        if hasattr(self, "line_labels"):
-            deprecated_keys = set(self.line_labels) & self.DEPRECATED_KEYS
-            if deprecated_keys and sync_line_label_deprecation_warning:
-                warnings.warn((f"The loaded sync file contains the "
-                               f"following deprecated line label keys: "
-                               f"{deprecated_keys}. Consider updating the sync "  # NOQA E501
-                               f"file line labels."), stacklevel=2)
-        else:
-            warnings.warn((f"The loaded sync file has no line labels and may "  # NOQA F541
-                           f"not be valid."), stacklevel=2)
 
     def _process_times(self):
         """

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -26,7 +26,8 @@ def get_keys(sync_dset: Dataset, invalid_sync_line_warning=False) -> dict:
     sync dataset line labels.
     Args:
         sync_dset: The sync dataset to search for keys within
-        invalid_sync_line_warning: (bool) if True, prints warnings about keys in sync file
+        invalid_sync_line_warning: (bool) if True,
+                prints warnings about keys in sync file
 
     Returns:
         key_dict: dictionary of key value pairs for finding data in the

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -19,15 +19,13 @@ LONG_STIM_THRESHOLD = 0.2     # seconds
 MAX_MONITOR_DELAY = 0.07     # seconds
 
 
-def get_keys(sync_dset: Dataset, invalid_sync_line_warning=False) -> dict:
+def get_keys(sync_dset: Dataset) -> dict:
     """
     Gets the correct keys for the sync file by searching the sync file
     line labels. Removes key from the dictionary if it is not in the
     sync dataset line labels.
     Args:
         sync_dset: The sync dataset to search for keys within
-        invalid_sync_line_warning: (bool) if True,
-                prints warnings about keys in sync file
 
     Returns:
         key_dict: dictionary of key value pairs for finding data in the
@@ -45,19 +43,26 @@ def get_keys(sync_dset: Dataset, invalid_sync_line_warning=False) -> dict:
                            "eye_frame_received"],
             "behavior_camera": ["cam1_exposure", "behavior_monitoring",
                                 "beh_frame_received"],
-            "acquiring": ["2p_acquiring"],
+            "acquiring": ["2p_acquiring", "acq_trigger"],
             "lick_sensor": ["lick_1", "lick_sensor"]
             }
     label_set = set(sync_dset.line_labels)
     remove_keys = []
     for key, value in key_dict.items():
+        # for each key in the above `key_dict`, this loop
+        # checks to see if there is a corresponing value in
+        # the set of line labels present in the sync file (`label_set`)
+        # If not, the key is added to the `remove_keys` list
         value_set = set(value)
         diff = value_set.intersection(label_set)
         if len(diff) == 1:
             key_dict[key] = diff.pop()
         else:
             remove_keys.append(key)
-    if len(remove_keys) > 0 and invalid_sync_line_warning:
+
+    # the contents of the `remove_keys` list is printed to the console
+    # as a user warning
+    if len(remove_keys) > 0:
         logging.warning("Could not find valid lines for the following data "
                         "sources")
         for key in remove_keys:

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -19,13 +19,14 @@ LONG_STIM_THRESHOLD = 0.2     # seconds
 MAX_MONITOR_DELAY = 0.07     # seconds
 
 
-def get_keys(sync_dset: Dataset) -> dict:
+def get_keys(sync_dset: Dataset, invalid_sync_line_warning=False) -> dict:
     """
     Gets the correct keys for the sync file by searching the sync file
     line labels. Removes key from the dictionary if it is not in the
     sync dataset line labels.
     Args:
         sync_dset: The sync dataset to search for keys within
+        invalid_sync_line_warning: (bool) if True, prints warnings about keys in sync file
 
     Returns:
         key_dict: dictionary of key value pairs for finding data in the
@@ -55,7 +56,7 @@ def get_keys(sync_dset: Dataset) -> dict:
             key_dict[key] = diff.pop()
         else:
             remove_keys.append(key)
-    if len(remove_keys) > 0:
+    if len(remove_keys) > 0 and invalid_sync_line_warning:
         logging.warning("Could not find valid lines for the following data "
                         "sources")
         for key in remove_keys:


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
When loading sessions using the `BehaviorOphysExperiment` class, there are two warnings presented to users relating to the contents of the sync file. The first looks like this:

> UserWarning: The loaded sync file contains the following deprecated line label keys: {'cam2_exposure', 'cam1_exposure'}. Consider updating the sync file line labels.

The second looks like this:

> WARNING:root:Could not find valid lines for the following data sources
> WARNING:root:acquiring (valid line label(s) = ['2p_acquiring']

In both cases, users of the data have no control over the line labels, and these deprecated and/or invalid line labels are so commonly used in the data that these warnings are thrown for nearly every session. When loading data in a loop, the console window will quickly fill with hundreds of these warnings printed repeatedly.

# Addresses:
This addresses issue #1502, which has been open since April 16, 2020. @alexpiet has also commented on this issue on multiple occasions and re-iterated the need to suppress these warnings.

# Type of Fix:
<!--Chose One-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
In `time_sync.py` I added `acq_trigger` to the list of possible keys corresponding to 'acquiring'. This avoids the first warning above

In `sync_dataset.py` I removed the logic that printed warnings related to deprecated keys.

# Changes:
In `time_sync.py` I added `acq_trigger` to the list of possible keys corresponding to 'acquiring'. This avoids the first warning above

In `sync_dataset.py` I removed the logic that printed warnings related to deprecated keys.

I also made a number of syntax changes to `sync_dataset.py` to get it past the linter. Most of these changes had nothing to do with this PR, but I'm assuming that this module had not previously been subject to Flake8 tests.

# Validation:
I ran the following code block, which previously resulted in the two warnings described above:

```
from allensdk.brain_observatory.behavior.behavior_ophys_experiment import BehaviorOphysExperiment
ophys_experiment_id = 957759564
dataset = BehaviorOphysExperiment.from_lims(ophys_experiment_id)
metadata = dataset.metadata
```
After running the above code block, the console window was free of warnings. I did a small dance to celebrate.

# Checklist
- [X] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [X] I have performed a self review of my own code
- [X] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [X] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [X] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
Given the discussion below, I changed my strategy from simply suppressing these warnings to 1) change the underlying code to avoid the warning and 2) remove the warning altogether.
