### PR TITLE
ticket/2245/event/sampling

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py
@@ -110,7 +110,7 @@ class BehaviorOphysExperiment(BehaviorSession):
                   ophys_experiment_id: int,
                   eye_tracking_z_threshold: float = 3.0,
                   eye_tracking_dilation_frames: int = 2,
-                  events_filter_scale: float = 2.0/31.0,
+                  events_filter_scale_seconds: float = 2.0/31.0,
                   events_filter_n_time_steps: int = 20,
                   exclude_invalid_rois=True,
                   skip_eye_tracking=False) -> \
@@ -123,7 +123,7 @@ class BehaviorOphysExperiment(BehaviorSession):
             See `BehaviorOphysExperiment.from_nwb`
         eye_tracking_dilation_frames
             See `BehaviorOphysExperiment.from_nwb`
-        events_filter_scale
+        events_filter_scale_seconds
             See `BehaviorOphysExperiment.from_nwb`
         events_filter_n_time_steps
             See `BehaviorOphysExperiment.from_nwb`
@@ -198,7 +198,7 @@ class BehaviorOphysExperiment(BehaviorSession):
             ophys_timestamps=ophys_timestamps,
             segmentation_mask_image_spacing=projections.max_projection.spacing,
             events_params=EventsParams(
-                filter_scale=events_filter_scale,
+                filter_scale_seconds=events_filter_scale_seconds,
                 filter_n_time_steps=events_filter_n_time_steps),
             exclude_invalid_rois=exclude_invalid_rois
         )
@@ -227,7 +227,7 @@ class BehaviorOphysExperiment(BehaviorSession):
     def from_nwb(cls, nwbfile: NWBFile,
                  eye_tracking_z_threshold: float = 3.0,
                  eye_tracking_dilation_frames: int = 2,
-                 events_filter_scale: float = 2.0/31.0,
+                 events_filter_scale_seconds: float = 2.0/31.0,
                  events_filter_n_time_steps: int = 20,
                  exclude_invalid_rois=True
                  ) -> "BehaviorOphysExperiment":
@@ -244,10 +244,11 @@ class BehaviorOphysExperiment(BehaviorSession):
             Determines the number of adjacent frames that will be marked
             as 'likely_blink' when performing blink detection for
             `eye_tracking` data, by default 2
-        events_filter_scale : float, optional
+        events_filter_scale_seconds : float, optional
             Stdev of halfnorm distribution used to convolve ophys events with
             a 1d causal half-gaussian filter to smooth it for visualization,
-            in seconds (by default 2.0/31.0).
+            in seconds (by default 2.0/31.0; this value has been found to
+            perform well on Allen Institute data across multiple platforms).
         events_filter_n_time_steps : int, optional
             Number of time steps to use for convolution of ophys events
         exclude_invalid_rois
@@ -265,7 +266,7 @@ class BehaviorOphysExperiment(BehaviorSession):
             nwbfile=nwbfile,
             segmentation_mask_image_spacing=projections.max_projection.spacing,
             events_params=EventsParams(
-                filter_scale=events_filter_scale,
+                filter_scale_seconds=events_filter_scale_seconds,
                 filter_n_time_steps=events_filter_n_time_steps
             ),
             exclude_invalid_rois=exclude_invalid_rois
@@ -303,7 +304,7 @@ class BehaviorOphysExperiment(BehaviorSession):
                   session_data: dict,
                   eye_tracking_z_threshold: float = 3.0,
                   eye_tracking_dilation_frames: int = 2,
-                  events_filter_scale: float = 2.0/31.0,
+                  events_filter_scale_seconds: float = 2.0/31.0,
                   events_filter_n_time_steps: int = 20,
                   exclude_invalid_rois=True,
                   skip_eye_tracking=False) -> \
@@ -317,7 +318,7 @@ class BehaviorOphysExperiment(BehaviorSession):
             See `BehaviorOphysExperiment.from_nwb`
         eye_tracking_dilation_frames
             See `BehaviorOphysExperiment.from_nwb`
-        events_filter_scale
+        events_filter_scale_seconds
             See `BehaviorOphysExperiment.from_nwb`
         events_filter_n_time_steps
             See `BehaviorOphysExperiment.from_nwb`
@@ -377,7 +378,7 @@ class BehaviorOphysExperiment(BehaviorSession):
             ophys_timestamps=ophys_timestamps,
             segmentation_mask_image_spacing=projections.max_projection.spacing,
             events_params=EventsParams(
-                filter_scale=events_filter_scale,
+                filter_scale_seconds=events_filter_scale_seconds,
                 filter_n_time_steps=events_filter_n_time_steps),
             exclude_invalid_rois=exclude_invalid_rois
         )

--- a/allensdk/brain_observatory/behavior/data_objects/cell_specimens/cell_specimens.py
+++ b/allensdk/brain_observatory/behavior/data_objects/cell_specimens/cell_specimens.py
@@ -46,20 +46,20 @@ class EventsParams:
     """Container for arguments to event detection"""
 
     def __init__(self,
-                 filter_scale: float = 2.0/31.0,
+                 filter_scale_seconds: float = 2.0/31.0,
                  filter_n_time_steps: int = 20):
         """
-        :param filter_scale
-            See Events.filter_scale
+        :param filter_scale_seconds
+            See Events.filter_scale_seconds
         :param filter_n_time_steps
             See Events.filter_n_time_steps
         """
-        self._filter_scale = filter_scale
+        self._filter_scale_seconds = filter_scale_seconds
         self._filter_n_time_steps = filter_n_time_steps
 
     @property
-    def filter_scale(self):
-        return self._filter_scale
+    def filter_scale_seconds(self):
+        return self._filter_scale_seconds
 
     @property
     def filter_n_time_steps(self):
@@ -291,7 +291,7 @@ class CellSpecimens(DataObject, LimsReadableInterface,
             return cls._get_events(
                          events_file=events_file,
                          events_params=events_params,
-                         frame_rate=meta.imaging_plane.ophys_frame_rate)
+                         frame_rate_hz=meta.imaging_plane.ophys_frame_rate)
 
         cell_specimen_table = _get_cell_specimen_table()
 
@@ -343,7 +343,7 @@ class CellSpecimens(DataObject, LimsReadableInterface,
             return cls._get_events(
                         events_file=events_file,
                         events_params=events_params,
-                        frame_rate=meta.imaging_plane.ophys_frame_rate)
+                        frame_rate_hz=meta.imaging_plane.ophys_frame_rate)
 
         dff_traces = _get_dff_traces()
         corrected_fluorescence_traces = _get_corrected_fluorescence_traces()
@@ -397,9 +397,9 @@ class CellSpecimens(DataObject, LimsReadableInterface,
         def _get_events():
             return Events.from_nwb(
                 nwbfile=nwbfile,
-                filter_scale=events_params.filter_scale,
+                filter_scale_seconds=events_params.filter_scale_seconds,
                 filter_n_time_steps=events_params.filter_n_time_steps,
-                frame_rate=meta.imaging_plane.ophys_frame_rate)
+                frame_rate_hz=meta.imaging_plane.ophys_frame_rate)
 
         events = _get_events()
         ophys_timestamps = OphysTimestamps.from_nwb(nwbfile=nwbfile)
@@ -606,9 +606,9 @@ class CellSpecimens(DataObject, LimsReadableInterface,
     @staticmethod
     def _get_events(events_file: EventDetectionFile,
                     events_params: EventsParams,
-                    frame_rate: float):
+                    frame_rate_hz: float):
         return Events.from_data_file(
             events_file=events_file,
-            filter_scale=events_params.filter_scale,
+            filter_scale_seconds=events_params.filter_scale_seconds,
             filter_n_time_steps=events_params.filter_n_time_steps,
-            frame_rate=frame_rate)
+            frame_rate_hz=frame_rate_hz)

--- a/allensdk/brain_observatory/behavior/event_detection.py
+++ b/allensdk/brain_observatory/behavior/event_detection.py
@@ -17,7 +17,7 @@ def filter_events_array(arr: np.ndarray, scale: float = 2,
     arr: np.ndarray
         Trace matrix of dimension n traces x n frames
     scale: float
-        std deviation of halfnorm distribution
+        std deviation of halfnorm distribution in units of timesteps
     n_time_steps: int
         number of time steps to use for the convolution operation
 

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_cell_specimens.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_cell_specimens.py
@@ -61,7 +61,7 @@ class TestLims:
             ophys_timestamps=ots,
             segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
             events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
         assert not csp.table.empty
         assert not csp.events.empty
@@ -104,7 +104,7 @@ class TestJson:
             ophys_timestamps=self.ophys_timestamps,
             segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
             events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
         assert not csp.table.empty
         assert not csp.events.empty
@@ -123,7 +123,7 @@ class TestJson:
             ophys_timestamps=self.ophys_timestamps,
             segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
             events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
         private_attr = getattr(csp, f'_{data}')
         public_attr = getattr(csp, data)
@@ -159,7 +159,7 @@ class TestJson:
             ophys_timestamps=self.ophys_timestamps,
             segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
             events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
         private_trace_attr = getattr(csp, f'_{trace_type}')
 
@@ -231,7 +231,7 @@ class TestNWB:
             segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
             exclude_invalid_rois=exclude_invalid_rois,
             events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
 
         csp = cell_specimens._cell_specimen_table
@@ -248,7 +248,7 @@ class TestNWB:
                 exclude_invalid_rois=exclude_invalid_rois,
                 segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
                 events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
         else:
             obt = cell_specimens.from_nwb(
@@ -256,7 +256,7 @@ class TestNWB:
                 exclude_invalid_rois=exclude_invalid_rois,
                 segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
                 events_params=EventsParams(
-                           filter_scale=2.0/31.0,
+                           filter_scale_seconds=2.0/31.0,
                            filter_n_time_steps=20))
 
         if exclude_invalid_rois:

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_motion_correction.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_motion_correction.py
@@ -98,7 +98,7 @@ class TestNWB:
                 dict_repr=ij.dict_repr, ophys_timestamps=ophys_timestamps,
                 segmentation_mask_image_spacing=(.78125e-3, .78125e-3),
                 events_params=EventsParams(
-                               filter_scale=2.0/31.0,
+                               filter_scale_seconds=2.0/31.0,
                                filter_n_time_steps=20))
             csp.to_nwb(nwbfile=self.nwbfile, ophys_timestamps=ophys_timestamps)
 


### PR DESCRIPTION
This PR should address ticket #2245

It does so by changing the call signature for `Events.__init__` so that users must specify `filter_scale` in seconds and `frame_rate` for the experiments. The unitless scalar that is passed to`scipy.stats.halfnorm` is then computed by multiplying the two parameters together.

Here I show a series of filtered events taken from two experiments, one at 31 Hz, the other at 11 Hz. "baseline" represents the result from `master`. "test" represents the results from this PR. The 31 Hz experiment is unaffected, while the events in the 11 Hz mesoscope experiment are narrowed and sharpened, which, I believe, is what we expect to happen.


![953443028_filtered_event_comparisons](https://user-images.githubusercontent.com/1682854/136269792-1cc25ad2-32ab-4a08-abaa-58ef66a5c373.png)


![1088916626_filtered_event_comparisons](https://user-images.githubusercontent.com/1682854/136269842-a4ccc846-d62e-4f69-ab3f-197ebc633fb0.png)

@alexpiet Do you want to check your code on this branch?