### PR TITLE
bumps argschema to new major release

### DIFF
--- a/allensdk/brain_observatory/behavior/mtrain.py
+++ b/allensdk/brain_observatory/behavior/mtrain.py
@@ -117,7 +117,7 @@ def annotate_trials(trials):
 
 
 class FriendlyDateTime(fields.DateTime):
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         if isinstance(value, datetime):
             return value
         result = super(FriendlyDateTime, self)._deserialize(value, attr, data)
@@ -125,7 +125,7 @@ class FriendlyDateTime(fields.DateTime):
 
 
 class FriendlyDate(fields.Date):
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         if isinstance(value, date):
             return value
         result = super(FriendlyDate, self)._deserialize(value, attr, data)

--- a/allensdk/brain_observatory/behavior/mtrain.py
+++ b/allensdk/brain_observatory/behavior/mtrain.py
@@ -39,7 +39,10 @@ def assign_session_id(trials):
     --------
     io.load_trials
     """
-    trials['session_id'] = trials['mouse_id'] + '_' + trials['startdatetime'].map(lambda x: x.isoformat())
+    trials['session_id'] = (trials['mouse_id']
+                            + '_'
+                            + trials['startdatetime'].map(
+                                lambda x: x.isoformat()))
 
     return trials
 
@@ -58,7 +61,8 @@ def fix_change_time(trials):
     --------
     io.load_trials
     """
-    trials['change_time'] = trials['change_time'].map(lambda x: np.nan if x is None else x)
+    trials['change_time'] = trials['change_time'].map(
+            lambda x: np.nan if x is None else x)
 
     return trials
 
@@ -77,8 +81,10 @@ def explode_response_window(trials):
     --------
     io.load_trials
     """
-    trials['response_window_lower'] = trials['response_window'].map(lambda x: x[0])
-    trials['response_window_upper'] = trials['response_window'].map(lambda x: x[1])
+    trials['response_window_lower'] = \
+        trials['response_window'].map(lambda x: x[0])
+    trials['response_window_upper'] = \
+        trials['response_window'].map(lambda x: x[1])
 
     return trials
 
@@ -168,7 +174,8 @@ class ExtendedTrialSchema(Schema):
         allow_nan=True,
     )
     scheduled_change_time = fields.Float(
-        description='The time when the change was scheduled to occur on this trial',
+        description=("The time when the change was scheduled to occur "
+                     "on this trial"),
         required=True,
     )
     change_time = fields.Float(
@@ -184,7 +191,8 @@ class ExtendedTrialSchema(Schema):
         allow_none=True,
     )
     initial_image_name = fields.String(
-        description='The name of the last initial image before the change on this trial',
+        description=("The name of the last initial image before the "
+                     "change on this trial"),
         required=True,
         allow_none=True,
     )
@@ -222,7 +230,8 @@ class ExtendedTrialSchema(Schema):
         allow_nan=True,
     )
     delta_ori = fields.Float(
-        description='The difference between the initial and change orientations on this trial',
+        description=("The difference between the initial and change "
+                     "orientations on this trial"),
         required=True,
         allow_none=True,
     )
@@ -234,7 +243,8 @@ class ExtendedTrialSchema(Schema):
         required=True,
     )
     response_latency = fields.Float(
-        description='The latency between the change and the first lick on this trial',
+        description=("The latency between the change and the first lick "
+                     "on this trial"),
         required=True,
         allow_nan=True,
     )
@@ -264,7 +274,8 @@ class ExtendedTrialSchema(Schema):
         allow_none=True,
     )
     cumulative_reward_number = fields.Int(
-        description='the cumulative number of rewards in the session at trial end',
+        description=("the cumulative number of rewards in the session at "
+                     "trial end"),
         required=True,
     )
     cumulative_volume = fields.Float(
@@ -274,7 +285,8 @@ class ExtendedTrialSchema(Schema):
 
     # optogenetics
     optogenetics = fields.Bool(
-        description='whether optogenetic stimulation was applied on this trial',
+        description=("whether optogenetic stimulation was applied "
+                     "on this trial"),
         required=True,
     )
 

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -25,8 +25,7 @@ scikit-image>=0.14.0,<0.17.0
 scikit-build<1.0.0
 statsmodels==0.9.0
 simpleitk>=2.0.2,<3.0.0
-argschema<2.0.0
-marshmallow==3.0.0rc6
+argschema>=3.0.1,<4.0.0
 glymur==0.8.19
 xarray<0.16.0
 hdmf==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,7 @@ scikit-image>=0.14.0,<0.17.0
 scikit-build<1.0.0
 statsmodels<=0.13.0
 simpleitk>=2.0.2,<3.0.0
-argschema<3.0.0
-marshmallow==3.0.0rc6
+argschema>=3.0.1,<4.0.0
 glymur==0.8.19
 xarray<0.16.0
 pynwb>=1.3.2,<2.0.0


### PR DESCRIPTION
argschema is recently updated to v3.0.1
the main change was bumping argschema's dependency from marshmallow 3.0.0rc6 to >=3.0.0

To make this change, argschema needed only a single modification related to auto-generating doc strings.
AllenSDK, I only found 1 place where someone has defined a custom marshamallow field, and the deserialization method needed to be updated:
https://marshmallow.readthedocs.io/en/latest/upgrading.html?#custom-fields

- [x] bamboo tests pass
- [x] bamboo nightly tests pass