### PR TITLE
Adding behavior ophys changes to the rc/2.13.2 branch

### DIFF
--- a/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
@@ -18,14 +18,13 @@ STIMULUS_FILE_QUERY_TEMPLATE = """
         wkf.storage_directory || wkf.filename AS stim_file
     FROM
         well_known_files wkf
-    JOIN 
+    JOIN
         well_known_file_types wkft
         ON wkf.well_known_file_type_id = wkft.id
     WHERE
         wkf.attachable_id = {behavior_session_id}
         AND wkft.name = 'StimulusPickle'
 """
-
 
 
 def from_json_cache_key(cls, dict_repr: dict):

--- a/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
@@ -12,19 +12,20 @@ from allensdk.internal.core.lims_utilities import safe_system_path
 from allensdk.brain_observatory.behavior.data_files import DataFile
 
 # Query returns path to StimulusPickle file for given behavior session
+# TODO: Test new query with old behavior session
 STIMULUS_FILE_QUERY_TEMPLATE = """
     SELECT
         wkf.storage_directory || wkf.filename AS stim_file
     FROM
         well_known_files wkf
+    JOIN 
+        well_known_file_types wkft
+        ON wkf.well_known_file_type_id = wkft.id
     WHERE
         wkf.attachable_id = {behavior_session_id}
-        AND wkf.attachable_type = 'BehaviorSession'
-        AND wkf.well_known_file_type_id IN (
-            SELECT id
-            FROM well_known_file_types
-            WHERE name = 'StimulusPickle');
+        AND wkft.name = 'StimulusPickle'
 """
+
 
 
 def from_json_cache_key(cls, dict_repr: dict):

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/ophys_experiment_metadata/multi_plane_metadata/multi_plane_metadata.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/ophys_experiment_metadata/multi_plane_metadata/multi_plane_metadata.py
@@ -25,11 +25,12 @@ from allensdk.brain_observatory.behavior.data_objects.metadata \
 from allensdk.internal.api import PostgresQueryMixin
 
 
+#TODO: Implement a check to see if experiment containers exist
 class MultiplaneMetadata(OphysExperimentMetadata):
     def __init__(self,
                  ophys_experiment_id: int,
                  ophys_session_id: OphysSessionId,
-                 experiment_container_id: ExperimentContainerId,
+                 #experiment_container_id: ExperimentContainerId,
                  field_of_view_shape: FieldOfViewShape,
                  imaging_depth: ImagingDepth,
                  imaging_plane_group: ImagingPlaneGroup,
@@ -37,7 +38,7 @@ class MultiplaneMetadata(OphysExperimentMetadata):
         super().__init__(
             ophys_experiment_id=ophys_experiment_id,
             ophys_session_id=ophys_session_id,
-            experiment_container_id=experiment_container_id,
+            #experiment_container_id=experiment_container_id,
             field_of_view_shape=field_of_view_shape,
             imaging_depth=imaging_depth,
             project_code=project_code
@@ -55,7 +56,7 @@ class MultiplaneMetadata(OphysExperimentMetadata):
         return cls(
             ophys_experiment_id=ophys_experiment_metadata.ophys_experiment_id,
             ophys_session_id=ophys_experiment_metadata._ophys_session_id,
-            experiment_container_id=ophys_experiment_metadata._experiment_container_id,     # noqa E501
+            #experiment_container_id=ophys_experiment_metadata._experiment_container_id,     # noqa E501
             field_of_view_shape=ophys_experiment_metadata._field_of_view_shape,
             imaging_depth=ophys_experiment_metadata._imaging_depth,
             project_code=ophys_experiment_metadata._project_code,

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/ophys_experiment_metadata/multi_plane_metadata/multi_plane_metadata.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/ophys_experiment_metadata/multi_plane_metadata/multi_plane_metadata.py
@@ -1,9 +1,6 @@
 from pynwb import NWBFile
 
 from allensdk.brain_observatory.behavior.data_objects.metadata \
-    .ophys_experiment_metadata.experiment_container_id import \
-    ExperimentContainerId
-from allensdk.brain_observatory.behavior.data_objects.metadata \
     .ophys_experiment_metadata.field_of_view_shape import \
     FieldOfViewShape
 from allensdk.brain_observatory.behavior.data_objects.metadata \
@@ -25,12 +22,11 @@ from allensdk.brain_observatory.behavior.data_objects.metadata \
 from allensdk.internal.api import PostgresQueryMixin
 
 
-#TODO: Implement a check to see if experiment containers exist
+# TODO: Implement a check to see if experiment containers exist
 class MultiplaneMetadata(OphysExperimentMetadata):
     def __init__(self,
                  ophys_experiment_id: int,
                  ophys_session_id: OphysSessionId,
-                 #experiment_container_id: ExperimentContainerId,
                  field_of_view_shape: FieldOfViewShape,
                  imaging_depth: ImagingDepth,
                  imaging_plane_group: ImagingPlaneGroup,
@@ -38,7 +34,6 @@ class MultiplaneMetadata(OphysExperimentMetadata):
         super().__init__(
             ophys_experiment_id=ophys_experiment_id,
             ophys_session_id=ophys_session_id,
-            #experiment_container_id=experiment_container_id,
             field_of_view_shape=field_of_view_shape,
             imaging_depth=imaging_depth,
             project_code=project_code

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
@@ -148,6 +148,30 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
             stimulus_file=stimulus_file,
             stimulus_timestamps=stimulus_timestamps,
         )
+  @classmethod
+    @cached(cache=LRUCache(maxsize=10), key=from_lims_cache_key)
+    def from_ophys_lims(
+        cls,
+        db: PostgresQueryMixin,
+        behavior_session_id: int,
+        ophys_experiment_id: Optional[int] = None,
+    ) -> "RunningAcquisition":
+        print("TEST", behavior_session_id)
+        stimulus_file = StimulusFile.from_lims(db, behavior_session_id)
+        stimulus_timestamps = StimulusTimestamps.from_ophys_stimulus_file(
+            stimulus_file=stimulus_file
+        )
+        running_acq_df = get_running_df(
+            data=stimulus_file.data, time=stimulus_timestamps.value,
+        )
+        running_acq_df.drop("speed", axis=1, inplace=True)
+
+        return cls(
+            running_acquisition=running_acq_df,
+            stimulus_file=stimulus_file,
+            stimulus_timestamps=stimulus_timestamps,
+        )
+
 
     @classmethod
     def from_nwb(

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
@@ -148,7 +148,8 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
             stimulus_file=stimulus_file,
             stimulus_timestamps=stimulus_timestamps,
         )
-  @classmethod
+
+    @classmethod
     @cached(cache=LRUCache(maxsize=10), key=from_lims_cache_key)
     def from_ophys_lims(
         cls,
@@ -171,7 +172,6 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
             stimulus_file=stimulus_file,
             stimulus_timestamps=stimulus_timestamps,
         )
-
 
     @classmethod
     def from_nwb(

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_processing.py
@@ -298,7 +298,7 @@ def _zscore_threshold_1d(data: np.ndarray,
         corrected_data[np.abs(scores) > threshold] = np.nan
     return corrected_data
 
-
+# TODO: Use a check to verify vsig location
 def get_running_df(
     data, time: np.ndarray, lowpass: bool = True, zscore_threshold=10.0
 ):
@@ -351,8 +351,8 @@ def get_running_df(
     their own corrections and compute running speed from the raw
     source.
     """
-    v_sig = data["items"]["behavior"]["encoders"][0]["vsig"]
-    v_in = data["items"]["behavior"]["encoders"][0]["vin"]
+    v_sig = data["items"]['foraging']["encoders"][0]["vsig"]
+    v_in = data["items"]['foraging']["encoders"][0]["vin"]
 
     if len(v_in) > len(time) + 1:
         error_string = ("length of v_in ({}) cannot be longer than length of "
@@ -372,7 +372,7 @@ def get_running_df(
     # dx = 'd_theta' = angular change
     # There are some issues with angular change in the raw data so we
     # recompute this value
-    dx_raw = data["items"]["behavior"]["encoders"][0]["dx"]
+    dx_raw = data["items"]["foraging"]["encoders"][0]["dx"]
     # Identify "wraps" in the voltage signal that need to be unwrapped
     # This is where the encoder switches from 0V to 5V or vice versa
     pos_wraps, neg_wraps = _identify_wraps(

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_processing.py
@@ -298,6 +298,7 @@ def _zscore_threshold_1d(data: np.ndarray,
         corrected_data[np.abs(scores) > threshold] = np.nan
     return corrected_data
 
+
 # TODO: Use a check to verify vsig location
 def get_running_df(
     data, time: np.ndarray, lowpass: bool = True, zscore_threshold=10.0

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
@@ -75,7 +75,7 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
         return cls(
             timestamps=stimulus_timestamps,
             stimulus_file=stimulus_file
-        )    
+        )
 
     @classmethod
     def from_sync_file(

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
@@ -62,7 +62,8 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
             monitor_delay=monitor_delay,
             stimulus_file=stimulus_file
         )
-@classmethod
+
+    @classmethod
     def from_ophys_stimulus_file(
             cls,
             stimulus_file: StimulusFile) -> "StimulusTimestamps":

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
@@ -17,7 +17,8 @@ from allensdk.brain_observatory.behavior.data_objects.base \
     JsonWritableInterface, NwbWritableInterface
 from allensdk.brain_observatory.behavior.data_objects.timestamps\
     .stimulus_timestamps.timestamps_processing import (
-        get_behavior_stimulus_timestamps, get_ophys_stimulus_timestamps)
+        get_behavior_stimulus_timestamps, get_ophys_stimulus_timestamps,
+        get_wheel_timestamps)
 from allensdk.internal.api import PostgresQueryMixin
 
 
@@ -61,6 +62,19 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
             monitor_delay=monitor_delay,
             stimulus_file=stimulus_file
         )
+@classmethod
+    def from_ophys_stimulus_file(
+            cls,
+            stimulus_file: StimulusFile) -> "StimulusTimestamps":
+        print("Stimulus File:", stimulus_file)
+        stimulus_timestamps = get_wheel_timestamps(
+            stimulus_pkl=stimulus_file.data
+        )
+
+        return cls(
+            timestamps=stimulus_timestamps,
+            stimulus_file=stimulus_file
+        )    
 
     @classmethod
     def from_sync_file(

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
@@ -28,6 +28,27 @@ def get_behavior_stimulus_timestamps(stimulus_pkl: dict) -> np.ndarray:
     return stimulus_timestamps
 
 
+def get_wheel_timestamps(stimulus_pkl: dict) -> np.ndarray:
+    """Obtain visual behavior stimuli timing information from a behavior
+    stimulus *.pkl file.
+
+    Parameters
+    ----------
+    stimulus_pkl : dict
+        A dictionary containing stimulus presentation timing information
+        during a behavior session. Presentation timing info is stored as
+        an array of times between frames (frame time intervals) in
+        milliseconds.
+
+    Returns
+    -------
+    np.ndarray
+        Timestamps (in seconds) for presented stimulus frames during a session.
+    """
+    vsyncs = stimulus_pkl["intervalsms"]
+    stimulus_timestamps = np.hstack((0, vsyncs)).cumsum() / 1000.0
+    return stimulus_timestamps
+
 def get_ophys_stimulus_timestamps(sync_path: Union[str, Path]) -> np.ndarray:
     """Obtain visual behavior stimuli timing information from a sync *.h5 file.
 

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
@@ -49,6 +49,7 @@ def get_wheel_timestamps(stimulus_pkl: dict) -> np.ndarray:
     stimulus_timestamps = np.hstack((0, vsyncs)).cumsum() / 1000.0
     return stimulus_timestamps
 
+
 def get_ophys_stimulus_timestamps(sync_path: Union[str, Path]) -> np.ndarray:
     """Obtain visual behavior stimuli timing information from a sync *.h5 file.
 

--- a/allensdk/brain_observatory/behavior/schemas.py
+++ b/allensdk/brain_observatory/behavior/schemas.py
@@ -129,6 +129,11 @@ class NwbOphysMetadataSchema(RaisingSchema):
 
 
 class OphysMetadataSchema(NwbOphysMetadataSchema):
+    neurodata_type = 'OphysMetadata'
+    neurodata_type_inc = 'LabMetaData'
+    neurodata_doc = "Metadata for ophys experiments"
+    neurodata_skip = {"date_of_acquisition"}
+
     """This schema contains metadata pertaining to optical physiology (ophys).
     """
     ophys_experiment_id = fields.Int(

--- a/allensdk/brain_observatory/nwb/ndx-aibs-behavior-ophys.extension.yaml
+++ b/allensdk/brain_observatory/nwb/ndx-aibs-behavior-ophys.extension.yaml
@@ -73,6 +73,36 @@ groups:
   - name: stimulus_frame_rate
     dtype: float
     doc: Frame rate (frames/second) of the visual_stimulus from the monitor
+- neurodata_type_def: OphysMetadata
+  neurodata_type_inc: LabMetaData
+  doc: Metadata for ophys experiments
+  attributes:
+  - name: ophys_experiment_id
+    dtype: int
+    doc: Unique ID for the ophys experiment (aka imaging plane)
+  - name: ophys_session_id
+    dtype: int
+    doc: Unique ID for the ophys session
+  - name: experiment_container_id
+    dtype: int
+    doc: Container ID for the container that contains this ophys session
+  - name: imaging_depth
+    dtype: int
+    doc: Depth (microns) below the cortical surface targeted for two-photon acquisition
+  - name: field_of_view_width
+    dtype: int
+    doc: Width of optical physiology imaging plane in pixels
+  - name: field_of_view_height
+    dtype: int
+    doc: Height of optical physiology imaging plane in pixels
+  - name: imaging_plane_group
+    dtype: int
+    doc: A numeric index which indicates the order that an imaging plane was acquired
+      for a mesoscope experiment. Will be -1 for non-mesoscope data
+  - name: imaging_plane_group_count
+    dtype: int
+    doc: The total number of plane groups collected in a session for a mesoscope experiment.
+      Will be 0 if the scope did not capture multiple concurrent imaging planes.
 - neurodata_type_def: OphysBehaviorMetadata
   neurodata_type_inc: BehaviorMetadata
   doc: Metadata for behavior + ophys experiments


### PR DESCRIPTION


# Overview:
These changes to rc2.13.2 are intended to allow for NWB files of ophys sessions without behavior information to be easily generated.
# Addresses:
The root directory issues in my previous PR

# Type of Fix:
- [ ] New feature (non-breaking change which adds functionality)

# Changes:

- Addition of ophys session and experiment classes
- Changes to schema to account for ophys sessions with no behavior information


# Validation:
This PR is currently marked as a draft because there is some validation remaining with regards to testing generation of behavior and non-behavior ophys nwb files.

