### PR TITLE
2167 cloudcache from s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.12.0] = TBA
+- Added ability to specify a static cache directory (use_static_cache=True) to instantiate VisualBehaviorOphysProjectCache.from_local_cache()
 
 ## [2.11.2] = 2021-05-21
 - Fixed mkdir error for non-existing ecephys upload directory

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -28,7 +28,319 @@ class MissingLocalManifestWarning(UserWarning):
     pass
 
 
-class CloudCacheBase(ABC):
+class BasicLocalCache(ABC):
+    """
+    A class to handle the loading and accessing a project's data and
+    metadata from a local cache directory. Does NOT include any 'smart'
+    features like:
+    1. Keeping track of last loaded manifest
+    2. Constructing symlinks for valid data from previous dataset versions
+    3. Warning of outdated manifests
+
+    For those features (and more) see the CloudCacheBase class
+
+    Parameters
+    ----------
+    cache_dir: str or pathlib.Path
+        Path to the directory where data and meatadata arestored on the
+        local system
+
+    project_name: str
+        the name of the project this cache is supposed to access. This will
+        be the root directory for all files stored in the bucket.
+
+    ui_class_name: Optional[str]
+        Name of the class users are actually using to maniuplate this
+        functionality (used to populate helpful error messages)
+    """
+
+    def __init__(
+        self,
+        cache_dir: Union[str, Path],
+        project_name: str,
+        ui_class_name: Optional[str] = None
+    ):
+        os.makedirs(cache_dir, exist_ok=True)
+
+        # the class users are actually interacting with
+        # (for warning message purposes)
+        if ui_class_name is None:
+            self._user_interface_class = type(self).__name__
+        else:
+            self._user_interface_class = ui_class_name
+
+        self._manifest = None
+        self._manifest_name = None
+
+        self._cache_dir = cache_dir
+        self._project_name = project_name
+
+        self._manifest_file_names = self._list_all_manifests()
+
+    # ====================== BasicLocalCache properties =======================
+
+    @property
+    def ui(self):
+        return self._user_interface_class
+
+    @property
+    def current_manifest(self) -> Union[None, str]:
+        """The name of the currently loaded manifest"""
+        return self._manifest_name
+
+    @property
+    def project_name(self) -> str:
+        """The name of the project that this cache is accessing"""
+        return self._project_name
+
+    @property
+    def manifest_prefix(self) -> str:
+        """On-line prefix for manifest files"""
+        return f'{self.project_name}/manifests/'
+
+    @property
+    def file_id_column(self) -> str:
+        """The col name in metadata files used to uniquely identify data files
+        """
+        return self._manifest.file_id_column
+
+    @property
+    def version(self) -> str:
+        """The version of the dataset currently loaded"""
+        return self._manifest.version
+
+    @property
+    def metadata_file_names(self) -> list:
+        """List of metadata file names associated with this dataset"""
+        return self._manifest.metadata_file_names
+
+    @property
+    def manifest_file_names(self) -> list:
+        """Sorted list of manifest file names associated with this dataset
+        """
+        return self._manifest_file_names
+
+    @property
+    def latest_manifest_file(self) -> str:
+        """parses on-line available manifest files for semver string
+        and returns the latest one
+        self.manifest_file_names are assumed to be of the form
+        '<anything>_v<semver_str>.json'
+
+        Returns
+        -------
+        str
+            the filename whose semver string is the latest one
+        """
+        return self._find_latest_file(self.manifest_file_names)
+
+    # ====================== BasicLocalCache methods ==========================
+
+    @abstractmethod
+    def _list_all_manifests(self) -> list:
+        """
+        Return a list of all of the file names of the manifests associated
+        with this dataset
+        """
+        raise NotImplementedError()
+
+    def list_all_downloaded_manifests(self) -> list:
+        """
+        Return a list of all of the manifest files that have been
+        downloaded for this dataset
+        """
+        output = [x for x in os.listdir(self._cache_dir)
+                  if re.fullmatch(".*_manifest_v.*.json", x)]
+        output.sort()
+        return output
+
+    def _find_latest_file(self, file_name_list: List[str]) -> str:
+        """
+        Take a list of files named like
+
+        {blob}_v{version}.json
+
+        and return the one with the latest version
+        """
+        vstrs = [s.split(".json")[0].split("_v")[-1]
+                 for s in file_name_list]
+        versions = [semver.VersionInfo.parse(v) for v in vstrs]
+        imax = versions.index(max(versions))
+        return file_name_list[imax]
+
+    def _load_manifest(
+        self,
+        manifest_name: str,
+        use_static_project_dir: bool = False
+    ) -> Manifest:
+        """
+        Load and return a manifest from this dataset.
+
+        Parameters
+        ----------
+        manifest_name: str
+            The name of the manifest to load. Must be an element in
+            self.manifest_file_names
+        use_static_project_dir: bool
+            When determining what the local path of a remote resource
+            (data or metadata file) should be, the Manifest class will
+            typically create a versioned project subdirectory under the user
+            provided `cache_dir`
+            (e.g. f"{cache_dir}/{project_name}-{manifest_version}")
+            to allow the possibility of multiple manifest (and data) versions
+            to be used. In certain cases, like when using a project's s3 bucket
+            directly as the cache_dir, the project directory name needs to be
+            static (e.g. f"{cache_dir}/{project_name}"). When set to True,
+            the Manifest class will use a static project directory to determine
+            local paths for remote resources. Defaults to False.
+
+        Returns
+        -------
+        Manifest
+        """
+        if manifest_name not in self.manifest_file_names:
+            raise ValueError(
+                f"Manifest to load ({manifest_name}) is not one of the "
+                "valid manifest names for this dataset. Valid names include:\n"
+                f"{self.manifest_file_names}"
+            )
+
+        if use_static_project_dir:
+            manifest_path = os.path.join(
+                self._cache_dir, self.project_name, "manifests", manifest_name
+            )
+        else:
+            manifest_path = os.path.join(self._cache_dir, manifest_name)
+
+        with open(manifest_path, "r") as f:
+            local_manifest = Manifest(
+                cache_dir=self._cache_dir,
+                json_input=f,
+                use_static_project_dir=use_static_project_dir
+            )
+
+        return local_manifest
+
+    def load_manifest(self, manifest_name: str):
+        """
+        Load a manifest from this dataset.
+
+        Parameters
+        ----------
+        manifest_name: str
+            The name of the manifest to load. Must be an element in
+            self.manifest_file_names
+        """
+        self._manifest = self._load_manifest(manifest_name)
+        self._manifest_name = manifest_name
+
+    def _file_exists(self, file_attributes: CacheFileAttributes) -> bool:
+        """
+        Given a CacheFileAttributes describing a file, assess whether or
+        not that file exists locally.
+
+        Parameters
+        ----------
+        file_attributes: CacheFileAttributes
+            Description of the file to look for
+
+        Returns
+        -------
+        bool
+            True if the file exists and is valid; False otherwise
+
+        Raises
+        -----
+        RuntimeError
+            If file_attributes.local_path exists but is not a file.
+            It would be unclear how the cache should proceed in this case.
+        """
+        file_exists = False
+
+        if file_attributes.local_path.exists():
+            if not file_attributes.local_path.is_file():
+                raise RuntimeError(f"{file_attributes.local_path}\n"
+                                   "exists, but is not a file;\n"
+                                   "unsure how to proceed")
+
+            file_exists = True
+
+        return file_exists
+
+    def metadata_path(self, fname: str) -> dict:
+        """
+        Return the local path to a metadata file, and test for the
+        file's existence
+
+        Parameters
+        ----------
+        fname: str
+            The name of the metadata file to be accessed
+
+        Returns
+        -------
+        dict
+
+            'path' will be a pathlib.Path pointing to the file's location
+
+            'exists' will be a boolean indicating if the file
+            exists in a valid state
+
+            'file_attributes' is a CacheFileAttributes describing the file
+            in more detail
+
+        Raises
+        ------
+        RuntimeError
+            If the file cannot be downloaded
+        """
+        file_attributes = self._manifest.metadata_file_attributes(fname)
+        exists = self._file_exists(file_attributes)
+        local_path = file_attributes.local_path
+        output = {'local_path': local_path,
+                  'exists': exists,
+                  'file_attributes': file_attributes}
+
+        return output
+
+    def data_path(self, file_id) -> dict:
+        """
+        Return the local path to a data file, and test for the
+        file's existence
+
+        Parameters
+        ----------
+        file_id:
+            The unique identifier of the file to be accessed
+
+        Returns
+        -------
+        dict
+
+            'local_path' will be a pathlib.Path pointing to the file's location
+
+            'exists' will be a boolean indicating if the file
+            exists in a valid state
+
+            'file_attributes' is a CacheFileAttributes describing the file
+            in more detail
+
+        Raises
+        ------
+        RuntimeError
+            If the file cannot be downloaded
+        """
+        file_attributes = self._manifest.data_file_attributes(file_id)
+        exists = self._file_exists(file_attributes)
+        local_path = file_attributes.local_path
+        output = {'local_path': local_path,
+                  'exists': exists,
+                  'file_attributes': file_attributes}
+
+        return output
+
+
+class CloudCacheBase(BasicLocalCache):
     """
     A class to handle the downloading and accessing of data served from a cloud
     storage system
@@ -50,21 +362,8 @@ class CloudCacheBase(ABC):
     _bucket_name = None
 
     def __init__(self, cache_dir, project_name, ui_class_name=None):
-        os.makedirs(cache_dir, exist_ok=True)
-
-        # the class users are actually interacting with
-        # (for warning message purposes)
-        if ui_class_name is None:
-            self._user_interface_class = type(self).__name__
-        else:
-            self._user_interface_class = ui_class_name
-
-        self._manifest = None
-        self._manifest_name = None
-        self._cache_dir = cache_dir
-
-        self._project_name = project_name
-        self._manifest_file_names = self._list_all_manifests()
+        super().__init__(cache_dir=cache_dir, project_name=project_name,
+                         ui_class_name=ui_class_name)
 
         # what latest_manifest was the last time an OutdatedManifestWarning
         # was emitted
@@ -112,10 +411,6 @@ class CloudCacheBase(ABC):
                 msg += 'is not deleted between instantiations of this '
                 msg += 'cache'
                 warnings.warn(msg, MissingLocalManifestWarning)
-
-    @property
-    def ui(self):
-        return self._user_interface_class
 
     def construct_local_manifest(self) -> None:
         """
@@ -170,52 +465,6 @@ class CloudCacheBase(ABC):
         msg += "self.load_latest_manifest()\n\n"
         warnings.warn(msg, OutdatedManifestWarning)
         return None
-
-    def list_all_downloaded_manifests(self) -> list:
-        """
-        Return a list of all of the manifest files that have been
-        downloaded for this dataset
-        """
-        output = [x for x in os.listdir(self._cache_dir)
-                  if re.fullmatch(".*_manifest_v.*.json", x)]
-        output.sort()
-        return output
-
-    @abstractmethod
-    def _list_all_manifests(self) -> list:
-        """
-        Return a list of all of the file names of the manifests associated
-        with this dataset
-        """
-        raise NotImplementedError()
-
-    def _find_latest_file(self, file_name_list: List[str]):
-        """
-        Take a list of files named like
-
-        {blob}_v{version}.json
-
-        and return the one with the latest version
-        """
-        vstrs = [s.split(".json")[0].split("_v")[-1]
-                 for s in file_name_list]
-        versions = [semver.VersionInfo.parse(v) for v in vstrs]
-        imax = versions.index(max(versions))
-        return file_name_list[imax]
-
-    @property
-    def latest_manifest_file(self) -> str:
-        """parses on-line available manifest files for semver string
-        and returns the latest one
-        self.manifest_file_names are assumed to be of the form
-        '<anything>_v<semver_str>.json'
-
-        Returns
-        -------
-        str
-            the filename whose semver string is the latest one
-        """
-        return self._find_latest_file(self.manifest_file_names)
 
     @property
     def latest_downloaded_manifest_file(self) -> str:
@@ -341,92 +590,6 @@ class CloudCacheBase(ABC):
         """
         raise NotImplementedError()
 
-    @property
-    def current_manifest(self) -> Union[None, str]:
-        """
-        The name of the currently loaded manifest
-        """
-        return self._manifest_name
-
-    @property
-    def project_name(self) -> str:
-        """
-        The name of the project that this cache is accessing
-        """
-        return self._project_name
-
-    @property
-    def manifest_prefix(self) -> str:
-        """
-        On-line prefix for manifest files
-        """
-        return f'{self.project_name}/manifests/'
-
-    @property
-    def file_id_column(self) -> str:
-        """
-        The column in the metadata files used to uniquely
-        identify data files
-        """
-        return self._manifest.file_id_column
-
-    @property
-    def version(self) -> str:
-        """
-        The version of the dataset currently loaded
-        """
-        return self._manifest.version
-
-    @property
-    def metadata_file_names(self) -> list:
-        """
-        List of metadata file names associated with this dataset
-        """
-        return self._manifest.metadata_file_names
-
-    @property
-    def manifest_file_names(self) -> list:
-        """
-        Sorted list of manifest file names associated with this
-        dataset
-        """
-        return copy.deepcopy(self._manifest_file_names)
-
-    def _load_manifest(self, manifest_name: str) -> Manifest:
-        """
-        Load and return a manifest from this dataset.
-
-        Parameters
-        ----------
-        manifest_name: str
-            The name of the manifest to load. Must be an element in
-            self.manifest_file_names
-
-        Returns
-        -------
-        Manifest
-        """
-        if manifest_name not in self.manifest_file_names:
-            raise ValueError(f"manifest: {manifest_name}\n"
-                             "is not one of the valid manifest names "
-                             "for this dataset:\n"
-                             f"{self.manifest_file_names}")
-
-        filepath = os.path.join(self._cache_dir, manifest_name)
-        if not os.path.exists(filepath):
-            self._download_manifest(manifest_name)
-
-        with open(filepath) as f:
-            local_manifest = Manifest(
-                cache_dir=self._cache_dir,
-                json_input=f
-            )
-
-        with open(self._manifest_last_used, 'w') as out_file:
-            out_file.write(manifest_name)
-
-        return local_manifest
-
     def load_manifest(self, manifest_name: str):
         """
         Load a manifest from this dataset.
@@ -437,10 +600,27 @@ class CloudCacheBase(ABC):
             The name of the manifest to load. Must be an element in
             self.manifest_file_names
         """
+        if manifest_name not in self.manifest_file_names:
+            raise ValueError(
+                f"Manifest to load ({manifest_name}) is not one of the "
+                "valid manifest names for this dataset. Valid names include:\n"
+                f"{self.manifest_file_names}"
+            )
+
         if manifest_name != self.latest_manifest_file:
             self._warn_of_outdated_manifest(manifest_name)
 
+        # If desired manifest does not exist, try to download it
+        manifest_path = os.path.join(self._cache_dir, manifest_name)
+        if not os.path.exists(manifest_path):
+            self._download_manifest(manifest_name)
+
         self._manifest = self._load_manifest(manifest_name)
+
+        # Keep track of the newly loaded manifest
+        with open(self._manifest_last_used, 'w') as out_file:
+            out_file.write(manifest_name)
+
         self._manifest_name = manifest_name
 
     def _update_list_of_downloads(self,
@@ -563,42 +743,6 @@ class CloudCacheBase(ABC):
 
         return file_exists
 
-    def data_path(self, file_id) -> dict:
-        """
-        Return the local path to a data file, and test for the
-        file's existence/validity
-
-        Parameters
-        ----------
-        file_id:
-            The unique identifier of the file to be accessed
-
-        Returns
-        -------
-        dict
-
-            'local_path' will be a pathlib.Path pointing to the file's location
-
-            'exists' will be a boolean indicating if the file
-            exists in a valid state
-
-            'file_attributes' is a CacheFileAttributes describing the file
-            in more detail
-
-        Raises
-        ------
-        RuntimeError
-            If the file cannot be downloaded
-        """
-        file_attributes = self._manifest.data_file_attributes(file_id)
-        exists = self._file_exists(file_attributes)
-        local_path = file_attributes.local_path
-        output = {'local_path': local_path,
-                  'exists': exists,
-                  'file_attributes': file_attributes}
-
-        return output
-
     def download_data(self, file_id) -> pathlib.Path:
         """
         Return the local path to a data file, downloading the file
@@ -625,42 +769,6 @@ class CloudCacheBase(ABC):
         self._download_file(file_attributes)
         self._update_list_of_downloads(file_attributes)
         return file_attributes.local_path
-
-    def metadata_path(self, fname: str) -> dict:
-        """
-        Return the local path to a metadata file, and test for the
-        file's existence/validity
-
-        Parameters
-        ----------
-        fname: str
-            The name of the metadata file to be accessed
-
-        Returns
-        -------
-        dict
-
-            'path' will be a pathlib.Path pointing to the file's location
-
-            'exists' will be a boolean indicating if the file
-            exists in a valid state
-
-            'file_attributes' is a CacheFileAttributes describing the file
-            in more detail
-
-        Raises
-        ------
-        RuntimeError
-            If the file cannot be downloaded
-        """
-        file_attributes = self._manifest.metadata_file_attributes(fname)
-        exists = self._file_exists(file_attributes)
-        local_path = file_attributes.local_path
-        output = {'local_path': local_path,
-                  'exists': exists,
-                  'file_attributes': file_attributes}
-
-        return output
 
     def download_metadata(self, fname: str) -> pathlib.Path:
         """

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -42,7 +42,7 @@ class BasicLocalCache(ABC):
     Parameters
     ----------
     cache_dir: str or pathlib.Path
-        Path to the directory where data and meatadata arestored on the
+        Path to the directory where data and metadata are stored on the
         local system
 
     project_name: str
@@ -50,7 +50,7 @@ class BasicLocalCache(ABC):
         be the root directory for all files stored in the bucket.
 
     ui_class_name: Optional[str]
-        Name of the class users are actually using to maniuplate this
+        Name of the class users are actually using to manipulate this
         functionality (used to populate helpful error messages)
     """
 
@@ -355,7 +355,7 @@ class CloudCacheBase(BasicLocalCache):
         be the root directory for all files stored in the bucket.
 
     ui_class_name: Optional[str]
-        Name of the class users are actually using to maniuplate this
+        Name of the class users are actually using to manipulate this
         functionality (used to populate helpful error messages)
     """
 

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -1260,6 +1260,12 @@ class StaticLocalCache(BasicLocalCache):
         manifest_dir = os.path.join(
             self._cache_dir, self.project_name, "manifests"
         )
+        if not os.path.exists(manifest_dir):
+            raise RuntimeError(
+                f"Expected the provided cache_dir ({self._cache_dir})"
+                "to have the following subfolders but it did not: "
+                f"{self.project_name}/manifests"
+            )
 
         output = [x for x in os.listdir(manifest_dir)
                   if re.fullmatch(".*_manifest_v.*.json", x)]

--- a/allensdk/api/cloud_cache/file_attributes.py
+++ b/allensdk/api/cloud_cache/file_attributes.py
@@ -26,7 +26,7 @@ class CacheFileAttributes(object):
                  url: str,
                  version_id: str,
                  file_hash: str,
-                 local_path: str):
+                 local_path: pathlib.Path):
 
         if not isinstance(url, str):
             raise ValueError(f"url must be str; got {type(url)}")

--- a/allensdk/api/cloud_cache/utils.py
+++ b/allensdk/api/cloud_cache/utils.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from typing import Optional, Union
+from pathlib import Path
 import warnings
 import re
 import urllib.parse as url_parse
@@ -65,13 +66,13 @@ def relative_path_from_url(url: str) -> str:
     return url_params.path[1:]
 
 
-def file_hash_from_path(file_path: str) -> str:
+def file_hash_from_path(file_path: Union[str, Path]) -> str:
     """
     Return the hexadecimal file hash for a file
 
     Parameters
     ----------
-    file_path: str
+    file_path: Union[str, Path]
         path to a file
 
     Returns

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -163,9 +163,12 @@ class VisualBehaviorOphysProjectCache(object):
         return cls(fetch_api=fetch_api)
 
     @classmethod
-    def from_local_cache(cls, cache_dir: Union[str, Path],
-                         project_name: str = "visual-behavior-ophys"
-                         ) -> "VisualBehaviorOphysProjectCache":
+    def from_local_cache(
+        cls,
+        cache_dir: Union[str, Path],
+        project_name: str = "visual-behavior-ophys",
+        use_static_cache: bool = False
+    ) -> "VisualBehaviorOphysProjectCache":
         """instantiates this object with a local cache.
 
         Parameters
@@ -184,8 +187,11 @@ class VisualBehaviorOphysProjectCache(object):
 
         """
         fetch_api = BehaviorProjectCloudApi.from_local_cache(
-                cache_dir, project_name,
-                ui_class_name=cls.__name__)
+            cache_dir,
+            project_name,
+            ui_class_name=cls.__name__,
+            use_static_cache=use_static_cache
+        )
         return cls(fetch_api=fetch_api)
 
     @classmethod

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -10,7 +10,9 @@ from allensdk.brain_observatory.behavior.behavior_session import (
     BehaviorSession)
 from allensdk.brain_observatory.behavior.behavior_ophys_experiment import (
     BehaviorOphysExperiment)
-from allensdk.api.cloud_cache.cloud_cache import S3CloudCache, LocalCache
+from allensdk.api.cloud_cache.cloud_cache import (
+    S3CloudCache, LocalCache, StaticLocalCache
+)
 
 
 # [min inclusive, max exclusive)
@@ -70,9 +72,12 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         Whether to operate in local mode, where no data will be downloaded
         and instead will be loaded from local
     """
-    def __init__(self, cache: Union[S3CloudCache, LocalCache],
-                 skip_version_check: bool = False,
-                 local: bool = False):
+    def __init__(
+        self,
+        cache: Union[S3CloudCache, LocalCache, StaticLocalCache],
+        skip_version_check: bool = False,
+        local: bool = False
+    ):
 
         self.cache = cache
         self.skip_version_check = skip_version_check
@@ -158,9 +163,12 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         return BehaviorProjectCloudApi(cache)
 
     @staticmethod
-    def from_local_cache(cache_dir: Union[str, Path],
-                         project_name: str,
-                         ui_class_name: str) -> "BehaviorProjectCloudApi":
+    def from_local_cache(
+        cache_dir: Union[str, Path],
+        project_name: str,
+        ui_class_name: str,
+        use_static_cache: bool = False
+    ) -> "BehaviorProjectCloudApi":
         """instantiates this object with a local cache.
 
         Parameters
@@ -181,9 +189,18 @@ class BehaviorProjectCloudApi(BehaviorProjectBase):
         BehaviorProjectCloudApi instance
 
         """
-        cache = LocalCache(cache_dir,
-                           project_name,
-                           ui_class_name=ui_class_name)
+        if use_static_cache:
+            cache = StaticLocalCache(
+                cache_dir,
+                project_name,
+                ui_class_name=ui_class_name
+            )
+        else:
+            cache = LocalCache(
+                cache_dir,
+                project_name,
+                ui_class_name=ui_class_name
+            )
         return BehaviorProjectCloudApi(cache, local=True)
 
     def get_behavior_session(

--- a/allensdk/test/api/cloud_cache/test_static_local_cache.py
+++ b/allensdk/test/api/cloud_cache/test_static_local_cache.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+from typing import Tuple
+import json
+
+import pandas as pd
+import pytest
+
+from allensdk.api.cloud_cache.utils import file_hash_from_path
+from allensdk.api.cloud_cache.cloud_cache import StaticLocalCache
+
+
+@pytest.fixture
+def mounted_s3_dataset_fixture(tmp_path, request) -> Tuple[Path, str, dict]:
+    """A fixture which simulates a project s3 bucket that has been mounted
+    as a local directory.
+    """
+
+    # Get fixture parameters
+    project_name = request.param.get("project_name", "test_project_name_1")
+    dataset_version = request.param.get("dataset_version", "0.3.0")
+    metadata_file_id_column_name = request.param.get(
+        "metadata_file_id_column_name", "file_id"
+    )
+    metadata_files_contents = request.param.get(
+        "metadata_files_contents",
+        # Each item in list is a tuple of:
+        # (metadata_filename, metadata_contents)
+        [
+            ("metadata_1.csv", {"mouse": [1, 2, 3], "sex": ["F", "F", "M"]}),
+            (
+                "metadata_2.csv",
+                {
+                    "experiment": [4, 5, 6],
+                    metadata_file_id_column_name: ["data1", "data2", "data3"]
+                }
+            )
+        ]
+    )
+    data_files_contents = request.param.get(
+        "data_files_contents",
+        # Each item in list is a tuple of:
+        # (data_filename, data_contents)
+        [
+            ("data_1.nwb", "123456"),
+            ("data_2.nwb", "abcdef"),
+            ("data_3.nwb", "ghijkl")
+        ]
+    )
+
+    # Create mock mounted s3 directory structure
+    mock_mounted_base_dir = tmp_path / "mounted_remote_data"
+    mock_mounted_base_dir.mkdir()
+    mock_project_dir = mock_mounted_base_dir / project_name
+    mock_project_dir.mkdir()
+
+    # Create metadata files and manifest entries
+    mock_metadata_dir = mock_project_dir / "project_metadata"
+    mock_metadata_dir.mkdir()
+
+    manifest_meta_entries = dict()
+    for meta_fname, meta_contents in metadata_files_contents:
+        meta_save_path = mock_metadata_dir / meta_fname
+        df_to_save = pd.DataFrame(meta_contents)
+        df_to_save.to_csv(str(meta_save_path), index=False)
+
+        manifest_meta_entries[meta_fname.rstrip(".csv")] = {
+            "url": (
+                f"http://{project_name}.s3.amazonaws.com/{project_name}"
+                f"/project_metadata/{meta_fname}"
+            ),
+            "version_id": "test_placeholder",
+            "file_hash": file_hash_from_path(meta_save_path)
+        }
+
+    # Create data files and manifest entries
+    mock_data_dir = mock_project_dir / "project_data"
+    mock_data_dir.mkdir()
+
+    manifest_data_entries = dict()
+    for file_fname, file_contents in data_files_contents:
+        file_save_path = mock_data_dir / file_fname
+        with file_save_path.open('w') as f:
+            f.write(file_contents)
+
+        manifest_data_entries[file_fname.rstrip(".nwb")] = {
+            "url": (
+                f"http://{project_name}.s3.amazonaws.com/{project_name}"
+                f"/project_data/{file_fname}"
+            ),
+            "version_id": "test_placeholder",
+            "file_hash": file_hash_from_path(file_save_path)
+        }
+
+    # Create manifest dir and manifest
+    mock_manifests_dir = mock_project_dir / "manifests"
+    mock_manifests_dir.mkdir()
+    manifest_fname = f"test_manifest_v{dataset_version}.json"
+    manifest_path = mock_manifests_dir / manifest_fname
+
+    manifest_contents = {
+        "project_name": project_name,
+        "manifest_version": dataset_version,
+        "data_pipeline": [
+            {
+                "name": "AllenSDK",
+                "version": "2.11.0",
+                "comment": "This is a test entry. NOT REAL."
+            }
+        ],
+        "metadata_file_id_column_name": metadata_file_id_column_name,
+        "metadata_files": manifest_meta_entries,
+        "data_files": manifest_data_entries
+    }
+
+    with manifest_path.open('w') as f:
+        json.dump(manifest_contents, f, indent=4)
+
+    expected = {
+        "expected_metadata": metadata_files_contents,
+        "expected_data": data_files_contents
+    }
+
+    return mock_mounted_base_dir, project_name, expected
+
+
+@pytest.mark.parametrize(
+    "mounted_s3_dataset_fixture",
+    [
+        {"project_name": "visual-behavior-ophys"}
+    ],
+    indirect=["mounted_s3_dataset_fixture"]
+)
+def test_static_local_cache_access(mounted_s3_dataset_fixture):
+    local_static_cache_dir, proj_name, expected = mounted_s3_dataset_fixture
+
+    cache = StaticLocalCache(local_static_cache_dir, proj_name)
+    cache.load_last_manifest()
+
+    for exp_meta_fname, exp_meta_contents in expected["expected_metadata"]:
+        exp_df = pd.DataFrame(exp_meta_contents)
+        obt_df_path = cache.metadata_path(exp_meta_fname.rstrip(".csv"))
+        obt_df = pd.read_csv(obt_df_path["local_path"])
+        pd.testing.assert_frame_equal(exp_df, obt_df)
+
+    for exp_data_fname, exp_data_contents in expected["expected_data"]:
+        obt_data_path = cache.data_path(exp_data_fname.rstrip(".nwb"))
+        with open(obt_data_path["local_path"], "r") as f:
+            obt_data = f.read()
+        assert exp_data_contents == obt_data

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -118,6 +118,9 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
+What's New - 2.12.0
+-----------------------------------------------------------------------
+- Added ability to specify a static cache directory (use_static_cache=True) to instantiate VisualBehaviorOphysProjectCache.from_local_cache()
 
 What's New - 2.11.2
 -----------------------------------------------------------------------


### PR DESCRIPTION
This PR is intended to address #2167

Briefly, this set of changes is intended to support instantiating a VisualBehaviorOphysProjectCache from an S3 bucket that is mounted as a local file system. This is necessary for the Summer Workshop for the Dynamic Brain where AllenSDK will be run in Sagemaker IPython notebooks which have visual behavior ophys data accessibly via a mounted S3 bucket.

Validation:
- [x] I have already tried the following and it appears to be working, but having others try it out would also be good.

You can test out this new functionality by:
1. Install s3fs (https://github.com/s3fs-fuse/s3fs-fuse)
2. Make directory you want to act as S3 mount point (e.g. `mkdir /remote_data`)
3. Run `s3fs visual-behavior-ophys-data /remote_data/ -o default_acl="public-read" -o complement_stat,uid=$(id -u),gid=$(id -g),umask=222,public_bucket="1",endpoint="us-west-2"`
4. Run [example notebooks](https://allensdk.readthedocs.io/en/latest/visual_behavior_optical_physiology.html) but when instantiating the project cache use:

```
data_storage_directory = Path("/remote_data/")

cache = VisualBehaviorOphysProjectCache.from_local_cache(cache_dir=data_storage_directory, use_static_cache=True)
```
5. Don't forget to `umount` the S3 bucket