### PR TITLE
Fix for API change in pg8000 1.17

### DIFF
--- a/allensdk/internal/core/lims_utilities.py
+++ b/allensdk/internal/core/lims_utilities.py
@@ -79,7 +79,7 @@ def _connect(user="limsreader", host="limsdb2", database="lims2", password="lims
 
 def _select(cursor, query):
     cursor.execute(query)
-    columns = [ d[0].decode("utf-8") for d in cursor.description ]
+    columns = [ d[0].decode("utf-8") if isinstance(d[0], bytes) else d[0] for d in cursor.description ]
     return [ dict(zip(columns, c)) for c in cursor.fetchall() ]
 
 def select(cursor, query):

--- a/allensdk/internal/core/lims_utilities.py
+++ b/allensdk/internal/core/lims_utilities.py
@@ -1,4 +1,7 @@
-import os, platform, re, logging
+import os
+import platform
+import re
+import logging
 from allensdk.core.json_utilities import read_url_get
 
 HDF5_FILE_TYPE_ID = 306905526
@@ -11,13 +14,14 @@ BIOPHYS_MODEL_PARAMETERS_FILE_TYPE_ID = 329230374
 
 
 def get_well_known_files_by_type(wkfs, wkf_type_id):
-    out = [ os.path.join( wkf['storage_directory'], wkf['filename'] )
-            for wkf in wkfs
-            if wkf.get('well_known_file_type_id',None) == wkf_type_id ]
+    out = [os.path.join(wkf['storage_directory'], wkf['filename'])
+           for wkf in wkfs
+           if wkf.get('well_known_file_type_id', None) == wkf_type_id]
 
     if len(out) == 0:
-        raise IOError("Could not find well known files with type %d." % wkf_type_id)
-    
+        raise IOError(
+            "Could not find well known files with type %d." % wkf_type_id)
+
     return out
 
 
@@ -26,35 +30,42 @@ def get_well_known_file_by_type(wkfs, wkf_type_id):
 
     nout = len(out)
     if nout != 1:
-        raise IOError("Expected single well known file with type %d. Got %d." % (wkf_type_id, nout))
-    
+        raise IOError(
+            "Expected single well known file with type %d. Got %d." % (
+                wkf_type_id, nout))
+
     return out[0]
 
 
 def get_well_known_files_by_name(wkfs, filename):
-    out = [ os.path.join( wkf['storage_directory'], wkf['filename'] )
-            for wkf in wkfs
-            if wkf['filename'] == filename ]
+    out = [os.path.join(wkf['storage_directory'], wkf['filename'])
+           for wkf in wkfs
+           if wkf['filename'] == filename]
 
     if len(out) == 0:
-        raise IOError("Could not find well known files with name %s." % filename)
+        raise IOError(
+            "Could not find well known files with name %s." % filename)
 
     return out
+
 
 def get_well_known_file_by_name(wkfs, filename):
     out = get_well_known_files_by_name(wkfs, filename)
 
     nout = len(out)
     if nout != 1:
-        raise IOError("Expected single well known file with name %s. Got %d." % (filename, nout))
-    
+        raise IOError(
+            "Expected single well known file with name %s. Got %d." % (
+                filename, nout))
+
     return out[0]
+
 
 def append_well_known_file(wkfs, path, wkf_type_id=None, content_type=None):
     record = {
         'filename': os.path.basename(path),
         'storage_directory': os.path.dirname(path)
-        }
+    }
 
     if wkf_type_id is not None:
         record['well_known_file_type_id'] = wkf_type_id
@@ -64,36 +75,53 @@ def append_well_known_file(wkfs, path, wkf_type_id=None, content_type=None):
 
     for wkf in wkfs:
         if wkf['filename'] == record['filename']:
-            logging.debug("found existing well known file record for %s, updating", path)
+            logging.debug(
+                "found existing well known file record for %s, updating", path)
             wkf.update(record)
             return
 
-    logging.debug("could not find existing well known file record for %s, appending", path)
+    logging.debug(
+        "could not find existing well known file record for %s, appending",
+        path)
     wkfs.append(record)
 
-def _connect(user="limsreader", host="limsdb2", database="lims2", password="limsro", port=5432):
+
+def _connect(user="limsreader", host="limsdb2", database="lims2",
+             password="limsro", port=5432):
     import pg8000
 
-    conn = pg8000.connect(user=user, host=host, database=database, password=password, port=port)
+    conn = pg8000.connect(user=user, host=host, database=database,
+                          password=password, port=port)
     return conn, conn.cursor()
+
 
 def _select(cursor, query):
     cursor.execute(query)
-    columns = [ d[0].decode("utf-8") if isinstance(d[0], bytes) else d[0] for d in cursor.description ]
-    return [ dict(zip(columns, c)) for c in cursor.fetchall() ]
+    columns = [d[0].decode("utf-8") if isinstance(d[0], bytes) else d[0] for d
+               in cursor.description]
+    return [dict(zip(columns, c)) for c in cursor.fetchall()]
+
 
 def select(cursor, query):
-    raise DeprecationWarning("lims_utilities.select is deprecated.  Please use lims_utilities.query instead.")
+    raise DeprecationWarning(
+        "lims_utilities.select is deprecated.  Please use "
+        "lims_utilities.query instead.")
 
-def connect(user="limsreader", host="limsdb2", database="lims2", password="limsro", port=5432):
-    raise DeprecationWarning("lims_utilities.connect is deprecated.  Please use lims_utilities.query instead.")
 
-def query(query, user="limsreader", host="limsdb2", database="lims2", password="limsro", port=5432):
+def connect(user="limsreader", host="limsdb2", database="lims2",
+            password="limsro", port=5432):
+    raise DeprecationWarning(
+        "lims_utilities.connect is deprecated.  Please use "
+        "lims_utilities.query instead.")
+
+
+def query(query, user="limsreader", host="limsdb2", database="lims2",
+          password="limsro", port=5432):
     conn, cursor = _connect(user, host, database, password, port)
 
     # Guard against non-ascii characters in query
-    query = ''.join([i if ord(i) < 128 else ' ' for i in query]) 
-    
+    query = ''.join([i if ord(i) < 128 else ' ' for i in query])
+
     try:
         results = _select(cursor, query)
     finally:
@@ -101,16 +129,18 @@ def query(query, user="limsreader", host="limsdb2", database="lims2", password="
         conn.close()
     return results
 
+
 def safe_system_path(file_name):
     if platform.system() == "Windows":
         return linux_to_windows(file_name)
     else:
         return convert_from_titan_linux(os.path.normpath(file_name))
 
+
 def convert_from_titan_linux(file_name):
     # Lookup table mapping project to program
-    project_to_program= {
-        "neuralcoding": "braintv", 
+    project_to_program = {
+        "neuralcoding": "braintv",
         '0378': "celltypes",
         'conn': "celltypes",
         'ctyconn': "celltypes",
@@ -128,7 +158,7 @@ def convert_from_titan_linux(file_name):
         newpath = os.path.normpath(os.path.join(
             '/allen',
             'programs',
-            project_to_program.get(m.group(1),'undefined'),
+            project_to_program.get(m.group(1), 'undefined'),
             'production',
             m.group(1),
             m.group(2)
@@ -136,10 +166,11 @@ def convert_from_titan_linux(file_name):
         return newpath
     return file_name
 
+
 def linux_to_windows(file_name):
     # Lookup table mapping project to program
-    project_to_program= {
-        "neuralcoding": "braintv", 
+    project_to_program = {
+        "neuralcoding": "braintv",
         '0378': "celltypes",
         'conn': "celltypes",
         'ctyconn': "celltypes",
@@ -154,14 +185,15 @@ def linux_to_windows(file_name):
     # Simple case for new world order
     m = re.match('/allen', file_name)
     if m:
-        return "\\" + file_name.replace('/','\\')
+        return "\\" + file_name.replace('/', '\\')
 
     # /data/ paths are being retained (for now)
     # this will need to be extended to map directories to
     # /allen/{programs,aibs}/workgroups/foo
     m = re.match('/data/([^/]+)/(.*)', file_name)
     if m:
-        return os.path.normpath(os.path.join('\\\\aibsdata', m.group(1), m.group(2)))
+        return os.path.normpath(
+            os.path.join('\\\\aibsdata', m.group(1), m.group(2)))
 
     # Tough intermediary state where we have old paths
     # being translated to new paths
@@ -170,7 +202,7 @@ def linux_to_windows(file_name):
         newpath = os.path.normpath(os.path.join(
             '\\\\allen',
             'programs',
-            project_to_program.get(m.group(1),'undefined'),
+            project_to_program.get(m.group(1), 'undefined'),
             'production',
             m.group(1),
             m.group(2)


### PR DESCRIPTION
pg8000 version 1.17 has an API change (https://github.com/tlocke/pg8000#version-1-17-0-2021-01-30) that leads to the following error:
```
  File "allensdk/internal/core/lims_utilities.py", line 82, in <listcomp>
    columns = [ d[0].decode("utf-8") for d in cursor.description ]
AttributeError: 'str' object has no attribute 'decode'
```
The proposed change retains support for versions < 1.17 and adds support for versions >= 1.17
