### PR TITLE
rc/2.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.11.3] = 2021-08-04
+- Bugfixes related to NWB creation for BehaviorSessions
 
 ## [2.11.2] = 2021-05-21
 - Fixed mkdir error for non-existing ecephys upload directory

--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '2.11.2'
+__version__ = '2.11.3'
 
 
 try:

--- a/allensdk/brain_observatory/behavior/metadata/behavior_metadata.py
+++ b/allensdk/brain_observatory/behavior/metadata/behavior_metadata.py
@@ -239,12 +239,6 @@ class BehaviorMetadata:
         return self.parse_reporter_line(reporter_line=reporter_line, warn=True)
 
     @property
-    def indicator(self) -> Optional[str]:
-        """Parses indicator from reporter"""
-        reporter_line = self.reporter_line
-        return self.parse_indicator(reporter_line=reporter_line, warn=True)
-
-    @property
     def cre_line(self) -> Optional[str]:
         """Parses cre_line from full_genotype"""
         cre_line = self.parse_cre_line(full_genotype=self.full_genotype,

--- a/allensdk/brain_observatory/behavior/metadata/behavior_ophys_metadata.py
+++ b/allensdk/brain_observatory/behavior/metadata/behavior_ophys_metadata.py
@@ -26,6 +26,12 @@ class BehaviorOphysMetadata(BehaviorMetadata):
         self._exclude_from_equals = {'project_code'}
 
     @property
+    def indicator(self) -> Optional[str]:
+        """Parses indicator from reporter"""
+        reporter_line = self.reporter_line
+        return self.parse_indicator(reporter_line=reporter_line, warn=True)
+
+    @property
     def emission_lambda(self) -> float:
         return 520.0
 

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_json_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_json_api.py
@@ -51,10 +51,6 @@ class BehaviorJsonExtractor(BehaviorDataExtractorBase):
         """Get the age code of the subject (ie P123)"""
         return self.data['age']
 
-    def get_stimulus_name(self) -> str:
-        """Get the name of the stimulus presented for the experiment"""
-        return self.data['stimulus_name']
-
     def get_reporter_line(self) -> str:
         """Get the (gene) reporter line for the subject associated with an
         experiment"""

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from typing import Dict, List, Optional, Union
 import pytz
 
-import pandas as pd
-
 from allensdk.api.warehouse_cache.cache import memoize
 from allensdk.brain_observatory.behavior.session_apis.abcs.\
     data_extractor_base.behavior_data_extractor_base import \

--- a/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
+++ b/allensdk/brain_observatory/behavior/session_apis/data_io/behavior_lims_api.py
@@ -255,26 +255,6 @@ class BehaviorLimsExtractor(BehaviorDataExtractorBase):
         return self.lims_db.fetchone(query, strict=True)
 
     @memoize
-    def get_stimulus_name(self) -> str:
-        """Get the stimulus set used from the behavior session pkl file
-        :rtype: str
-        """
-        behavior_stimulus_path = self.get_behavior_stimulus_file()
-        pkl = pd.read_pickle(behavior_stimulus_path)
-
-        try:
-            stimulus_name = pkl["items"]["behavior"]["cl_params"]["stage"]
-        except KeyError:
-            raise RuntimeError(
-                f"Could not obtain stimulus_name/stage information from "
-                f"the *.pkl file ({behavior_stimulus_path}) "
-                f"for the behavior session to save as NWB! The "
-                f"following series of nested keys did not work: "
-                f"['items']['behavior']['cl_params']['stage']"
-            )
-        return stimulus_name
-
-    @memoize
     def get_reporter_line(self) -> List[str]:
         """Returns the genotype name(s) of the reporter line(s).
         :rtype: list

--- a/allensdk/brain_observatory/session_api_utils.py
+++ b/allensdk/brain_observatory/session_api_utils.py
@@ -17,6 +17,7 @@ from pandas.util.testing import assert_frame_equal
 from allensdk.core.lazy_property import LazyProperty
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def is_equal(a: Any, b: Any) -> bool:

--- a/allensdk/test/brain_observatory/behavior/test_behavior_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_metadata.py
@@ -246,7 +246,7 @@ def test_get_task_parameters_task_id_exception():
     }
 
     with pytest.raises(RuntimeError) as error:
-        _ = get_task_parameters(input_data)
+        get_task_parameters(input_data)
     assert "does not know how to parse 'task_id'" in error.value.args[0]
 
 
@@ -285,7 +285,7 @@ def test_get_task_parameters_flash_duration_exception():
     }
 
     with pytest.raises(RuntimeError) as error:
-        _ = get_task_parameters(input_data)
+        get_task_parameters(input_data)
     shld_be = "'images' and/or 'grating' not a valid key"
     assert shld_be in error.value.args[0]
 
@@ -585,57 +585,3 @@ def test_get_date_of_acquisition(monkeypatch, tmp_path, test_params,
             obt_date = metadata.date_of_acquisition
 
         assert obt_date == extractor_expt_date
-
-
-def test_indicator(monkeypatch):
-    """Test that indicator is parsed from full_genotype"""
-
-    class MockExtractor:
-        def get_reporter_line(self):
-            return 'Ai148(TIT2L-GC6f-ICL-tTA2)'
-
-    extractor = MockExtractor()
-
-    with monkeypatch.context() as ctx:
-        def dummy_init(self):
-            self._extractor = extractor
-
-        ctx.setattr(BehaviorMetadata,
-                    '__init__',
-                    dummy_init)
-
-        metadata = BehaviorMetadata()
-
-        assert metadata.indicator == 'GCaMP6f'
-
-
-@pytest.mark.parametrize("input_reporter_line, warning_msg, expected", (
-        (None, 'Error parsing reporter line. It is null.', None),
-        ('foo', 'Could not parse indicator from reporter because none'
-                'of the expected substrings were found in the reporter', None)
-)
-                         )
-def test_indicator_edge_cases(monkeypatch, input_reporter_line, warning_msg,
-                              expected):
-    """Test indicator parsing edge cases"""
-
-    class MockExtractor:
-        def get_reporter_line(self):
-            return input_reporter_line
-
-    extractor = MockExtractor()
-
-    with monkeypatch.context() as ctx:
-        def dummy_init(self):
-            self._extractor = extractor
-
-        ctx.setattr(BehaviorMetadata,
-                    '__init__',
-                    dummy_init)
-
-        metadata = BehaviorMetadata()
-
-        with pytest.warns(UserWarning) as record:
-            indicator = metadata.indicator
-        assert indicator is expected
-        assert str(record[0].message) == warning_msg

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_metadata.py
@@ -1,0 +1,58 @@
+import pytest
+
+from allensdk.brain_observatory.behavior.metadata.behavior_ophys_metadata \
+        import BehaviorOphysMetadata
+
+
+def test_indicator(monkeypatch):
+    """Test that indicator is parsed from full_genotype"""
+
+    class MockExtractor:
+        def get_reporter_line(self):
+            return 'Ai148(TIT2L-GC6f-ICL-tTA2)'
+
+    extractor = MockExtractor()
+
+    with monkeypatch.context() as ctx:
+        def dummy_init(self):
+            self._extractor = extractor
+
+        ctx.setattr(BehaviorOphysMetadata,
+                    '__init__',
+                    dummy_init)
+
+        metadata = BehaviorOphysMetadata()
+
+        assert metadata.indicator == 'GCaMP6f'
+
+
+@pytest.mark.parametrize("input_reporter_line, warning_msg, expected", (
+        (None, 'Error parsing reporter line. It is null.', None),
+        ('foo', 'Could not parse indicator from reporter because none'
+                'of the expected substrings were found in the reporter', None)
+)
+                         )
+def test_indicator_edge_cases(monkeypatch, input_reporter_line, warning_msg,
+                              expected):
+    """Test indicator parsing edge cases"""
+
+    class MockExtractor:
+        def get_reporter_line(self):
+            return input_reporter_line
+
+    extractor = MockExtractor()
+
+    with monkeypatch.context() as ctx:
+        def dummy_init(self):
+            self._extractor = extractor
+
+        ctx.setattr(BehaviorOphysMetadata,
+                    '__init__',
+                    dummy_init)
+
+        metadata = BehaviorOphysMetadata()
+
+        with pytest.warns(UserWarning) as record:
+            indicator = metadata.indicator
+        assert indicator is expected
+        assert str(record[0].message) == warning_msg

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -119,6 +119,11 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
 
+What's New - 2.11.3
+-----------------------------------------------------------------------
+- Bugfixes related to NWB creation for BehaviorSessions
+
+
 What's New - 2.11.2
 -----------------------------------------------------------------------
 - Fixed mkdir error for non-existing ecephys upload directory


### PR DESCRIPTION
### Description
write_behavior_nwb was failing on NWB checks.
* property `indicator` needed to be moved from `BehaviorMetadata` to `BehaviorOphysMetadata`
* the `BehaviorJsonExtractor` needed to share the code with `BehaviorLimsExtractor` for getting the `stimulus_name` from a pkl file.

### Validations
#### 1) This code snippet reproduced the observed error from production (and one other related to `stimulus_name`) and passes now in this branch.
```
import json
from allensdk.brain_observatory.behavior.write_behavior_nwb.__main__ import write_behavior_nwb

prod_injson_path = "/allen/programs/braintv/production/visualbehavior/prod2/specimen_900263316/behavior_session_928263200/BEHAVIOR_WRITE_NWB_QUEUE_928263200_input.json"
with open(prod_injson_path, "r") as f:
    j = json.load(f)

write_behavior_nwb(j["session_data"], "tmp.nwb")
```
#### 2) This code snippet passes the `assert` and shows that this branch reproduces a released `BehaviorSession`
```
import json

from allensdk.brain_observatory.behavior.write_behavior_nwb.__main__ import write_behavior_nwb
from allensdk.brain_observatory.behavior.behavior_project_cache import VisualBehaviorOphysProjectCache
from allensdk.brain_observatory.behavior.behavior_session import BehaviorSession
from allensdk.brain_observatory.session_api_utils import sessions_are_equal


data_storage_directory = "/home/danielk/data"
cache = VisualBehaviorOphysProjectCache.from_s3_cache(
        cache_dir=data_storage_directory)
prod_session = cache.get_behavior_session(870987812)

prod_injson_path = "/allen/programs/braintv/production/visualbehavior/prod2/specimen_850862430/behavior_session_870987812/BEHAVIOR_WRITE_NWB_QUEUE_870987812_input.json"
with open(prod_injson_path, "r") as f:
    j = json.load(f)
write_behavior_nwb(j["session_data"], "tmp.nwb")

test_session = BehaviorSession.from_nwb_path("tmp.nwb")
assert sessions_are_equal(prod_session, test_session)
```
#### 3. This snippet passes the `assert` and shows that this branch reproduces a released `BehaviorOphysExperiment`
```
import json
  
from allensdk.brain_observatory.behavior.write_nwb.__main__ import write_behavior_ophys_nwb
from allensdk.brain_observatory.behavior.behavior_project_cache import VisualBehaviorOphysProjectCache
from allensdk.brain_observatory.behavior.behavior_ophys_experiment import BehaviorOphysExperiment
from allensdk.brain_observatory.session_api_utils import sessions_are_equal


data_storage_directory = "/home/danielk/data"
cache = VisualBehaviorOphysProjectCache.from_s3_cache(
        cache_dir=data_storage_directory)
prod_experiment = cache.get_behavior_ophys_experiment(951980471)

prod_injson_path = "/allen/programs/braintv/production/neuralcoding/prod0/specimen_840355567/ophys_session_951410079/ophys_experiment_951980471/BEHAVIOR_OPHYS_WRITE_NWB_QUEUE_NO_STATE_CHANGE_951980471_input.json"
with open(prod_injson_path, "r") as f:
    j = json.load(f)
write_behavior_ophys_nwb(j["session_data"], "tmp.nwb", skip_eye_tracking=False)

test_experiment = BehaviorOphysExperiment.from_nwb_path("tmp.nwb")
assert sessions_are_equal(prod_experiment, test_experiment)

```
#### 4) Bamboo tests are passing.