### PR TITLE
2302 failures in source density

### DIFF
--- a/allensdk/brain_observatory/ecephys/current_source_density/__main__.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/__main__.py
@@ -85,7 +85,8 @@ def run_csd(args: dict) -> dict:
             pre_stimulus_time=args['pre_stimulus_time'],
             post_stimulus_time=args['post_stimulus_time'],
             num_trials=args['num_trials'],
-            stimulus_index=args['stimulus']['index']
+            stimulus_index=args['stimulus']['index'],
+            start_field=args['start_field']
         )
 
         logging.info('Loading LFP data')

--- a/allensdk/brain_observatory/ecephys/current_source_density/_current_source_density.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/_current_source_density.py
@@ -9,12 +9,17 @@ from ._interpolation_utils import regular_grid_extractor_factory
 
 
 def extract_trial_windows(
-    stimulus_table: pd.DataFrame, stimulus_name: str,
-    time_step: float, pre_stimulus_time: float, post_stimulus_time: float,
+    stimulus_table: pd.DataFrame,
+    stimulus_name: str,
+    time_step: float,
+    pre_stimulus_time: float,
+    post_stimulus_time: float,
     num_trials: Optional[int] = None,
     stimulus_index: Optional[int] = None,
-    name_field: str = 'stimulus_name', index_field: str = 'stimulus_index',
-    start_field: str = 'Start', end_field: str = 'End'
+    name_field: str = 'stimulus_name',
+    index_field: str = 'stimulus_index',
+    start_field: str = 'Start',
+    end_field: str = 'End'
 ) -> Tuple[List[np.ndarray], np.ndarray]:
     '''Obtains time interval surrounding stimulus sweep onsets
 

--- a/allensdk/brain_observatory/ecephys/current_source_density/_filter_utils.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/_filter_utils.py
@@ -31,7 +31,12 @@ def select_good_channels(lfp: np.ndarray,
     channel_variance = np.mean(np.std(lfp, 2), 0)
     noisy_channels = np.where(channel_variance > noisy_channel_threshold)[0]
 
-    to_remove = np.concatenate((np.array(reference_channels), noisy_channels)).astype(int)
+    to_remove = np.concatenate(
+        (
+            np.array(reference_channels),
+            noisy_channels
+        )
+    ).astype(int)
     good_indices = np.delete(np.arange(0, lfp.shape[1]), to_remove)
 
     # Remove noisy or reference channels (axis=1)

--- a/allensdk/brain_observatory/ecephys/current_source_density/_filter_utils.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/_filter_utils.py
@@ -31,7 +31,7 @@ def select_good_channels(lfp: np.ndarray,
     channel_variance = np.mean(np.std(lfp, 2), 0)
     noisy_channels = np.where(channel_variance > noisy_channel_threshold)[0]
 
-    to_remove = np.concatenate((np.array(reference_channels), noisy_channels))
+    to_remove = np.concatenate((np.array(reference_channels), noisy_channels)).astype(int)
     good_indices = np.delete(np.arange(0, lfp.shape[1]), to_remove)
 
     # Remove noisy or reference channels (axis=1)

--- a/allensdk/brain_observatory/ecephys/current_source_density/_schemas.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/_schemas.py
@@ -83,6 +83,8 @@ class InputParameters(ArgSchema):
     noisy_channel_threshold = Float(default=1500.0,
                                     help='Threshold for removing noisy '
                                          'channels from analysis')
+    start_field = String(default='Start',
+         help='Column from which to extract start times.')
 
 
 class ProbeOutputParameters(DefaultSchema):

--- a/allensdk/brain_observatory/ecephys/current_source_density/_schemas.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/_schemas.py
@@ -83,8 +83,10 @@ class InputParameters(ArgSchema):
     noisy_channel_threshold = Float(default=1500.0,
                                     help='Threshold for removing noisy '
                                          'channels from analysis')
-    start_field = String(default='Start',
-         help='Column from which to extract start times.')
+    start_field = String(
+        default='Start',
+        help='Column from which to extract start times.'
+    )
 
 
 class ProbeOutputParameters(DefaultSchema):


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
The VBN jobs are failing in the ecephys_current_source_density queue. After investigation, it was found that there where multiple causes of these failures. These include differing column names in the stimulus table (across projects), varying stimulus names and a numpy casting issue. The code assumed everything would be named the same and broke when it was not. 

There was also a casting issue which needed to be addressed.

# Addresses:
This PR addresses https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/allensdk/2302

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
The solution to this problem was to allow for the name of the start_field column to be passed in as an argument and for a numpy result to be cast to an int type (bug fix). Additional changes were required in the LIMS in order to pass in a 'stimulus_name' for the VBN jobs. This included creating a new queue with static arguments (set in the LIMS db) in order to pass in both the start_field and the stimulus_name.

# Changes:
-allowed for a start_field to be passed in as a arg
-fixed type issue bug
-fixed existing flake8 issues

# Validation:

I've run my code using data from 12 different jobs from both current density queues and they all run successfully. 

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
The existing code is at a poor coding standard and it needs to be refactored. This caused very cryptic errors when trying to fix this issue. The refactor is out of scope for this issue.
