### PR TITLE
try fix readthedocs

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -33,3 +33,4 @@ pynwb==1.0.2
 seaborn<1.0.0
 aiohttp==3.7.4
 nest_asyncio==1.2.0
+docutils<0.18


### PR DESCRIPTION
readthedocs build started failing with 
```
TypeError: 'generator' object is not subscriptable
```

A google search turned up this: https://github.com/readthedocs/readthedocs.org/issues/8616

Try pinning docutils to fix the issue.