### PR TITLE
Pandas 1.4 updates

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -188,9 +188,9 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
             dilation_frames=dilation_frames)
 
         eye_tracking_data["likely_blink"] = likely_blinks
-        eye_tracking_data.at[likely_blinks, "eye_area"] = np.nan
-        eye_tracking_data.at[likely_blinks, "pupil_area"] = np.nan
-        eye_tracking_data.at[likely_blinks, "cr_area"] = np.nan
+        eye_tracking_data.loc[likely_blinks, "eye_area"] = np.nan
+        eye_tracking_data.loc[likely_blinks, "pupil_area"] = np.nan
+        eye_tracking_data.loc[likely_blinks, "cr_area"] = np.nan
 
         return EyeTrackingTable(eye_tracking=eye_tracking_data)
 

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -283,13 +283,21 @@ def get_stimulus_metadata(pkl) -> pd.DataFrame:
         stimulus_index_df = pd.DataFrame(columns=[
             'image_name', 'image_category', 'image_set', 'phase',
             'spatial_frequency', 'image_index'])
+        stimulus_index_df = stimulus_index_df.astype({
+            'image_name': str,
+            'image_category': str,
+            'image_set': str,
+            'phase': float,
+            'spatial_frequency': float,
+            'image_index': int
+        })
 
     # get the grating metadata will be empty if gratings are absent
     grating_df = get_gratings_metadata(stimuli,
                                        start_idx=len(stimulus_index_df))
-    stimulus_index_df = stimulus_index_df.append(grating_df,
-                                                 ignore_index=True,
-                                                 sort=False)
+    stimulus_index_df = pd.concat([stimulus_index_df, grating_df],
+                                  ignore_index=True,
+                                  sort=False)
 
     # Add an entry for omitted stimuli
     omitted_df = pd.DataFrame({'image_category': ['omitted'],
@@ -299,8 +307,9 @@ def get_stimulus_metadata(pkl) -> pd.DataFrame:
                                'phase': np.NaN,
                                'spatial_frequency': np.NaN,
                                'image_index': len(stimulus_index_df)})
-    stimulus_index_df = stimulus_index_df.append(omitted_df, ignore_index=True,
-                                                 sort=False)
+    stimulus_index_df = pd.concat([stimulus_index_df, omitted_df],
+                                  ignore_index=True,
+                                  sort=False)
     stimulus_index_df.set_index(['image_index'], inplace=True, drop=True)
     return stimulus_index_df
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ ndx-events<=0.2.0
 boto3==1.17.21
 semver
 cachetools>=4.2.1,<5.0.0
+sqlalchemy


### PR DESCRIPTION
Updates to support new pandas 1.4 

- `.at` was incorrect when the index contains multiple elements; use `.loc` instead
- `Frame.append` is deprecated; use `pd.concat` instead
- `pd.concat` with empty dataframe with unknown dtype and with nonempty dataframe coerces dtypes to object. Explicitly set dtypes of nonempty dataframe
- sqlalchemy was not automatically installed; explicitly install it