### PR TITLE
Fix monitor delay bug

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         image: ["allensdk_local_py37:latest"]
-        branch: ["master", "rc/2.13.4"]
+        branch: ["master", "rc/2.13.5"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py
@@ -363,11 +363,15 @@ class BehaviorOphysExperiment(BehaviorSession):
         is_multiplane_session = _is_multi_plane_session()
         meta = BehaviorOphysMetadata.from_json(
             dict_repr=session_data, is_multiplane=is_multiplane_session)
-        monitor_delay = calculate_monitor_delay(
-            sync_file=sync_file, equipment=meta.behavior_metadata.equipment)
+        if 'monitor_delay' not in session_data:
+            monitor_delay = calculate_monitor_delay(
+                sync_file=sync_file,
+                equipment=meta.behavior_metadata.equipment
+            )
+            session_data['monitor_delay'] = monitor_delay
+
         behavior_session = BehaviorSession.from_json(
-            session_data=session_data,
-            monitor_delay=monitor_delay
+            session_data=session_data
         )
 
         if is_multiplane_session:

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -81,38 +81,30 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
     @classmethod
     def from_json(cls,
-                  session_data: dict,
-                  monitor_delay: Optional[float] = None) \
-            -> "BehaviorSession":
+                  session_data: dict) -> "BehaviorSession":
         """
 
         Parameters
         ----------
         session_data
             Dict of input data necessary to construct a session
-        monitor_delay
-            Monitor delay. If not provided, will use an estimate.
-            To provide this value, see for example
-            allensdk.brain_observatory.behavior.data_objects.stimuli.util.
-            calculate_monitor_delay
 
         Returns
         -------
         `BehaviorSession` instance
 
         """
-        if monitor_delay is None:
+        if 'monitor_delay' not in session_data:
             monitor_delay = cls._get_monitor_delay()
+            session_data['monitor_delay'] = monitor_delay
 
         behavior_session_id = BehaviorSessionId.from_json(
             dict_repr=session_data)
         stimulus_file = StimulusFile.from_json(dict_repr=session_data)
         stimulus_timestamps = StimulusTimestamps.from_json(
-            dict_repr=session_data,
-            monitor_delay=monitor_delay)
+            dict_repr=session_data)
         running_acquisition = RunningAcquisition.from_json(
-            dict_repr=session_data,
-            monitor_delay=monitor_delay)
+            dict_repr=session_data)
         raw_running_speed = RunningSpeed.from_json(
             dict_repr=session_data, filtered=False
         )
@@ -122,8 +114,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
         licks, rewards, stimuli, task_parameters, trials = \
             cls._read_data_from_stimulus_file(
                 stimulus_file=stimulus_file,
-                stimulus_timestamps=stimulus_timestamps,
-                trial_monitor_delay=monitor_delay
+                stimulus_timestamps=stimulus_timestamps
             )
         date_of_acquisition = DateOfAcquisition.from_json(
             dict_repr=session_data)\
@@ -212,7 +203,6 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             cls._read_data_from_stimulus_file(
                 stimulus_file=stimulus_file,
                 stimulus_timestamps=stimulus_timestamps,
-                trial_monitor_delay=monitor_delay
             )
         if date_of_acquisition is None:
             date_of_acquisition = DateOfAcquisition.from_lims(
@@ -891,8 +881,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
     @classmethod
     def _read_data_from_stimulus_file(
             cls, stimulus_file: StimulusFile,
-            stimulus_timestamps: StimulusTimestamps,
-            trial_monitor_delay: float):
+            stimulus_timestamps: StimulusTimestamps):
         """Helper method to read data from stimulus file"""
         licks = Licks.from_stimulus_file(
             stimulus_file=stimulus_file,

--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/_schemas.py
@@ -1,5 +1,5 @@
 from argschema import ArgSchema
-from argschema.fields import (LogLevel, String, Int, Nested, List)
+from argschema.fields import (LogLevel, String, Int, Nested, List, Float)
 import marshmallow as mm
 import pandas as pd
 
@@ -42,6 +42,8 @@ class BehaviorSessionData(RaisingSchema):
     stimulus_name = String(required=True,
                            description=("Name of stimulus presented during "
                                         "behavior session"))
+    monitor_delay = Float(required=False,
+                          description=("Value of delay to adjust timestamps"))
 
     @mm.pre_load
     def set_stimulus_name(self, data, **kwargs):

--- a/allensdk/test/brain_observatory/behavior/test_behavior_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_session.py
@@ -1,6 +1,37 @@
 from allensdk.brain_observatory.behavior.behavior_session import (
     BehaviorSession)
 
+from allensdk.brain_observatory.session_api_utils import sessions_are_equal
+
+import pytest
+
+
+@pytest.fixture
+def session_data_fixture():
+
+    return {
+        "behavior_session_id": 1010991549,
+        "foraging_id": "bfcc4803-8892-4cb4-88e0-9437b98936db",
+        "driver_line": [
+            "Vip-IRES-Cre"
+        ],
+        "reporter_line": [
+            "Ai32(RCL-ChR2(H134R)_EYFP)"
+        ],
+        "full_genotype": "Vip-IRES-Cre/wt;Ai32(RCL-ChR2(H134R)_EYFP)/wt",
+        "rig_name": "BEH.G-Box1",
+        "date_of_acquisition": "2020-02-28 03:11:17",
+        "external_specimen_name": 506940,
+        "behavior_stimulus_file":
+            "/allen/programs/braintv/production/visualbehavior/prod0/"
+            "specimen_1000324129/behavior_session_1010991549/"
+            "200228111053_506940_bfcc4803-8892-4cb4-88e0-9437b98936db.pkl",
+        "date_of_birth": "2019-11-24 16:00:00",
+        "sex": "M",
+        "age": "unknown",
+        "stimulus_name": None
+    }
+
 
 def test_behavior_session_list_data_attributes_and_methods(monkeypatch):
     """Test that data related methods/attributes/properties for
@@ -32,3 +63,14 @@ def test_behavior_session_list_data_attributes_and_methods(monkeypatch):
     }
 
     assert any(expected ^ set(obt)) is False
+
+
+@pytest.mark.nightly
+def test_behavior_session_equivalent_json_lims(session_data_fixture):
+
+    json_session = BehaviorSession.from_json(session_data_fixture)
+
+    behavior_session_id = session_data_fixture['behavior_session_id']
+    lims_session = BehaviorSession.from_lims(behavior_session_id)
+
+    assert sessions_are_equal(json_session, lims_session, reraise=True)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,7 +7,7 @@ pytest-mock>=1.5.0,<3.0.0
 mock>=1.0.1,<5.0.0
 coverage>=3.7.1,<6.0.0
 scikit-learn<1.0.0
-moto==2.0.1
+moto==3.0.7
 # these overlap with requirements specified in doc_requirements. As long as they are needed, these specifications must be kept in sync
 # TODO: see if we can avoid duplicating these requirements - this will involved surveying CI
 pep8==1.7.0,<2.0.0
@@ -16,3 +16,5 @@ pylint>=1.5.4,<3.0.0
 jinja2>=2.7.3,<2.12.0
 numpydoc>=0.6.0,<1.0.0
 jupyter>=1.0.0,<2.0.0
+markupsafe==2.0.1
+pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'win32'


### PR DESCRIPTION
Addresses #2314

**Problem:**
Running LIMS BEHAVIOR_WRITE_NWB_QUEUE in order to create behaviour only NWB was failing with error:
```sh
Traceback (most recent call last):
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/site-packages/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py", line 87, in <module>
    main()
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/site-packages/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py", line 81, in main
    raise err
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/site-packages/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py", line 76, in main
    parser.args['output_path'])
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/site-packages/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py", line 53, in write_behavior_nwb
    raise e
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/site-packages/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py", line 30, in write_behavior_nwb
    json_session = BehaviorSession.from_json(session_data)
  File "/allen/aibs/technology/conda/production/allensdk_py36/lib/python3.6/site-packages/allensdk/brain_observatory/behavior/behavior_session.py", line 112, in from_json
    monitor_delay=monitor_delay)
TypeError: from_json() got an unexpected keyword argument 'monitor_delay'
```

**Validation:**
Successfully created behavior only nwb when running on the same session in `/allen/aibs/technology/sergeyg/Projects/vbn`

