### PR TITLE
Issue/2304/genotype/is/none

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/full_genotype.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/full_genotype.py
@@ -14,7 +14,7 @@ class FullGenotype(DataObject, LimsReadableInterface, JsonReadableInterface,
                    NwbReadableInterface):
     """the name of the subject's genotype"""
     def __init__(self, full_genotype: str):
-        super().__init__(name="full_genotype", value=full_genotype)
+        super().__init__(name="full_genotype", value=str(full_genotype))
 
     @classmethod
     def from_json(cls, dict_repr: dict) -> "FullGenotype":

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/full_genotype.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/full_genotype.py
@@ -13,7 +13,10 @@ from allensdk.internal.api import PostgresQueryMixin
 class FullGenotype(DataObject, LimsReadableInterface, JsonReadableInterface,
                    NwbReadableInterface):
     """the name of the subject's genotype"""
-    def __init__(self, full_genotype: str):
+    def __init__(self, full_genotype: Optional[str]):
+
+        # casting full_genotype into a str because there are instances
+        # in LIMS of full_genotype == NULL
         super().__init__(name="full_genotype", value=str(full_genotype))
 
     @classmethod

--- a/allensdk/test/brain_observatory/behavior/data_objects/metadata/behavior_metadata/test_behavior_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/metadata/behavior_metadata/test_behavior_metadata.py
@@ -114,6 +114,16 @@ class TestBehaviorMetadata(BehaviorMetaTestCase):
         assert str(record[0].message) == 'Unable to parse cre_line from ' \
                                          'full_genotype'
 
+    def test_cre_line_full_genotype_is_none(self):
+        """Test that cre_line is None and no error raised"""
+        fg = FullGenotype(full_genotype=None)
+
+        with pytest.warns(UserWarning) as record:
+            cre_line = fg.parse_cre_line(warn=True)
+        assert cre_line is None
+        assert str(record[0].message) == 'Unable to parse cre_line from ' \
+                                         'full_genotype'
+
     def test_reporter_line(self):
         """Test that reporter line properly parsed from list"""
         reporter_line = ReporterLine.parse(reporter_line=['foo'])


### PR DESCRIPTION
This addresses #2304. @matchings was unable to get the experiments_table from LIMS because there are donors in LIMS with full_genotype==NULL.
