### PR TITLE
DataFile: Use safe_system_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [2.13.2] = TBD
+- Fixes bug that caused file paths on windows machines to be incorrect in Visual behavior user-facing classes
 
 ## [2.13.1] = 2021-10-04
 - Fixes bug that was preventing the BehaviorSession from properly instantiating passive sessions.

--- a/allensdk/brain_observatory/behavior/data_files/_data_file_abc.py
+++ b/allensdk/brain_observatory/behavior/data_files/_data_file_abc.py
@@ -2,6 +2,8 @@ import abc
 from typing import Any, Union
 from pathlib import Path
 
+from allensdk.internal.core.lims_utilities import safe_system_path
+
 
 class DataFile(abc.ABC):
     """An abstract class that prototypes methods for accessing internal
@@ -15,7 +17,7 @@ class DataFile(abc.ABC):
     """
 
     def __init__(self, filepath: Union[str, Path]):  # pragma: no cover
-        self._filepath: str = str(filepath)
+        self._filepath: str = safe_system_path(str(filepath))
         self._data = self.load_data(filepath=self._filepath)
 
     @property

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -33,3 +33,4 @@ pynwb==1.0.2
 seaborn<1.0.0
 aiohttp==3.7.4
 nest_asyncio==1.2.0
+docutils<0.18

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -120,7 +120,7 @@ See the `mouse connectivity section <connectivity.html>`_ for more details.
 
 What's New - 2.13.2
 -----------------------------------------------------------------------
-
+- Fixes bug that caused file paths on windows machines to be incorrect in Visual behavior user-facing classes
 
 What's New - 2.13.1
 -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue in which filepath was incorrect on windows machines.

Note: test coverage should be improved to catch this issue, but I made this PR to quickly fix this issue. 