### PR TITLE
Bugfix/210920/b/cache

### DIFF
--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -649,6 +649,12 @@ class CloudCacheBase(BasicLocalCache):
             downloaded_data = {}
 
         abs_path = str(file_attributes.local_path.resolve())
+        if abs_path in downloaded_data:
+            if downloaded_data[abs_path] == file_attributes.file_hash:
+                # this file has already been logged;
+                # there is nothing to do
+                return None
+
         downloaded_data[abs_path] = file_attributes.file_hash
         with open(self._downloaded_data_path, 'w') as out_file:
             out_file.write(json.dumps(downloaded_data,

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -557,17 +557,8 @@ class CloudCacheBase(BasicLocalCache):
     @abstractmethod
     def _download_file(self, file_attributes: CacheFileAttributes) -> bool:
         """
-        Check if a file exists and is in the expected state.
-
-        If it is, return True.
-
-        If it is not, download the file, creating the directory
-        where the file is to be stored if necessary.
-
-        If the download is successful, return True.
-
-        If the download fails (file hash does not match expectation),
-        return False.
+        Check if a file exists locally. If it does not, download it and
+        return True. Return False otherwise.
 
         Parameters
         ----------
@@ -772,8 +763,9 @@ class CloudCacheBase(BasicLocalCache):
         """
         super_attributes = self.data_path(file_id)
         file_attributes = super_attributes['file_attributes']
-        self._download_file(file_attributes)
-        self._update_list_of_downloads(file_attributes)
+        was_downloaded = self._download_file(file_attributes)
+        if was_downloaded:
+            self._update_list_of_downloads(file_attributes)
         return file_attributes.local_path
 
     def download_metadata(self, fname: str) -> pathlib.Path:
@@ -799,8 +791,9 @@ class CloudCacheBase(BasicLocalCache):
         """
         super_attributes = self.metadata_path(fname)
         file_attributes = super_attributes['file_attributes']
-        self._download_file(file_attributes)
-        self._update_list_of_downloads(file_attributes)
+        was_downloaded = self._download_file(file_attributes)
+        if was_downloaded:
+            self._update_list_of_downloads(file_attributes)
         return file_attributes.local_path
 
     def get_metadata(self, fname: str) -> pd.DataFrame:
@@ -1100,17 +1093,8 @@ class S3CloudCache(CloudCacheBase):
 
     def _download_file(self, file_attributes: CacheFileAttributes) -> bool:
         """
-        Check if a file exists and is in the expected state.
-
-        If it is, return True.
-
-        If it is not, download the file, creating the directory
-        where the file is to be stored if necessary.
-
-        If the download is successful, return True.
-
-        If the download fails (file hash does not match expectation),
-        return False.
+        Check if a file exists locally. If it does not, download it
+        and return True. Return False otherwise.
 
         Parameters
         ----------
@@ -1131,6 +1115,7 @@ class S3CloudCache(CloudCacheBase):
             If it is not able to successfully download the file after
             10 iterations
         """
+        was_downloaded = False
 
         local_path = file_attributes.local_path
 
@@ -1168,6 +1153,7 @@ class S3CloudCache(CloudCacheBase):
                              unit="MB")
 
         while not self._file_exists(file_attributes):
+            was_downloaded = True
             response = self.s3_client.get_object(Bucket=bucket_name,
                                                  Key=str(obj_key),
                                                  VersionId=version_id)
@@ -1194,7 +1180,7 @@ class S3CloudCache(CloudCacheBase):
         if pbar is not None:
             pbar.close()
 
-        return None
+        return was_downloaded
 
 
 class LocalCache(CloudCacheBase):

--- a/allensdk/api/cloud_cache/cloud_cache.py
+++ b/allensdk/api/cloud_cache/cloud_cache.py
@@ -567,7 +567,8 @@ class CloudCacheBase(BasicLocalCache):
 
         Returns
         -------
-        None
+        bool
+            True if the file was downloaded; False otherwise
 
         Raises
         ------
@@ -1103,7 +1104,8 @@ class S3CloudCache(CloudCacheBase):
 
         Returns
         -------
-        None
+        bool
+            True if the file was downloaded; False otherwise
 
         Raises
         ------

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_from_s3.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_from_s3.py
@@ -89,18 +89,11 @@ def test_local_cache_construction(tmpdir, s3_cloud_cache_data):
     cmd = 'VisualBehaviorOphysProjectCache.construct_local_manifest()'
     assert cmd in f'{warnings[0].message}'
 
-    # check that downloaded data is not in local manifest
-    # before running construction function (because
-    # VisualBehaviorOphysProjectCache automatically
-    # downloads metadata files, those will already
-    # be in there)
+    # Because, at the point where the cache was reconstitute,
+    # the metadata files already existed at their expected local paths,
+    # the file at _downloaded_data_path file will not have been created
     manifest_path = cache.fetch_api.cache._downloaded_data_path
-    with open(manifest_path, 'rb') as in_file:
-        local_manifest = json.load(in_file)
-    fnames = set([pathlib.Path(k).name for k in local_manifest])
-    assert 'ophys_file_1.nwb' not in fnames
-    print(local_manifest)
-    assert len(local_manifest) == 4
+    assert not manifest_path.exists()
 
     cache.construct_local_manifest()
     assert cache.fetch_api.cache._downloaded_data_path.is_file()


### PR DESCRIPTION
This fixes a bug that was preventing the scientists from accessing a single cache from multiple processes at once (see discussion in #2233).

The problem is that, whenever we download a file into a cloud-based cache, we have to update a locally stored JSON file that associates file paths with file hashes. Nothing was done to prevent multiple threads from attempting to write to this JSON file at once, corrupting the file.

While the problem of multiple threads attempting to actually download data at once remains unresolved, this PR resolves the problem of multiple threads accessing already downloaded data by updating the `_update_list_of_downloads` method so that it does not attempt to write to the JSON file if the file path and file hash have already been already recorded.

One can see that this PR achieves its end because this script, which previously failed because of the corruption of the JSON file, now runs successfully

```
from allensdk.brain_observatory.behavior.\
    behavior_project_cache.behavior_project_cache \
    import VisualBehaviorOphysProjectCache as vbo_cache

import multiprocessing

import pathlib

def download_worker(cache, behavior_session_id):
    cache.get_behavior_session(behavior_session_id=behavior_session_id)

if __name__ == "__main__":
    base_dir = pathlib.Path('/allen/aibs/informatics/danielsf')

    cache_dir = base_dir / 'good_cache_dir'

    if not cache_dir.is_dir():
        cache_dir.mkdir()

    cache = vbo_cache.from_s3_cache(cache_dir=cache_dir)
    p_list = []
    behavior_session_table = cache.get_behavior_session_table()
    behavior_session_id = behavior_session_table.index

    # download all of the necessary data first
    downloaded_id = []
    for ii in range(20):
        b_id = behavior_session_id[ii]
        cache.get_behavior_session(behavior_session_id=b_id)
        downloaded_id.append(b_id)

    # try to access it from multiple concurrent processes
    for ii in range(60):
        b_id = downloaded_id[ii%20]
        p = multiprocessing.Process(target=download_worker,
                                    args=(cache,
                                          b_id))
        p.start()
        p_list.append(p)
    for p in p_list:
        p.join()
```
