### PR TITLE
Ticket 2114/remember/dataset/version

### DIFF
--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -560,10 +560,7 @@ class CloudCacheBase(ABC):
                                    "exists, but is not a file;\n"
                                    "unsure how to proceed")
 
-            full_path = file_attributes.local_path.resolve()
-            test_checksum = file_hash_from_path(full_path)
-            if test_checksum == file_attributes.file_hash:
-                file_exists = True
+            file_exists = True
 
         if not file_exists:
             file_exists = self._check_for_identical_copy(file_attributes)
@@ -1066,6 +1063,13 @@ class S3CloudCache(CloudCacheBase):
                         out_file.write(chunk)
                         pbar.update(len(chunk))
 
+            # Verify the hash of the downloaded file
+            full_path = file_attributes.local_path.resolve()
+            test_checksum = file_hash_from_path(full_path)
+            if test_checksum != file_attributes.file_hash:
+                file_attributes.local_path.exists()
+                file_attributes.local_path.unlink()
+
             n_iter += 1
             if n_iter > max_iter:
                 pbar.close()
@@ -1074,6 +1078,7 @@ class S3CloudCache(CloudCacheBase):
                                    "In {max_iter} iterations")
         if pbar is not None:
             pbar.close()
+
         return None
 
 

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -517,12 +517,6 @@ class CloudCacheBase(ABC):
         if matched_path is None:
             return False
 
-        # double check that locally downloaded file still has
-        # the expected hash
-        candidate_hash = file_hash_from_path(matched_path)
-        if candidate_hash != file_attributes.file_hash:
-            return False
-
         local_parent = file_attributes.local_path.parent.resolve()
         if not local_parent.exists():
             os.makedirs(local_parent)

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -70,11 +70,16 @@ class CloudCacheBase(ABC):
         # was emitted
         self._manifest_last_warned_on = None
 
+        c_path = pathlib.Path(self._cache_dir)
+
+        # self._manifest_last_used contains the name of the manifest
+        # last loaded from this cache dir (if applicable)
+        self._manifest_last_used = c_path / '_manifest_last_used.txt'
+
         # self._downloaded_data_path is where we will keep a JSONized
         # dict mapping paths to downloaded files to their file_hashes;
         # this will be used when determining if a downloaded file
         # can instead be a symlink
-        c_path = pathlib.Path(self._cache_dir)
         self._downloaded_data_path = c_path / '_downloaded_data.json'
 
         # if the local manifest is missing but there are
@@ -124,7 +129,8 @@ class CloudCacheBase(ABC):
         for file_name in file_iterator:
             if file_name.is_file():
                 if 'json' not in file_name.name:
-                    files_to_hash.add(file_name.resolve())
+                    if file_name != self._manifest_last_used:
+                        files_to_hash.add(file_name.resolve())
 
         with tqdm.tqdm(files_to_hash,
                        total=len(files_to_hash),
@@ -225,6 +231,45 @@ class CloudCacheBase(ABC):
         if len(file_list) == 0:
             return ''
         return self._find_latest_file(self.list_all_downloaded_manifests())
+
+    def load_last_manifest(self):
+        """
+        If this Cache was used previously, load the last manifest
+        used in this cache. If this cache has never been used, load
+        the latest manifest.
+        """
+        if not self._manifest_last_used.exists():
+            self.load_latest_manifest()
+            return None
+
+        with open(self._manifest_last_used, 'r') as in_file:
+            to_load = in_file.read()
+
+        latest = self.latest_manifest_file
+
+        if to_load not in self.manifest_file_names:
+            msg = 'The manifest version recorded as last used '
+            msg += f'for this cache -- {to_load}-- '
+            msg += 'is not a valid manifest for this dataset. '
+            msg += f'Loading latest version -- {latest} -- '
+            msg += 'instead.'
+            warnings.warn(msg, UserWarning)
+            self.load_latest_manifest()
+            return None
+
+        if latest != to_load:
+            self._manifest_last_warned_on = self.latest_manifest_file
+            msg = f"You are loading {to_load}. A more up to date "
+            msg += f"version of the dataset -- {latest} -- exists "
+            msg += "online. To see the changes between the two "
+            msg += "versions of the dataset, run\n"
+            msg += f"{self.ui}.compare_manifests('{to_load}',"
+            msg += f" '{latest}')\n"
+            msg += "To load another version of the dataset, run\n"
+            msg += f"{self.ui}.load_manifest('{latest}')"
+            warnings.warn(msg, OutdatedManifestWarning)
+        self.load_manifest(to_load)
+        return None
 
     def load_latest_manifest(self):
         latest_downloaded = self.latest_downloaded_manifest_file
@@ -374,6 +419,10 @@ class CloudCacheBase(ABC):
                 cache_dir=self._cache_dir,
                 json_input=f
             )
+
+        with open(self._manifest_last_used, 'w') as out_file:
+            out_file.write(manifest_name)
+
         return local_manifest
 
     def load_manifest(self, manifest_name: str):

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -155,7 +155,6 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
                              bucket_name,
                              project_name,
                              ui_class_name=ui_class_name)
-        cache.load_latest_manifest()
         return BehaviorProjectCloudApi(cache)
 
     @staticmethod
@@ -185,7 +184,6 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         cache = LocalCache(cache_dir,
                            project_name,
                            ui_class_name=ui_class_name)
-        cache.load_latest_manifest()
         return BehaviorProjectCloudApi(cache, local=True)
 
     def get_behavior_session(

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -90,7 +90,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
             (default: None)
         """
         if manifest_name is None:
-            self.cache.load_latest_manifest()
+            self.cache.load_last_manifest()
         else:
             self.cache.load_manifest(manifest_name)
 

--- a/allensdk/test/api/cloud_cache/test_cache.py
+++ b/allensdk/test/api/cloud_cache/test_cache.py
@@ -164,13 +164,6 @@ def test_file_exists(tmpdir):
                                          test_file_path)
     assert cache._file_exists(good_attribute)
 
-    # test when checksum is wrong
-    bad_attribute = CacheFileAttributes('http://silly.url.com',
-                                        '12345',
-                                        'probably_not_the_checksum',
-                                        test_file_path)
-    assert not cache._file_exists(bad_attribute)
-
     # test when file path is wrong
     bad_path = pathlib.Path('definitely/not/a/file.txt')
     bad_attribute = CacheFileAttributes('http://silly.url.com',
@@ -333,7 +326,7 @@ def test_download_file_multiple_versions(tmpdir):
 def test_re_download_file(tmpdir):
     """
     Test that S3CloudCache._download_file will re-download a file
-    when it has been altered locally
+    when it has been removed from the local system
     """
 
     hasher = hashlib.blake2b()
@@ -380,21 +373,6 @@ def test_re_download_file(tmpdir):
     # now, remove the file, and see if it gets re-downloaded
     expected_path.unlink()
     assert not expected_path.exists()
-
-    cache._download_file(good_attributes)
-    assert expected_path.exists()
-    hasher = hashlib.blake2b()
-    with open(expected_path, 'rb') as in_file:
-        hasher.update(in_file.read())
-    assert hasher.hexdigest() == true_checksum
-
-    # now, alter the file, and see if it gets re-downloaded
-    with open(expected_path, 'wb') as out_file:
-        out_file.write(b'778899')
-    hasher = hashlib.blake2b()
-    with open(expected_path, 'rb') as in_file:
-        hasher.update(in_file.read())
-    assert hasher.hexdigest() != true_checksum
 
     cache._download_file(good_attributes)
     assert expected_path.exists()

--- a/allensdk/test/api/cloud_cache/test_cache.py
+++ b/allensdk/test/api/cloud_cache/test_cache.py
@@ -761,15 +761,12 @@ def test_load_last_manifest(tmpdir, example_datasets_with_metadata):
     # check that load_last_manifest on an old cache emits the
     # expected warning and loads the correct manifest
     cache = S3CloudCache(cache_dir, bucket_name, 'project-x')
-    with pytest.warns(OutdatedManifestWarning) as warnings:
+    expected = 'A more up to date version of the '
+    expected += 'dataset -- project-x_manifest_v15.0.0.json '
+    expected += '-- exists online'
+    with pytest.warns(OutdatedManifestWarning,
+                      match=expected) as warnings:
         cache.load_last_manifest()
-    for w in warnings.list:
-        if w._category_name == 'OutdatedManifestWarning':
-            msg = str(w.message)
-            expected = 'A more up to date version of the '
-            expected += 'dataset -- project-x_manifest_v15.0.0.json '
-            expected += '-- exists online'
-            assert expected in msg
 
     assert cache.current_manifest == 'project-x_manifest_v7.0.0.json'
     cache.load_manifest('project-x_manifest_v4.0.0.json')
@@ -778,15 +775,12 @@ def test_load_last_manifest(tmpdir, example_datasets_with_metadata):
     # repeat the above test, making sure the correct manifest is
     # loaded again
     cache = S3CloudCache(cache_dir, bucket_name, 'project-x')
-    with pytest.warns(OutdatedManifestWarning) as warnings:
+    expected = 'A more up to date version of the '
+    expected += 'dataset -- project-x_manifest_v15.0.0.json '
+    expected += '-- exists online'
+    with pytest.warns(OutdatedManifestWarning,
+                      match=expected) as warnings:
         cache.load_last_manifest()
-    for w in warnings.list:
-        if w._category_name == 'OutdatedManifestWarning':
-            msg = str(w.message)
-            expected = 'A more up to date version of the '
-            expected += 'dataset -- project-x_manifest_v15.0.0.json '
-            expected += '-- exists online'
-            assert expected in msg
 
     assert cache.current_manifest == 'project-x_manifest_v4.0.0.json'
 

--- a/allensdk/test/api/cloud_cache/test_smart_download.py
+++ b/allensdk/test/api/cloud_cache/test_smart_download.py
@@ -126,14 +126,13 @@ def test_on_corrupted_files(tmpdir, example_datasets):
     hasher.update(b'4567890')
     true_hash = hasher.hexdigest()
 
-    # Check that, when a file on disk gets corrupted,
+    # Check that, when a file on disk gets removed,
     # all of the symlinks that point back to that file
     # get marked as `not exists`
 
     cache.load_manifest('project-x_manifest_v1.0.0.json')
     attr = cache.data_path('2')
-    with open(attr['local_path'], 'wb') as out_file:
-        out_file.write(b'xxxxxx')
+    attr['local_path'].unlink()
 
     attr = cache.data_path('2')
     assert not attr['exists']
@@ -353,9 +352,8 @@ def test_corrupted_download_manifest(tmpdir, example_datasets):
     # CloudCache won't consult _downloaded_data_path
     assert attr['exists']
 
-    # now corrupt one of the data files
-    with open(attr['local_path'], 'wb') as out_file:
-        out_file.write(b'xxxxx')
+    # now remove one of the data files
+    attr['local_path'].unlink()
 
     # now that the file is corrupted, 'exists' is False
     attr = cache.data_path('2')

--- a/allensdk/test/api/cloud_cache/test_smart_download.py
+++ b/allensdk/test/api/cloud_cache/test_smart_download.py
@@ -5,7 +5,7 @@ import pathlib
 from moto import mock_s3
 from .utils import create_bucket
 from allensdk.api.cloud_cache.cloud_cache import MissingLocalManifestWarning
-from allensdk.api.cloud_cache.cloud_cache import S3CloudCache
+from allensdk.api.cloud_cache.cloud_cache import S3CloudCache, LocalCache
 from allensdk.api.cloud_cache.file_attributes import CacheFileAttributes  # noqa: E501
 
 
@@ -476,3 +476,48 @@ def test_reconstruction_of_local_manifest(tmpdir):
     dummy.load_manifest('project-x_manifest_v3.0.0.json')
     with pytest.raises(RuntimeError):
         dummy.download_data('1')
+
+
+@mock_s3
+def test_local_cache_symlink(tmpdir, example_datasets):
+    """
+    Test that a LocalCache is smart enough to construct
+    a symlink where appropriate
+    """
+    test_bucket_name = 'local_cache_test_bucket'
+    create_bucket(test_bucket_name,
+                  example_datasets)
+
+    cache_dir = pathlib.Path(tmpdir) / 'cache'
+
+    # create an online cache and download some data
+    online_cache = S3CloudCache(cache_dir, test_bucket_name, 'project-x')
+    online_cache.load_manifest('project-x_manifest_v1.0.0.json')
+    p0 = online_cache.download_data('1')
+    online_cache.load_manifest('project-x_manifest_v3.0.0.json')
+
+    # path to file we intend to download
+    # (just making sure it wasn't accidentally created early
+    # by the online cache)
+    shld_be = cache_dir / 'project-x-3.0.0/data/f1.txt'
+    assert not shld_be.exists()
+
+    del online_cache
+
+    # create a local cache pointing to the same cache directory
+    # an try to access a data file that, while not downloaded,
+    # is identical to a file that has been downloaded
+    local_cache = LocalCache(cache_dir, test_bucket_name, 'project-x')
+    local_cache.load_manifest('project-x_manifest_v3.0.0.json')
+    attr = local_cache.data_path('1')
+    assert attr['exists']
+    assert attr['local_path'].absolute() == shld_be.absolute()
+    assert attr['local_path'].is_symlink()
+    assert attr['local_path'].resolve() == p0.resolve()
+
+    # test that LocalCache does not have access to data that
+    # has not been downloaded
+    attr = local_cache.data_path('2')
+    assert not attr['exists']
+    with pytest.raises(NotImplementedError):
+        local_cache.download_data('2')

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_cloud_api.py
@@ -51,7 +51,7 @@ class MockCache():
             'exists': True
         }
 
-    def load_latest_manifest(self):
+    def load_last_manifest(self):
         return None
 
 


### PR DESCRIPTION
This addresses ticket #2114 

Here is the output from running the validation steps on my local machine
```
>>> from allensdk.brain_observatory.behavior.behavior_project_cache.behavior_project_cache import VisualBehaviorOphysProjectCache as vbopc
>>> cache_dir = '/Users/scott.daniel/Pika/garage/test_cache_210506'
>>> cache = vbopc.from_s3_cache(cache_dir=cache_dir)
ophys_session_table.csv: 100%|███████████████████████████████████████████████████████| 165k/165k [00:00<00:00, 322kMB/s]
behavior_session_table.csv: 100%|████████████████████████████████████████████████████| 885k/885k [00:02<00:00, 427kMB/s]
ophys_experiment_table.csv: 100%|████████████████████████████████████████████████████| 336k/336k [00:00<00:00, 391kMB/s]
>>> cache.current_manifest()
'visual-behavior-ophys_project_manifest_v0.2.0.json'
>>> cache.load_manifest('visual-behavior-ophys_project_manifest_v0.1.0.json')
/Users/scott.daniel/miniconda3/envs/allensdk_37/lib/python3.7/site-packages/allensdk-2.11.0-py3.7.egg/allensdk/api/cloud_cache/cloud_cache.py:171: OutdatedManifestWarning: 

The manifest file you are loading is not the most up to date manifest file available for this dataset. The most up to data manifest file available for this dataset is 

visual-behavior-ophys_project_manifest_v0.2.0.json

To see the differences between these manifests,run

VisualBehaviorOphysProjectCache.compare_manifests('visual-behavior-ophys_project_manifest_v0.1.0.json', 'visual-behavior-ophys_project_manifest_v0.2.0.json')

To see all of the manifest files currently downloaded onto your local system, run

self.list_all_downloaded_manifests()

If you just want to load the latest manifest, run

self.load_latest_manifest()


  warnings.warn(msg, OutdatedManifestWarning)
ophys_session_table.csv: 100%|███████████████████████████████████████████████████████| 165k/165k [00:00<00:00, 309kMB/s]
behavior_session_table.csv: 100%|████████████████████████████████████████████████████| 879k/879k [00:02<00:00, 416kMB/s]
ophys_experiment_table.csv: 100%|████████████████████████████████████████████████████| 336k/336k [00:00<00:00, 385kMB/s]
>>> del cache
>>> cache = vbopc.from_s3_cache(cache_dir=cache_dir)
/Users/scott.daniel/miniconda3/envs/allensdk_37/lib/python3.7/site-packages/allensdk-2.11.0-py3.7.egg/allensdk/api/cloud_cache/cloud_cache.py:270: OutdatedManifestWarning: You are loading visual-behavior-ophys_project_manifest_v0.1.0.json. A more up to date version of the dataset -- visual-behavior-ophys_project_manifest_v0.2.0.json -- exists online. To see the changes between the two versions of the dataset, run
VisualBehaviorOphysProjectCache.compare_manifests('visual-behavior-ophys_project_manifest_v0.1.0.json', 'visual-behavior-ophys_project_manifest_v0.2.0.json')
To load another version of the dataset, run
VisualBehaviorOphysProjectCache.load_manifest('visual-behavior-ophys_project_manifest_v0.2.0.json')
  warnings.warn(msg, OutdatedManifestWarning)
>>> cache.current_manifest()
'visual-behavior-ophys_project_manifest_v0.1.0.json'
```

You can see that, after the cache is deleted and reinstantiated, it emits the correct warning and loads the correct manifest.