### PR TITLE
Ticket/2194/reorder/stimulus/table

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -60,7 +60,7 @@ class BehaviorSession(LazyPropertyMixin):
             _df = _df[['initial_image_name', 'change_image_name',
                        'stimulus_change', 'change_time',
                        'go', 'catch', 'lick_times', 'response_time',
-                       'response_latency','reward_time', 'reward_volume',
+                       'response_latency', 'reward_time', 'reward_volume',
                        'hit', 'false_alarm', 'miss', 'correct_reject',
                        'aborted', 'auto_rewarded', 'change_frame',
                        'start_time', 'stop_time', 'trial_length']]

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -54,7 +54,19 @@ class BehaviorSession(LazyPropertyMixin):
             self.api.get_stimulus_timestamps, settable=True)
         self._task_parameters = LazyProperty(self.api.get_task_parameters,
                                              settable=True)
-        self._trials = LazyProperty(self.api.get_trials, settable=True)
+
+        def trials_getter():
+            _df = self.api.get_trials()
+            _df = _df[['initial_image_name', 'change_image_name',
+                       'stimulus_change', 'change_time',
+                       'go', 'catch', 'lick_times', 'response_time',
+                       'response_latency','reward_time', 'reward_volume',
+                       'hit', 'false_alarm', 'miss', 'correct_reject',
+                       'aborted', 'auto_rewarded', 'change_frame',
+                       'start_time', 'stop_time', 'trial_length']]
+            return _df
+        self._trials = LazyProperty(trials_getter, settable=True)
+
         self._metadata = LazyProperty(self.api.get_metadata, settable=True)
 
     # ==================== class and utility methods ======================

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -476,6 +476,8 @@ class BehaviorSession(LazyPropertyMixin):
                     image index (0-7) for a given session,
                     corresponding to each image name
                 is_change: (bool)
+                    True if the presentation represents a change
+                    in image
                 omitted: (bool)
                     True if no image was shown for this stimulus
                     presentation
@@ -604,9 +606,29 @@ class BehaviorSession(LazyPropertyMixin):
             dataframe columns:
                 trials_id: (int)
                     trial identifier
+                initial_image_name: (string)
+                    name of image presented at start of trial
+                change_image_name: (string)
+                    name of image that is changed to at the change time,
+                    on go trials
+                stimulus_change: (bool)
+                    True if an image change occurs during the trial
+                    (if the trial was both a 'go' trial and the trial
+                    was not aborted)
+                change_time: (float)
+                go: (bool)
+                    Trial type. True if there was a change in stimulus
+                    image identity on this trial
+                catch: (bool)
+                    Trial type. True if there was not a change in stimulus
+                    identity on this trial
                 lick_times: (array of float)
                     array of lick times in seconds during that trial.
                     Empty array if no licks occured during the trial.
+                response_time: (float)
+                    time of first lick in trial in seconds and NaN if
+                    trial aborted
+                response_latency: (float)
                 reward_time: (NaN or float)
                     Time the reward is delivered following a correct
                     response or on auto rewarded trials.
@@ -622,41 +644,24 @@ class BehaviorSession(LazyPropertyMixin):
                 miss: (bool)
                     Behavior response type. On a go trial, mouse either
                     does not lick at all, or licks after reward window
-                stimulus_change: (bool)
-                    True if an image change occurs during the trial
-                    (if the trial was both a 'go' trial and the trial
-                    was not aborted)
-                aborted: (bool)
-                    Behavior response type. True if the mouse licks
-                    before the scheduled change time.
-                go: (bool)
-                    Trial type. True if there was a change in stimulus
-                    image identity on this trial
-                catch: (bool)
-                    Trial type. True if there was not a change in stimulus
-                    identity on this trial
-                auto_rewarded: (bool)
-                    True if free reward was delivered for that trial.
-                    Occurs during the first 5 trials of a session and
-                    throughout as needed.
                 correct_reject: (bool)
                     Behavior response type. On a catch trial, mouse
                     either does not lick at all or licks after reward
                     window
+                aborted: (bool)
+                    Behavior response type. True if the mouse licks
+                    before the scheduled change time.
+                auto_rewarded: (bool)
+                    True if free reward was delivered for that trial.
+                    Occurs during the first 5 trials of a session and
+                    throughout as needed.
+                change_frame: (float)
                 start_time: (float)
                     start time of the trial in seconds
                 stop_time: (float)
                     end time of the trial in seconds
                 trial_length: (float)
                     duration of trial in seconds (stop_time -start_time)
-                response_time: (float)
-                    time of first lick in trial in seconds and NaN if
-                    trial aborted
-                initial_image_name: (string)
-                    name of image presented at start of trial
-                change_image_name: (string)
-                    name of image that is changed to at the change time,
-                    on go trials
         """
         return self._trials
 

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -38,12 +38,13 @@ class BehaviorSession(LazyPropertyMixin):
 
         def stimulus_getter():
             _df = self.api.get_stimulus_presentations()
-            _df.drop(['image_set', 'index'], axis=1, errors='ignore')
+            _df.drop(['index'], axis=1, errors='ignore')
             _df = _df[['start_time', 'stop_time',
                        'duration',
                        'image_name', 'image_index',
                        'is_change', 'omitted',
-                       'start_frame', 'end_frame']]
+                       'start_frame', 'end_frame',
+                       'image_set']]
             return _df
         self._stimulus_presentations = LazyProperty(
             stimulus_getter, settable=True)
@@ -485,6 +486,8 @@ class BehaviorSession(LazyPropertyMixin):
                     image presentation start frame
                 end_frame: (float)
                     image presentation end frame
+                image_set: (string)
+                    image set for this behavior session
         """
         return self._stimulus_presentations
 

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -35,8 +35,19 @@ class BehaviorSession(LazyPropertyMixin):
                                            settable=True, lowpass=True)
         self._raw_running_speed = LazyProperty(self.api.get_running_speed,
                                                settable=True, lowpass=False)
+
+        def stimulus_getter():
+            _df = self.api.get_stimulus_presentations()
+            _df.drop(['image_set', 'index'], axis=1, errors='ignore')
+            _df = _df[['start_time', 'stop_time',
+                       'duration',
+                       'image_name', 'image_index',
+                       'is_change', 'omitted',
+                       'start_frame', 'end_frame']]
+            return _df
         self._stimulus_presentations = LazyProperty(
-            self.api.get_stimulus_presentations, settable=True)
+            stimulus_getter, settable=True)
+
         self._stimulus_templates = LazyProperty(
             self.api.get_stimulus_templates, settable=True)
         self._stimulus_timestamps = LazyProperty(
@@ -441,27 +452,25 @@ class BehaviorSession(LazyPropertyMixin):
                 stimulus_presentations_id [index]: (int)
                     identifier for a stimulus presentation
                     (presentation of an image)
+                start_time: (float)
+                    image presentation start time in seconds
+                stop_time: (float)
+                    image presentation end time in seconds
                 duration: (float)
                     duration of an image presentation (flash)
                     in seconds (stop_time - start_time). NaN if omitted
-                end_frame: (float)
-                    image presentation end frame
+                image_name: (str)
                 image_index: (int)
                     image index (0-7) for a given session,
                     corresponding to each image name
-                image_set: (string)
-                    image set for this behavior session
-                index: (int)
-                    an index assigned to each stimulus presentation
+                is_change: (bool)
                 omitted: (bool)
                     True if no image was shown for this stimulus
                     presentation
                 start_frame: (int)
                     image presentation start frame
-                start_time: (float)
-                    image presentation start time in seconds
-                stop_time: (float)
-                    image presentation end time in seconds
+                end_frame: (float)
+                    image presentation end frame
         """
         return self._stimulus_presentations
 


### PR DESCRIPTION
This addresses tickets #2194 and #2200

Validation: running this code
```
import numpy as np
import allensdk.brain_observatory.behavior.behavior_project_cache as bpc

lims_cache = bpc.VisualBehaviorOphysProjectCache.from_lims()

oeid = 907694954

lims_experiment = lims_cache.get_behavior_ophys_experiment(oeid)

print('stimulus_presentations columns')
print(lims_experiment.stimulus_presentations.columns)
print('index: ',lims_experiment.stimulus_presentations.index.name)
print('')
print('trials columns')
print(lims_experiment.trials.columns)
print('index: ',lims_experiment.trials.index.name)
```

produces this output
```
stimulus_presentations columns
Index(['start_time', 'stop_time', 'duration', 'image_name', 'image_index',
       'is_change', 'omitted', 'start_frame', 'end_frame'],
      dtype='object')
index:  stimulus_presentations_id

trials columns
Index(['initial_image_name', 'change_image_name', 'stimulus_change',
       'change_time', 'go', 'catch', 'lick_times', 'response_time',
       'response_latency', 'reward_time', 'reward_volume', 'hit',
       'false_alarm', 'miss', 'correct_reject', 'aborted', 'auto_rewarded',
       'change_frame', 'start_time', 'stop_time', 'trial_length'],
      dtype='object')
index:  trials_id
```
