### PR TITLE
Speed up loading of stimulus presentations table from NWB 2.0 files

### DIFF
--- a/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
@@ -150,6 +150,7 @@ def standardize_movie_numbers(
 
     # for some reason pandas really wants us to use the captures
     warnings.filterwarnings("ignore", "This pattern has match groups")
+    warnings.filterwarnings("ignore", category=UserWarning)
 
     movie_rows = table[stim_colname].str.contains(movie_re, na=False)
     table.loc[movie_rows, stim_colname] = \

--- a/allensdk/brain_observatory/nwb/nwb_api.py
+++ b/allensdk/brain_observatory/nwb/nwb_api.py
@@ -83,7 +83,7 @@ class NwbApi:
                 presentations = collections.defaultdict(list)
                 for col in interval.columns:
                     if col.name not in columns_to_ignore:
-                        presentations[col.name].extend(col.data)
+                        presentations[col.name].extend(col.data[:])
                 df = pd.DataFrame(presentations).replace({'N/A': ''})
                 presentation_dfs.append(df)
 


### PR DESCRIPTION
# Overview:
When using `ecephys` NWB 2.0 files, the stimulus presentations table has always been quite slow to load. It takes anywhere from 30 seconds to several minutes to load the stimulus `DataFrame` into memory. I had previously assumed that this was due to a limitation of NWB files, but it turns out it's just due to an inefficiency in the AllenSDK which has a very simple fix.

# Addresses:
This addresses an issue that was originally raised in the `pynwb` GitHub repository: https://github.com/NeurodataWithoutBorders/pynwb/issues/1430

# Type of Fix:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
When loading the stimulus presentations `DataFrame`, instead of using `presentations[col.name].extend(col.data)`, it now uses `presentations[col.name].extend(col.data[:])`. This decreases load times down to a few seconds.

Replacing some of our custom loading code with the `pynwb` method `DynamicTable.to_dataframe` would also work.

Thanks to @oruebel for help with this.

# Changes:
- Changed one line in `brain_observatory/nwb/nwb_api.py` to improve stimulus table loading times.
- Added a warning suppression in `brain_observatory/ecephys/stimulus_table/naming_utilities.py` to ignore a `UserWarning` related to regular-expression-based string matching

# Validation:
To validate, I just ran four lines of code:

```python
from allensdk.brain_observatory.ecephys.ecephys_session import EcephysSession
fname = '/mnt/nvme0/ecephys_cache_dir_2/session_715093703/session_715093703.nwb'
session = EcephysSession.from_nwb_path(fname)
df = session.stimulus_presentations
```
After implementing these changes, the last line returns an identical `DataFrame` object *much* faster.

# Checklist
- [X] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [X] My code is unit tested and does not decrease test coverage
- [X] I have performed a self review of my own code
- [X] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [X] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [X] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [X] My code passes all AllenSDK tests
