### PR TITLE
ticket/nnnn/sync/stim/aligner

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -7,7 +7,7 @@ import pytz
 
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import \
     JsonReadableInterface, NwbReadableInterface, \
     LimsReadableInterface
@@ -98,7 +98,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
         behavior_session_id = BehaviorSessionId.from_json(
             dict_repr=session_data)
-        stimulus_file = StimulusFile.from_json(dict_repr=session_data)
+        stimulus_file = BehaviorStimulusFile.from_json(dict_repr=session_data)
         stimulus_timestamps = StimulusTimestamps.from_json(
             dict_repr=session_data)
         running_acquisition = RunningAcquisition.from_json(
@@ -174,7 +174,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             monitor_delay = cls._get_monitor_delay()
 
         behavior_session_id = BehaviorSessionId(behavior_session_id)
-        stimulus_file = StimulusFile.from_lims(
+        stimulus_file = BehaviorStimulusFile.from_lims(
             db=lims_db, behavior_session_id=behavior_session_id.value)
         if stimulus_timestamps is None:
             stimulus_timestamps = StimulusTimestamps.from_stimulus_file(
@@ -878,7 +878,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
     @classmethod
     def _read_data_from_stimulus_file(
-            cls, stimulus_file: StimulusFile,
+            cls, stimulus_file: BehaviorStimulusFile,
             stimulus_timestamps: StimulusTimestamps):
         """Helper method to read data from stimulus file"""
         licks = Licks.from_stimulus_file(

--- a/allensdk/brain_observatory/behavior/data_files/__init__.py
+++ b/allensdk/brain_observatory/behavior/data_files/__init__.py
@@ -1,2 +1,6 @@
-from allensdk.brain_observatory.behavior.data_files.stimulus_file import BehaviorStimulusFile  # noqa E501, F401
+from allensdk.brain_observatory.behavior.data_files.stimulus_file import (  # noqa F401
+    BehaviorStimulusFile,
+    ReplayStimulusFile,
+    MappingStimulusFile)
+
 from allensdk.brain_observatory.behavior.data_files.sync_file import SyncFile  # noqa E501, F401

--- a/allensdk/brain_observatory/behavior/data_files/__init__.py
+++ b/allensdk/brain_observatory/behavior/data_files/__init__.py
@@ -1,2 +1,2 @@
-from allensdk.brain_observatory.behavior.data_files.stimulus_file import StimulusFile  # noqa E501, F401
+from allensdk.brain_observatory.behavior.data_files.stimulus_file import BehaviorStimulusFile  # noqa E501, F401
 from allensdk.brain_observatory.behavior.data_files.sync_file import SyncFile  # noqa E501, F401

--- a/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
@@ -37,7 +37,7 @@ def from_lims_cache_key(cls, db, behavior_session_id: int):
     return hashkey(behavior_session_id)
 
 
-class StimulusFile(DataFile):
+class BehaviorStimulusFile(DataFile):
     """A DataFile which contains methods for accessing and loading visual
     behavior stimulus *.pkl files.
 
@@ -80,7 +80,9 @@ class StimulusFileReadableInterface(abc.ABC):
     """Marks a data object as readable from stimulus file"""
     @classmethod
     @abc.abstractmethod
-    def from_stimulus_file(cls, stimulus_file: StimulusFile) -> "DataObject":
+    def from_stimulus_file(
+            cls,
+            stimulus_file: BehaviorStimulusFile) -> "DataObject":
         """Populate a DataObject from the stimulus file
 
         Returns

--- a/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
@@ -14,7 +14,7 @@ from allensdk.internal.core import DataFile
 from allensdk.core import DataObject
 
 # Query returns path to StimulusPickle file for given behavior session
-STIMULUS_FILE_QUERY_TEMPLATE = """
+BEHAVIOR_STIMULUS_FILE_QUERY_TEMPLATE = """
     SELECT
         wkf.storage_directory || wkf.filename AS stim_file
     FROM
@@ -37,7 +37,45 @@ def from_lims_cache_key(cls, db, behavior_session_id: int):
     return hashkey(behavior_session_id)
 
 
-class BehaviorStimulusFile(DataFile):
+class _NumFramesMixin(object):
+    """
+    Mixin to implement num_frames for a generic (i.e. non-behavior)
+    StimulusFile
+    """
+
+    def _validate_frame_data(self) -> None:
+        """
+        Check that self.data['intervalsms'] is present and
+        that self.data['items']['behavior']['intervalsms'] is empty
+        """
+        msg = ""
+        if 'intervalsms' not in self.data:
+            msg += "self.data['intervalsms'] not present\n"
+        if "items" in self.data:
+            if "behavior" in self.data["items"]:
+                if "intervalsms" in self.data["items"]["behavior"]:
+                    val = self.data["items"]["behavior"]["intervalsms"]
+                    if len(val) > 0:
+                        msg += ("len(self.data['items']['behavior']"
+                                f"['intervalsms'] == {len(val)}; "
+                                "expected zero\n")
+        if len(msg) > 0:
+            full_msg = f"When getting num_frames from {type(self)}\n"
+            full_msg += msg
+            full_msg += f"\nfilepath: {self.filepath}"
+            raise RuntimeError(full_msg)
+
+        return None
+
+    def num_frames(self) -> int:
+        """
+        Return the number of frames associated with this StimulusFile
+        """
+        self._validate_frame_data()
+        return len(self.data['intervalsms']) + 1
+
+
+class _StimulusFile(DataFile):
     """A DataFile which contains methods for accessing and loading visual
     behavior stimulus *.pkl files.
 
@@ -46,34 +84,110 @@ class BehaviorStimulusFile(DataFile):
     trials, and timing for all of the above.
     """
 
+    @classmethod
+    def file_path_key(cls) -> str:
+        """
+        The key in the dict_repr that maps to the path
+        to this StimulusFile's pickle file on disk.
+        """
+        raise NotImplementedError()
+
     def __init__(self, filepath: Union[str, Path]):
         super().__init__(filepath=filepath)
 
     @classmethod
     @cached(cache=LRUCache(maxsize=10), key=from_json_cache_key)
-    def from_json(cls, dict_repr: dict) -> "StimulusFile":
-        filepath = dict_repr["behavior_stimulus_file"]
+    def from_json(cls, dict_repr: dict) -> "_StimulusFile":
+        filepath = dict_repr[cls.file_path_key()]
         return cls(filepath=filepath)
 
     def to_json(self) -> Dict[str, str]:
-        return {"behavior_stimulus_file": str(self.filepath)}
+        return {self.file_path_key(): str(self.filepath)}
 
     @classmethod
     @cached(cache=LRUCache(maxsize=10), key=from_lims_cache_key)
     def from_lims(
         cls, db: PostgresQueryMixin,
         behavior_session_id: Union[int, str]
-    ) -> "StimulusFile":
-        query = STIMULUS_FILE_QUERY_TEMPLATE.format(
-            behavior_session_id=behavior_session_id
-        )
-        filepath = db.fetchone(query, strict=True)
-        return cls(filepath=filepath)
+    ) -> "_StimulusFile":
+        raise NotImplementedError()
 
     @staticmethod
     def load_data(filepath: Union[str, Path]) -> dict:
         filepath = safe_system_path(file_name=filepath)
         return pd.read_pickle(filepath)
+
+    def num_frames(self) -> int:
+        """
+        Return the number of frames associated with this StimulusFile
+        """
+        raise NotImplementedError()
+
+
+class BehaviorStimulusFile(_StimulusFile):
+
+    @classmethod
+    def file_path_key(cls) -> str:
+        return "behavior_stimulus_file"
+
+    @classmethod
+    @cached(cache=LRUCache(maxsize=10), key=from_lims_cache_key)
+    def from_lims(
+        cls, db: PostgresQueryMixin,
+        behavior_session_id: Union[int, str]
+    ) -> "BehaviorStimulusFile":
+        query = BEHAVIOR_STIMULUS_FILE_QUERY_TEMPLATE.format(
+            behavior_session_id=behavior_session_id
+        )
+        filepath = db.fetchone(query, strict=True)
+        return cls(filepath=filepath)
+
+    def _validate_frame_data(self):
+        """
+        Make sure that self.data['intervalsms'] does not exist and that
+        self.data['items']['behavior']['intervalsms'] does exist.
+        """
+        msg = ""
+        if "intervalsms" in self.data:
+            msg += "self.data['intervalsms'] present; did not expect that\n"
+        if "items" not in self.data:
+            msg += "self.data['items'] not present\n"
+        else:
+            if "behavior" not in self.data["items"]:
+                msg += "self.data['items']['behavior'] not present\n"
+            else:
+                if "intervalsms" not in self.data["items"]["behavior"]:
+                    msg += ("self.data['items']['behavior']['intervalsms'] "
+                            "not present\n")
+
+        if len(msg) > 0:
+            full_msg = f"When getting num_frames from {type(self)}\n"
+            full_msg += msg
+            full_msg += f"\nfilepath: {self.filepath}"
+            raise RuntimeError(full_msg)
+
+        return None
+
+    def num_frames(self) -> int:
+        """
+        Return the number of frames associated with this StimulusFile
+        """
+        self._validate_frame_data()
+        return len(self.data['items']['behavior']['intervalsms']) + 1
+
+
+class ReplayStimulusFile(_NumFramesMixin, _StimulusFile):
+
+    @classmethod
+    def file_path_key(cls) -> str:
+        return "replay_stimulus_file"
+
+
+class MappingStimulusFile(_NumFramesMixin, _StimulusFile):
+
+    @classmethod
+    def file_path_key(cls) -> str:
+        return "mapping_stimulus_file"
 
 
 class StimulusFileReadableInterface(abc.ABC):

--- a/allensdk/brain_observatory/behavior/data_objects/licks.py
+++ b/allensdk/brain_observatory/behavior/data_objects/licks.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pandas as pd
 from pynwb import NWBFile, TimeSeries, ProcessingModule
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.core import \
@@ -31,7 +31,7 @@ class Licks(DataObject, StimulusFileReadableInterface, NwbReadableInterface,
         super().__init__(name='licks', value=licks)
 
     @classmethod
-    def from_stimulus_file(cls, stimulus_file: StimulusFile,
+    def from_stimulus_file(cls, stimulus_file: BehaviorStimulusFile,
                            stimulus_timestamps: StimulusTimestamps) -> "Licks":
         """Get lick data from pkl file.
         This function assumes that the first sensor in the list of

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_metadata.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_metadata.py
@@ -4,7 +4,7 @@ import re
 import numpy as np
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 
 from allensdk.brain_observatory.behavior.data_objects import BehaviorSessionId
@@ -208,7 +208,7 @@ class BehaviorMetadata(DataObject, LimsReadableInterface,
         equipment = Equipment.from_lims(
             behavior_session_id=behavior_session_id.value, lims_db=lims_db)
 
-        stimulus_file = StimulusFile.from_lims(
+        stimulus_file = BehaviorStimulusFile.from_lims(
             db=lims_db, behavior_session_id=behavior_session_id.value)
         stimulus_frame_rate = StimulusFrameRate.from_stimulus_file(
             stimulus_file=stimulus_file)
@@ -238,7 +238,7 @@ class BehaviorMetadata(DataObject, LimsReadableInterface,
         behavior_session_id = BehaviorSessionId.from_json(dict_repr=dict_repr)
         equipment = Equipment.from_json(dict_repr=dict_repr)
 
-        stimulus_file = StimulusFile.from_json(dict_repr=dict_repr)
+        stimulus_file = BehaviorStimulusFile.from_json(dict_repr=dict_repr)
         stimulus_frame_rate = StimulusFrameRate.from_stimulus_file(
             stimulus_file=stimulus_file)
         session_type = SessionType.from_stimulus_file(

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_session_uuid.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_session_uuid.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
     NwbReadableInterface
@@ -20,7 +20,8 @@ class BehaviorSessionUUID(DataObject, StimulusFileReadableInterface,
 
     @classmethod
     def from_stimulus_file(
-            cls, stimulus_file: StimulusFile) -> "BehaviorSessionUUID":
+            cls,
+            stimulus_file: BehaviorStimulusFile) -> "BehaviorSessionUUID":
         id = stimulus_file.data.get('session_uuid')
         if id:
             id = uuid.UUID(id)
@@ -34,7 +35,7 @@ class BehaviorSessionUUID(DataObject, StimulusFileReadableInterface,
 
     def validate(self, behavior_session_id: int,
                  foraging_id: int,
-                 stimulus_file: StimulusFile) -> "BehaviorSessionUUID":
+                 stimulus_file: BehaviorStimulusFile) -> "BehaviorSessionUUID":
         """
         Sanity check to ensure that pkl file data matches up with
         the behavior session that the pkl file has been associated with.

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/date_of_acquisition.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/date_of_acquisition.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytz
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
     JsonReadableInterface, LimsReadableInterface, NwbReadableInterface
@@ -48,7 +48,7 @@ class DateOfAcquisition(DataObject, LimsReadableInterface,
     def from_nwb(cls, nwbfile: NWBFile) -> "DateOfAcquisition":
         return cls(date_of_acquisition=nwbfile.session_start_time)
 
-    def validate(self, stimulus_file: StimulusFile,
+    def validate(self, stimulus_file: BehaviorStimulusFile,
                  behavior_session_id: int) -> "DateOfAcquisition":
         """raise a warning if the date differs too much from the
         datetime obtained from the behavior stimulus (*.pkl) file."""

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/session_type.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/session_type.py
@@ -1,6 +1,6 @@
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
     NwbReadableInterface
@@ -17,7 +17,7 @@ class SessionType(DataObject, StimulusFileReadableInterface,
     @classmethod
     def from_stimulus_file(
             cls,
-            stimulus_file: StimulusFile) -> "SessionType":
+            stimulus_file: BehaviorStimulusFile) -> "SessionType":
         try:
             stimulus_name = \
                 stimulus_file.data["items"]["behavior"]["cl_params"]["stage"]

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/stimulus_frame_rate.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/stimulus_frame_rate.py
@@ -1,6 +1,6 @@
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
     NwbReadableInterface
@@ -22,7 +22,7 @@ class StimulusFrameRate(DataObject, StimulusFileReadableInterface,
     @classmethod
     def from_stimulus_file(
             cls,
-            stimulus_file: StimulusFile) -> "StimulusFrameRate":
+            stimulus_file: BehaviorStimulusFile) -> "StimulusFrameRate":
 
         # in this data object, we only care about the difference between
         # timestamps, so we can set the monitor_delay to any

--- a/allensdk/brain_observatory/behavior/data_objects/rewards.py
+++ b/allensdk/brain_observatory/behavior/data_objects/rewards.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pandas as pd
 from pynwb import NWBFile, TimeSeries, ProcessingModule
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.core import \
@@ -21,7 +21,7 @@ class Rewards(DataObject, StimulusFileReadableInterface, NwbReadableInterface,
 
     @classmethod
     def from_stimulus_file(
-            cls, stimulus_file: StimulusFile,
+            cls, stimulus_file: BehaviorStimulusFile,
             stimulus_timestamps: StimulusTimestamps) -> "Rewards":
         """Get reward data from pkl file, based on timestamps
         (not sync file).

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
@@ -18,7 +18,7 @@ from allensdk.internal.api import PostgresQueryMixin
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_files import (
-    StimulusFile
+    BehaviorStimulusFile
 )
 from allensdk.brain_observatory.behavior.data_objects.running_speed.running_processing import (  # noqa: E501
     get_running_df
@@ -66,7 +66,7 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
     def __init__(
         self,
         running_acquisition: pd.DataFrame,
-        stimulus_file: Optional[StimulusFile] = None,
+        stimulus_file: Optional[BehaviorStimulusFile] = None,
         stimulus_timestamps: Optional[StimulusTimestamps] = None,
     ):
         super().__init__(name="running_acquisition", value=running_acquisition)
@@ -79,7 +79,7 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
         cls,
         dict_repr: dict,
     ) -> "RunningAcquisition":
-        stimulus_file = StimulusFile.from_json(dict_repr)
+        stimulus_file = BehaviorStimulusFile.from_json(dict_repr)
 
         stimulus_timestamps = StimulusTimestamps.from_json(
                 dict_repr=dict_repr)
@@ -111,8 +111,9 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
         if self._stimulus_file is None or self._stimulus_timestamps is None:
             raise RuntimeError(
                 "RunningAcquisition DataObject lacks information about the "
-                "StimulusFile or StimulusTimestamps. This is likely due to "
-                "instantiating from NWB which prevents to_json() functionality"
+                "BehaviorStimulusFile or StimulusTimestamps. This is likely "
+                "due to instantiating from NWB which prevents to_json() "
+                "functionality"
             )
         output_dict = dict()
         output_dict.update(self._stimulus_file.to_json())
@@ -129,7 +130,7 @@ class RunningAcquisition(DataObject, LimsReadableInterface,
         ophys_experiment_id: Optional[int] = None,
     ) -> "RunningAcquisition":
 
-        stimulus_file = StimulusFile.from_lims(db, behavior_session_id)
+        stimulus_file = BehaviorStimulusFile.from_lims(db, behavior_session_id)
 
         stimulus_timestamps = StimulusTimestamps.from_stimulus_file(
                 stimulus_file=stimulus_file,

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_speed.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_speed.py
@@ -14,7 +14,7 @@ from allensdk.internal.api import PostgresQueryMixin
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_files import (
-    StimulusFile
+    BehaviorStimulusFile
 )
 from allensdk.brain_observatory.behavior.data_objects.running_speed.running_processing import (  # noqa: E501
     get_running_df
@@ -37,7 +37,7 @@ class RunningSpeed(DataObject, LimsReadableInterface, NwbReadableInterface,
     def __init__(
         self,
         running_speed: pd.DataFrame,
-        stimulus_file: Optional[StimulusFile] = None,
+        stimulus_file: Optional[BehaviorStimulusFile] = None,
         stimulus_timestamps: Optional[StimulusTimestamps] = None,
         filtered: bool = True
     ):
@@ -48,7 +48,7 @@ class RunningSpeed(DataObject, LimsReadableInterface, NwbReadableInterface,
 
     @staticmethod
     def _get_running_speed_df(
-        stimulus_file: StimulusFile,
+        stimulus_file: BehaviorStimulusFile,
         stimulus_timestamps: StimulusTimestamps,
         filtered: bool = True,
         zscore_threshold: float = 1.0
@@ -75,7 +75,7 @@ class RunningSpeed(DataObject, LimsReadableInterface, NwbReadableInterface,
         filtered: bool = True,
         zscore_threshold: float = 10.0
     ) -> "RunningSpeed":
-        stimulus_file = StimulusFile.from_json(dict_repr)
+        stimulus_file = BehaviorStimulusFile.from_json(dict_repr)
         stimulus_timestamps = StimulusTimestamps.from_json(dict_repr)
 
         running_speed = cls._get_running_speed_df(
@@ -91,8 +91,9 @@ class RunningSpeed(DataObject, LimsReadableInterface, NwbReadableInterface,
         if self._stimulus_file is None or self._stimulus_timestamps is None:
             raise RuntimeError(
                 "RunningSpeed DataObject lacks information about the "
-                "StimulusFile or StimulusTimestamps. This is likely due to "
-                "instantiating from NWB which prevents to_json() functionality"
+                "BehaviorStimulusFile or StimulusTimestamps. This is "
+                "likely due to instantiating from NWB which prevents "
+                "to_json() functionality"
             )
         output_dict = dict()
         output_dict.update(self._stimulus_file.to_json())
@@ -109,7 +110,9 @@ class RunningSpeed(DataObject, LimsReadableInterface, NwbReadableInterface,
         stimulus_timestamps: Optional[StimulusTimestamps] = None,
         monitor_delay: Optional[float] = None,
     ) -> "RunningSpeed":
-        stimulus_file = StimulusFile.from_lims(db, behavior_session_id)
+        stimulus_file = BehaviorStimulusFile.from_lims(
+                                db,
+                                behavior_session_id)
         if stimulus_timestamps is None:
             if monitor_delay is None:
                 raise RuntimeError("Must specify monitor delay "

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 import pandas as pd
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.core import \
@@ -84,7 +84,7 @@ class Presentations(DataObject, StimulusFileReadableInterface,
 
     @classmethod
     def from_stimulus_file(
-            cls, stimulus_file: StimulusFile,
+            cls, stimulus_file: BehaviorStimulusFile,
             stimulus_timestamps: StimulusTimestamps,
             limit_to_images: Optional[List] = None) -> "Presentations":
         """Get stimulus presentation data.

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/stimuli.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/stimuli.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.core import \
@@ -42,7 +42,7 @@ class Stimuli(DataObject, StimulusFileReadableInterface,
 
     @classmethod
     def from_stimulus_file(
-            cls, stimulus_file: StimulusFile,
+            cls, stimulus_file: BehaviorStimulusFile,
             stimulus_timestamps: StimulusTimestamps,
             limit_to_images: Optional[List] = None) -> "Stimuli":
         p = Presentations.from_stimulus_file(

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/templates.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/templates.py
@@ -6,7 +6,7 @@ import imageio
 from pynwb import NWBFile
 
 from allensdk.brain_observatory import nwb
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
     NwbReadableInterface
@@ -35,7 +35,7 @@ class Templates(DataObject, StimulusFileReadableInterface,
 
     @classmethod
     def from_stimulus_file(
-            cls, stimulus_file: StimulusFile,
+            cls, stimulus_file: BehaviorStimulusFile,
             limit_to_images: Optional[List] = None) -> "Templates":
         """Get stimulus templates (movies, scenes) for behavior session."""
 

--- a/allensdk/brain_observatory/behavior/data_objects/task_parameters.py
+++ b/allensdk/brain_observatory/behavior/data_objects/task_parameters.py
@@ -4,7 +4,7 @@ from typing import List
 
 from pynwb import NWBFile
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
     NwbReadableInterface
@@ -132,8 +132,9 @@ class TaskParameters(DataObject, StimulusFileReadableInterface,
         return TaskParameters(**data)
 
     @classmethod
-    def from_stimulus_file(cls,
-                           stimulus_file: StimulusFile) -> "TaskParameters":
+    def from_stimulus_file(
+            cls,
+            stimulus_file: BehaviorStimulusFile) -> "TaskParameters":
         data = stimulus_file.data
 
         behavior = data["items"]["behavior"]
@@ -169,7 +170,8 @@ class TaskParameters(DataObject, StimulusFileReadableInterface,
         )
 
     @staticmethod
-    def _calculate_stimulus_duration(stimulus_file: StimulusFile) -> float:
+    def _calculate_stimulus_duration(
+            stimulus_file: BehaviorStimulusFile) -> float:
         data = stimulus_file.data
 
         behavior = data["items"]["behavior"]
@@ -210,7 +212,8 @@ class TaskParameters(DataObject, StimulusFileReadableInterface,
         return stim_duration
 
     @staticmethod
-    def _parse_task(stimulus_file: StimulusFile) -> TaskType:
+    def _parse_task(
+            stimulus_file: BehaviorStimulusFile) -> TaskType:
         data = stimulus_file.data
         config = data["items"]["behavior"]["config"]
 
@@ -224,7 +227,8 @@ class TaskParameters(DataObject, StimulusFileReadableInterface,
         return task
 
     @staticmethod
-    def _calculuate_n_stimulus_frames(stimulus_file: StimulusFile) -> int:
+    def _calculuate_n_stimulus_frames(
+            stimulus_file: BehaviorStimulusFile) -> int:
         data = stimulus_file.data
         behavior = data["items"]["behavior"]
 

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
@@ -12,7 +12,7 @@ from allensdk.brain_observatory.behavior.data_files.stimulus_file import \
     StimulusFileReadableInterface
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_files import (
-    StimulusFile, SyncFile
+    BehaviorStimulusFile, SyncFile
 )
 from allensdk.core import \
     JsonWritableInterface, NwbWritableInterface
@@ -39,7 +39,7 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
         self,
         timestamps: np.ndarray,
         monitor_delay: float,
-        stimulus_file: Optional[StimulusFile] = None,
+        stimulus_file: Optional[BehaviorStimulusFile] = None,
         sync_file: Optional[SyncFile] = None
     ):
         super().__init__(name="stimulus_timestamps",
@@ -51,7 +51,7 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
     @classmethod
     def from_stimulus_file(
             cls,
-            stimulus_file: StimulusFile,
+            stimulus_file: BehaviorStimulusFile,
             monitor_delay: float) -> "StimulusTimestamps":
         stimulus_timestamps = get_behavior_stimulus_timestamps(
             stimulus_pkl=stimulus_file.data
@@ -87,7 +87,7 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
                         sync_file=sync_file,
                         monitor_delay=dict_repr['monitor_delay'])
         else:
-            stim_file = StimulusFile.from_json(dict_repr=dict_repr)
+            stim_file = BehaviorStimulusFile.from_json(dict_repr=dict_repr)
             return cls.from_stimulus_file(
                         stimulus_file=stim_file,
                         monitor_delay=dict_repr['monitor_delay'])
@@ -99,7 +99,9 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
         behavior_session_id: int,
         ophys_experiment_id: Optional[int] = None
     ) -> "StimulusTimestamps":
-        stimulus_file = StimulusFile.from_lims(db, behavior_session_id)
+        stimulus_file = BehaviorStimulusFile.from_lims(
+                            db,
+                            behavior_session_id)
 
         if ophys_experiment_id:
             sync_file = SyncFile.from_lims(
@@ -114,8 +116,8 @@ class StimulusTimestamps(DataObject, StimulusFileReadableInterface,
         if self._stimulus_file is None:
             raise RuntimeError(
                 "StimulusTimestamps DataObject lacks information about the "
-                "StimulusFile. This is likely due to instantiating from NWB "
-                "which prevents to_json() functionality"
+                "BehaviorStimulusFile. This is likely due to instantiating "
+                "from NWB which prevents to_json() functionality"
             )
 
         output_dict = dict()

--- a/allensdk/brain_observatory/behavior/data_objects/trials/trial.py
+++ b/allensdk/brain_observatory/behavior/data_objects/trials/trial.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Any, Tuple
 import numpy as np
 
 from allensdk import one
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_objects.licks import Licks
 from allensdk.brain_observatory.behavior.data_objects.rewards import Rewards
@@ -11,7 +11,7 @@ from allensdk.brain_observatory.behavior.data_objects.rewards import Rewards
 
 class Trial:
     def __init__(self, trial: dict, start: float, end: float,
-                 behavior_stimulus_file: StimulusFile,
+                 behavior_stimulus_file: BehaviorStimulusFile,
                  index: int,
                  stimulus_timestamps: StimulusTimestamps,
                  licks: Licks, rewards: Rewards, stimuli: dict):
@@ -113,8 +113,9 @@ class Trial:
             reward_times)
 
     @staticmethod
-    def _calculate_trial_end(trial_end,
-                             behavior_stimulus_file: StimulusFile) -> int:
+    def _calculate_trial_end(
+            trial_end,
+            behavior_stimulus_file: BehaviorStimulusFile) -> int:
         if trial_end < 0:
             bhv = behavior_stimulus_file.data['items']['behavior']['items']
             if 'fingerprint' in bhv.keys():

--- a/allensdk/brain_observatory/behavior/data_objects/trials/trial_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/trials/trial_table.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pynwb import NWBFile
 
 from allensdk.brain_observatory import dict_to_indexed_array
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.core import \
@@ -61,7 +61,7 @@ class TrialTable(DataObject, StimulusFileReadableInterface,
         return TrialTable(trials=trials)
 
     @classmethod
-    def from_stimulus_file(cls, stimulus_file: StimulusFile,
+    def from_stimulus_file(cls, stimulus_file: BehaviorStimulusFile,
                            stimulus_timestamps: StimulusTimestamps,
                            licks: Licks,
                            rewards: Rewards

--- a/allensdk/brain_observatory/sync_stim_aligner.py
+++ b/allensdk/brain_observatory/sync_stim_aligner.py
@@ -353,7 +353,12 @@ def get_start_frames_from_stimulus_blocks(
     if not isinstance(stimulus_files, list):
         stimulus_files = [stimulus_files, ]
 
-    safe_sync_path = safe_system_path(file_name=sync_file)
+    if isinstance(sync_file, pathlib.Path):
+        str_path = str(sync_file.resolve().absolute())
+    else:
+        str_path = sync_file
+    safe_sync_path = safe_system_path(file_name=str_path)
+
     with sync_dataset.Dataset(safe_sync_path) as sync_data:
         raw_frame_times = frame_time_fn(
                             data=sync_data,

--- a/allensdk/brain_observatory/sync_stim_aligner.py
+++ b/allensdk/brain_observatory/sync_stim_aligner.py
@@ -1,0 +1,293 @@
+# Here we will define a class for aligning the timesteps in a sync
+# file with the frames listed in a stimulus pickle file.
+
+from typing import Tuple, Union, List
+import numpy as np
+import logging
+from allensdk.brain_observatory import sync_dataset
+
+
+def _choose_line(
+        data: sync_dataset.Dataset,
+        sync_lines: Union[str, Tuple[str]]) -> str:
+    """
+    Scan through sync_lines in order. Select the first one
+    that is present in the sync file. Raise an exception if
+    none are present.
+
+    Parameters
+    ----------
+    data: sync_dataset.Dataset
+
+    sync_lines: Union[str, Tuple[str]]
+
+    Returns
+    -------
+    chosen_line: str
+        The first line in sync_lines that is present in
+        the sync file.
+    """
+    if isinstance(sync_lines, str):
+        sync_lines = (sync_lines, )
+
+    chosen_line = None
+    for this_line in sync_lines:
+        if this_line in data.line_labels:
+            chosen_line = this_line
+            break
+
+    if chosen_line is None:
+        msg = ("Could not find one of "
+               f"{sync_lines} in sync dataset. "
+               f"available lines:\n{data.line_labels}")
+        raise RuntimeError(msg)
+
+    return chosen_line
+
+
+def _get_rising_times(
+        data: sync_dataset.Dataset,
+        sync_lines: Union[str, Tuple[str]]):
+    """
+    Get the timestamps, in seconds, associated with the rising
+    edges in a specific line in a sync file
+
+    Parameters
+    ----------
+    data: sync_dataset.Dataset
+
+    sync_lines: Union[str, Tuple[str]]
+        The line to look for in the sync file.
+        If a str, return the rising edges in that line.
+        If a Tuple, work through the tuple **in order** until
+        a line is found that is present in the sync file. That
+        is the line for which timestamps will be returned.
+
+    Returns
+    -------
+    timestamps: np.ndarray
+        The times, in seconds, associated with the rising edges
+        of the chosen line.
+    """
+    chosen_line = _choose_line(
+                        data=data,
+                        sync_lines=sync_lines)
+
+    timestamps = data.get_rising_edges(
+                        line=chosen_line,
+                        units='seconds')
+
+    return timestamps
+
+
+def _get_falling_times(
+        data: sync_dataset.Dataset,
+        sync_lines: Union[str, Tuple[str]]):
+    """
+    Get the timestamps, in seconds, associated with the falling
+    edges in a specific line in a sync file.
+
+    Note: only falling edges that occur after rising edges are
+    returned. This is a quality control measure.
+
+    Parameters
+    ----------
+    data: sync_dataset.Dataset
+
+    sync_lines: Union[str, Tuple[str]]
+        The line to look for in the sync file.
+        If a str, return the falling edges in that line.
+        If a Tuple, work through the tuple **in order** until
+        a line is found that is present in the sync file. That
+        is the line for which timestamps will be returned.
+
+    Returns
+    -------
+    timestamps: np.ndarray
+        The times, in seconds, associated with the rising edges
+        of the chosen line.
+    """
+
+    chosen_line = _choose_line(
+                        data=data,
+                        sync_lines=sync_lines)
+
+    rising_edges = data.get_rising_edges(
+                        line=chosen_line,
+                        units='seconds')
+
+    falling_edges = data.get_falling_edges(
+                        line=chosen_line,
+                        units='seconds')
+
+    valid = (falling_edges > rising_edges[0])
+    return falling_edges[valid]
+
+
+def _get_line_starts_and_ends(
+        data: sync_dataset.Dataset,
+        sync_lines: Union[str, Tuple[str]]) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Parameters
+    ----------
+    data: sync_dataset.Dataset
+
+    sync_lines: Union[str, Tuple[str]]
+        The line to look for in the sync file.
+        If a str, return the falling edges in that line.
+        If a Tuple, work through the tuple **in order** until
+        a line is found that is present in the sync file. That
+        is the line for which timestamps will be returned.
+
+    Returns
+    -------
+    (start_times, end_times): Tuple[np.ndarray, np.ndarray]
+        np.ndarrays of times (in seconds) that the given
+        line turns on (rises) and turns off (falls).
+    """
+    start_times = _get_rising_times(
+                        data=data,
+                        sync_lines=sync_lines)
+
+    end_times = _get_falling_times(
+                        data=data,
+                        sync_lines=sync_lines)
+
+    return (start_times, end_times)
+
+
+def _get_start_frames(
+        data: sync_dataset.Dataset,
+        raw_frame_times: np.ndarray,
+        stimulus_frame_counts: List[int],
+        tolerance: float) -> List[int]:
+    """
+    Find the start frames for a series of stimuli that need to be
+    registered to a single sync file.
+
+    Parameters
+    ----------
+    data: sync_dataset.Dataset
+        A representation of the sync file being registered
+    raw_frame_times: np.ndarray
+        The timestamps (in seconds) of the events being registered
+    stimulus_frame_counts: List[int]
+        The number of events occuring during each stimulus
+        as read from the pickle file, **in the order** that
+        the stimuli were run.
+    tolerance: float
+        The tolerance within which the length of an epoch
+        and an element of stimulus_frame_counts will be
+        considered the same.
+
+    Returns
+    -------
+    start_frames: List[int]
+        The global index of the starting frames associated with the
+        stimuli represented by stimulus_frame_counts
+
+    Notes
+    -----
+    Ideally, the vsync_stim line in the sync file represents when
+    frames from a stimulus are presented to the mouse. Unfortunately,
+    they do not carry any information about which stimulus block
+    the frames correspond to (behavior, mapping, or replay in a fiducial
+    VBN session). The stim_running line, however, can be used to find
+    the dividing times between the three stimulus presentations.
+    stim_running is high when a stimulus block is being presented
+    and low when it is not. What this method does is:
+
+    1) Take a list of raw frame times as input (probably the falling
+    edges of the vsync_stim line, but possibly the rising edges,
+    depending on our use case)
+
+    2) Find the timestamps associated with the rising and falling
+    edges of stim_running. These are taken to be the breaks between
+    stimulus blocks.
+
+    3) Divide the raw frame times into blocks that fall between the
+    stimulus block start/end times from (2).
+
+    4) Try to match the blocks of frame times against the expected
+    number of frames in each block as specified in stimulus_frame_counts.
+
+    See discussion here
+    http://confluence.corp.alleninstitute.org/pages/viewpage.action?spaceKey=IT&title=Addressing+variable+monitor+lag+in+sync+data+for+Visual+Behavior+Neuropixels
+
+    This is a modified copy of a method originally implemented in
+    ecephys_etl_pipelines/.../vbn_create_stimulus_table/create_stim_table.py
+    The purpose of the modified copy is to allow us to use rising *or* falling
+    edges as raw_stim_times, depending on the use case.
+    """
+
+    frame_count_arr = np.array(stimulus_frame_counts)
+
+    stim_starts, stim_ends = _get_line_starts_and_ends(
+                                   data=data,
+                                   sync_lines=('stim_running', 'sweep'))
+
+    # break raw_frame_times into epochs based on stim_starts and stim_ends
+    epoch_frame_counts = []
+    epoch_start_frames = []
+    for start, end in zip(stim_starts, stim_ends):
+        # Inner expression returns a bool array where conditions are True
+        # np.where evaluates bool array to return indices where bool array True
+        epoch_frames = np.where((raw_frame_times >= start)
+                                & (raw_frame_times < end))[0]
+        epoch_frame_counts.append(len(epoch_frames))
+        epoch_start_frames.append(epoch_frames[0])
+
+    if len(epoch_frame_counts) == len(frame_count_arr):
+        # There is a 1:1 mapping between the epochs found by sub-dividing
+        # the stim_running line and the stimulus blocks expected based on
+        # the stimulus pickle files.
+
+        if not np.allclose(frame_count_arr, epoch_frame_counts):
+            logging.warning(
+                f"Number of frames derived from sync file "
+                f"({epoch_frame_counts})for each epoch not matching up with "
+                f"frame counts derived from pkl files ({frame_count_arr})!"
+            )
+        start_frames = epoch_start_frames
+    elif len(epoch_frame_counts) > len(frame_count_arr):
+        # There were, for some reason, more epochs found by sub-dividing the
+        # stim_running line than there were expected based on the stimulus
+        # pickle files.
+
+        logging.warning(
+            f"Number of stim presentations obtained from sync "
+            f"({len(epoch_frame_counts)}) higher than number expected "
+            f"({len(frame_count_arr)}). Inferring start frames."
+        )
+
+        start_frames = []
+        for stim_idx, fc in enumerate(frame_count_arr):
+
+            logging.info(f"Finding stim start for stim with index: {stim_idx}")
+            # Get index of stimulus whose frame counts most closely match
+            # the expected number of frames
+            best_match = int(
+                np.argmin([np.abs(efc - fc) for efc in epoch_frame_counts])
+            )
+            lower_tol = fc * (1.0 - tolerance)
+            upper_tol = fc * (1.0 + tolerance)
+            if lower_tol <= epoch_frame_counts[best_match] <= upper_tol:
+                _ = epoch_frame_counts.pop(best_match)
+                start_frame = epoch_start_frames.pop(best_match)
+                start_frames.append(start_frame)
+                logging.info(
+                    f"Found stim start for stim with index ({stim_idx})"
+                    f"at vsync ({start_frame})"
+                )
+            else:
+                raise RuntimeError(
+                    f"Could not find matching sync frames for stim: {stim_idx}"
+                )
+    else:
+        raise RuntimeError(
+            f"Do not know how to handle more pkl frame count entries "
+            f"({frame_count_arr}) than sync derived epoch frame count "
+            f"entries ({epoch_frame_counts})!"
+        )
+
+    return start_frames

--- a/allensdk/test/brain_observatory/behavior/data_files/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/data_files/conftest.py
@@ -24,8 +24,11 @@ def behavior_pkl_fixture(
     pd.to_pickle(result, pkl_path)
     yield {'path': pkl_path, 'expected_frames': nframes}
 
-    if pkl_path.exists():
-        pkl_path.unlink()
+    try:
+        if pkl_path.exists():
+            pkl_path.unlink()
+    except PermissionError:
+        pass
 
 
 @pytest.fixture
@@ -46,5 +49,8 @@ def general_pkl_fixture(
     pd.to_pickle(result, pkl_path)
     yield {'path': pkl_path, 'expected_frames': nframes}
 
-    if pkl_path.exists():
-        pkl_path.unlink()
+    try:
+        if pkl_path.exists():
+            pkl_path.unlink()
+    except PermissionError:
+        pass

--- a/allensdk/test/brain_observatory/behavior/data_files/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/data_files/conftest.py
@@ -1,0 +1,50 @@
+import pytest
+import pathlib
+import tempfile
+import pandas as pd
+
+
+@pytest.fixture
+def behavior_pkl_fixture(
+        tmp_path_factory):
+    """
+    Write a behavior pkl file to disk.
+    Return a dict containing the path to that file, as well as the
+    expected number of frames associated with the pickle file.
+    """
+    tmpdir = tmp_path_factory.mktemp('behavior_pkl')
+    pkl_path = pathlib.Path(
+                   tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    nframes = 17
+    result = {'items':
+              {'behavior':
+               {'intervalsms': list(range(nframes-1))}}}
+
+    pd.to_pickle(result, pkl_path)
+    yield {'path': pkl_path, 'expected_frames': nframes}
+
+    if pkl_path.exists():
+        pkl_path.unlink()
+
+
+@pytest.fixture
+def general_pkl_fixture(
+        tmp_path_factory):
+    """
+    Write a non-behavior stimulus pkl file to disk.
+    Return a dict containing the path to that file, as well as the
+    expected number of frames associated with the pickle file.
+    """
+    tmpdir = tmp_path_factory.mktemp('general_pkl')
+    pkl_path = pathlib.Path(
+                   tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    nframes = 19
+    result = {'intervalsms': list(range(nframes-1))}
+
+    pd.to_pickle(result, pkl_path)
+    yield {'path': pkl_path, 'expected_frames': nframes}
+
+    if pkl_path.exists():
+        pkl_path.unlink()

--- a/allensdk/test/brain_observatory/behavior/data_files/test_stimulus_file.py
+++ b/allensdk/test/brain_observatory/behavior/data_files/test_stimulus_file.py
@@ -6,7 +6,7 @@ from unittest.mock import create_autospec
 import pytest
 
 from allensdk.internal.api import PostgresQueryMixin
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
     STIMULUS_FILE_QUERY_TEMPLATE
 )
@@ -34,12 +34,12 @@ def test_stimulus_file_from_json(stimulus_file_fixture):
 
     # Basic test case
     input_json_dict = {"behavior_stimulus_file": str(stim_pkl_path)}
-    stimulus_file = StimulusFile.from_json(input_json_dict)
+    stimulus_file = BehaviorStimulusFile.from_json(input_json_dict)
     assert stimulus_file.data == stim_pkl_data
 
     # Now test caching by deleting the stimulus_file
     stim_pkl_path.unlink()
-    stimulus_file_cached = StimulusFile.from_json(input_json_dict)
+    stimulus_file_cached = BehaviorStimulusFile.from_json(input_json_dict)
     assert stimulus_file_cached.data == stim_pkl_data
 
 
@@ -54,13 +54,17 @@ def test_stimulus_file_from_lims(stimulus_file_fixture, behavior_session_id):
 
     # Basic test case
     mock_db_conn.fetchone.return_value = str(stim_pkl_path)
-    stimulus_file = StimulusFile.from_lims(mock_db_conn, behavior_session_id)
+    stimulus_file = BehaviorStimulusFile.from_lims(
+                           mock_db_conn,
+                           behavior_session_id)
     assert stimulus_file.data == stim_pkl_data
 
     # Now test caching by deleting stimulus_file and also asserting db
     # `fetchone` called only once
     stim_pkl_path.unlink()
-    stimfile_cached = StimulusFile.from_lims(mock_db_conn, behavior_session_id)
+    stimfile_cached = BehaviorStimulusFile.from_lims(
+                            mock_db_conn,
+                            behavior_session_id)
     assert stimfile_cached.data == stim_pkl_data
 
     query = STIMULUS_FILE_QUERY_TEMPLATE.format(
@@ -77,6 +81,6 @@ def test_stimulus_file_from_lims(stimulus_file_fixture, behavior_session_id):
 def test_stimulus_file_to_json(stimulus_file_fixture):
     stim_pkl_path, stim_pkl_data = stimulus_file_fixture
 
-    stimulus_file = StimulusFile(filepath=stim_pkl_path)
+    stimulus_file = BehaviorStimulusFile(filepath=stim_pkl_path)
     obt_json = stimulus_file.to_json()
     assert obt_json == {"behavior_stimulus_file": str(stim_pkl_path)}

--- a/allensdk/test/brain_observatory/behavior/data_files/test_stimulus_file.py
+++ b/allensdk/test/brain_observatory/behavior/data_files/test_stimulus_file.py
@@ -6,9 +6,13 @@ from unittest.mock import create_autospec
 import pytest
 
 from allensdk.internal.api import PostgresQueryMixin
-from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
+from allensdk.brain_observatory.behavior.data_files import (
+    BehaviorStimulusFile,
+    ReplayStimulusFile,
+    MappingStimulusFile)
+
 from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
-    STIMULUS_FILE_QUERY_TEMPLATE
+    BEHAVIOR_STIMULUS_FILE_QUERY_TEMPLATE
 )
 
 
@@ -67,7 +71,7 @@ def test_stimulus_file_from_lims(stimulus_file_fixture, behavior_session_id):
                             behavior_session_id)
     assert stimfile_cached.data == stim_pkl_data
 
-    query = STIMULUS_FILE_QUERY_TEMPLATE.format(
+    query = BEHAVIOR_STIMULUS_FILE_QUERY_TEMPLATE.format(
         behavior_session_id=behavior_session_id
     )
 
@@ -84,3 +88,106 @@ def test_stimulus_file_to_json(stimulus_file_fixture):
     stimulus_file = BehaviorStimulusFile(filepath=stim_pkl_path)
     obt_json = stimulus_file.to_json()
     assert obt_json == {"behavior_stimulus_file": str(stim_pkl_path)}
+
+
+@pytest.mark.parametrize(
+        "stimulus_class_name", ["replay", "mapping"]
+)
+def test_replay_mapping_round_trip(
+        general_pkl_fixture,
+        stimulus_class_name):
+    """
+    Test the round tripping of ReplayStimulusFile and MappingStimulusFile
+    """
+    if stimulus_class_name == "replay":
+        json_key = "replay_stimulus_file"
+        stimulus_class = ReplayStimulusFile
+    else:
+        json_key = "mapping_stimulus_file"
+        stimulus_class = MappingStimulusFile
+
+    str_path = str(general_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {json_key: str_path}
+    stim = stimulus_class.from_json(dict_repr=dict_repr)
+
+    new_dict_repr = stim.to_json()
+    new_stim = stimulus_class.from_json(dict_repr=new_dict_repr)
+    assert new_stim.data == stim.data
+
+
+def test_behavior_num_frames(
+        behavior_pkl_fixture):
+    """
+    Test that BehaviorStimulusFile.num_frames returns the
+    expected result
+    """
+    str_path = str(behavior_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {"behavior_stimulus_file": str_path}
+    beh_stim = BehaviorStimulusFile.from_json(dict_repr=dict_repr)
+    assert beh_stim.num_frames() == behavior_pkl_fixture['expected_frames']
+
+
+def test_replay_num_frames(
+        general_pkl_fixture):
+    """
+    Test that ReplayStimulusFile.num_frames returns the
+    expected result
+    """
+    str_path = str(general_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {"replay_stimulus_file": str_path}
+    rep_stim = ReplayStimulusFile.from_json(dict_repr=dict_repr)
+    assert rep_stim.num_frames() == general_pkl_fixture['expected_frames']
+
+
+def test_mapping_num_frames(
+        general_pkl_fixture):
+    """
+    Test that MappingStimulusFile.num_frames returns the
+    expected result
+    """
+    str_path = str(general_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {"mapping_stimulus_file": str_path}
+    map_stim = MappingStimulusFile.from_json(dict_repr=dict_repr)
+    assert map_stim.num_frames() == general_pkl_fixture['expected_frames']
+
+
+def test_malformed_behavior_pkl(
+        general_pkl_fixture):
+    """
+    Test that the correct error is raised when a behavior pickle file
+    is mal-formed
+    """
+    str_path = str(general_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {"behavior_stimulus_file": str_path}
+    stim = BehaviorStimulusFile.from_json(dict_repr=dict_repr)
+    with pytest.raises(RuntimeError,
+                       match="When getting num_frames from"):
+        stim.num_frames()
+
+
+def test_malformed_replay_pkl(
+        behavior_pkl_fixture):
+    """
+    Test that the correct error is raised when a replay pickle file
+    is mal-formed and num_frames is called
+    """
+    str_path = str(behavior_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {"replay_stimulus_file": str_path}
+    stim = ReplayStimulusFile.from_json(dict_repr=dict_repr)
+    with pytest.raises(RuntimeError,
+                       match="When getting num_frames from"):
+        stim.num_frames()
+
+
+def test_malformed_mapping_pkl(
+        behavior_pkl_fixture):
+    """
+    Test that the correct error is raised when a mapping pickle file
+    is mal-formed and num_frames is called
+    """
+    str_path = str(behavior_pkl_fixture['path'].resolve().absolute())
+    dict_repr = {"mapping_stimulus_file": str_path}
+    stim = MappingStimulusFile.from_json(dict_repr=dict_repr)
+    with pytest.raises(RuntimeError,
+                       match="When getting num_frames from"):  # noqa W605
+        stim.num_frames()

--- a/allensdk/test/brain_observatory/behavior/data_objects/metadata/behavior_metadata/test_behavior_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/metadata/behavior_metadata/test_behavior_metadata.py
@@ -8,7 +8,7 @@ import pytest
 import pytz
 from uuid import UUID
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects import BehaviorSessionId
 from allensdk.brain_observatory.behavior.data_objects.metadata \
     .behavior_metadata.behavior_metadata import \
@@ -225,7 +225,7 @@ class TestBehaviorMetadata(BehaviorMetaTestCase):
         extractor_expt_date = tz.localize(
             test_params['extractor_expt_date']).astimezone(pytz.utc)
 
-        stimulus_file = StimulusFile(filepath=pkl_save_path)
+        stimulus_file = BehaviorStimulusFile(filepath=pkl_save_path)
         obt_date = DateOfAcquisition(
             date_of_acquisition=extractor_expt_date)
 
@@ -262,13 +262,13 @@ class TestBehaviorMetadata(BehaviorMetaTestCase):
         assert str(record[0].message) == warning_msg
 
 
-class TestStimulusFile:
+class TestBehaviorStimulusFile:
     """Tests properties read from stimulus file"""
     def setup_class(cls):
         dir = Path(__file__).parent.parent.parent.resolve()
         test_data_dir = dir / 'test_data'
         sf_path = test_data_dir / 'stimulus_file.pkl'
-        cls.stimulus_file = StimulusFile.from_json(
+        cls.stimulus_file = BehaviorStimulusFile.from_json(
             dict_repr={'behavior_stimulus_file': str(sf_path)})
 
     def test_session_uuid(self):

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_acquisition.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_acquisition.py
@@ -4,7 +4,7 @@ from unittest.mock import create_autospec
 import pandas as pd
 
 from allensdk.internal.api import PostgresQueryMixin
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects.running_speed.running_processing import (  # noqa: E501
     get_running_df
 )
@@ -47,7 +47,7 @@ from allensdk.brain_observatory.behavior.data_objects import (
 def test_running_acquisition_from_json(
     monkeypatch, dict_repr, returned_running_acq_df, expected_running_acq_df
 ):
-    mock_stimulus_file = create_autospec(StimulusFile)
+    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
     mock_stimulus_timestamps = create_autospec(StimulusTimestamps)
     mock_get_running_df = create_autospec(get_running_df)
 
@@ -56,7 +56,7 @@ def test_running_acquisition_from_json(
     with monkeypatch.context() as m:
         m.setattr(
             "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_acquisition.StimulusFile",
+            ".running_speed.running_acquisition.BehaviorStimulusFile",
             mock_stimulus_file
         )
         m.setattr(
@@ -96,7 +96,7 @@ def test_running_acquisition_from_json(
         # Test to_json with both stimulus_file and sync_file
         (
             # stimulus_file
-            create_autospec(StimulusFile, instance=True),
+            create_autospec(BehaviorStimulusFile, instance=True),
             # stimulus_file_to_json_ret
             {"behavior_stimulus_file": "stim.pkl"},
             # stimulus_timestamps
@@ -126,7 +126,7 @@ def test_running_acquisition_from_json(
         # Test to_json without stimulus_timestamps
         (
             # stimulus_file
-            create_autospec(StimulusFile, instance=True),
+            create_autospec(BehaviorStimulusFile, instance=True),
             # stimulus_file_to_json_ret
             {"behavior_stimulus_file": "stim.pkl"},
             # stimulus_timestamps_to_json_ret
@@ -227,7 +227,7 @@ def test_running_acquisition_from_lims(
 ):
     mock_db_conn = create_autospec(PostgresQueryMixin, instance=True)
 
-    mock_stimulus_file = create_autospec(StimulusFile)
+    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
     mock_stimulus_timestamps = create_autospec(StimulusTimestamps)
     mock_get_running_df = create_autospec(get_running_df)
 
@@ -236,7 +236,7 @@ def test_running_acquisition_from_lims(
     with monkeypatch.context() as m:
         m.setattr(
             "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_acquisition.StimulusFile",
+            ".running_speed.running_acquisition.BehaviorStimulusFile",
             mock_stimulus_file
         )
         m.setattr(

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_speed.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_speed.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from allensdk.core.exceptions import DataFrameIndexError
 from allensdk.internal.api import PostgresQueryMixin
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects.running_speed.running_processing import (  # noqa: E501
     get_running_df
 )
@@ -50,7 +50,9 @@ def test_get_running_speed_df(
     expected_running_df, raises
 ):
 
-    mock_stimulus_file_instance = create_autospec(StimulusFile, instance=True)
+    mock_stimulus_file_instance = create_autospec(
+                                      BehaviorStimulusFile,
+                                      instance=True)
     mock_stimulus_timestamps_instance = create_autospec(
         StimulusTimestamps, instance=True
     )
@@ -113,7 +115,7 @@ def test_running_speed_from_json(
     monkeypatch, dict_repr, returned_running_df, expected_running_df,
     filtered, zscore_threshold
 ):
-    mock_stimulus_file = create_autospec(StimulusFile)
+    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
     mock_stimulus_timestamps = create_autospec(StimulusTimestamps)
     mock_get_running_speed_df = create_autospec(get_running_df)
 
@@ -122,7 +124,7 @@ def test_running_speed_from_json(
     with monkeypatch.context() as m:
         m.setattr(
             "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_speed.StimulusFile",
+            ".running_speed.running_speed.BehaviorStimulusFile",
             mock_stimulus_file
         )
         m.setattr(
@@ -165,7 +167,7 @@ def test_running_speed_from_json(
         # Test to_json with both stimulus_file and sync_file
         (
             # stimulus_file
-            create_autospec(StimulusFile, instance=True),
+            create_autospec(BehaviorStimulusFile, instance=True),
             # stimulus_file_to_json_ret
             {"behavior_stimulus_file": "stim.pkl"},
             # stimulus_timestamps
@@ -195,7 +197,7 @@ def test_running_speed_from_json(
         # Test to_json without stimulus_timestamps
         (
             # stimulus_file
-            create_autospec(StimulusFile, instance=True),
+            create_autospec(BehaviorStimulusFile, instance=True),
             # stimulus_file_to_json_ret
             {"behavior_stimulus_file": "stim.pkl"},
             # stimulus_timestamps_to_json_ret
@@ -268,7 +270,7 @@ def test_running_speed_from_lims(
 ):
     mock_db_conn = create_autospec(PostgresQueryMixin, instance=True)
 
-    mock_stimulus_file = create_autospec(StimulusFile)
+    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
     mock_stimulus_timestamps = create_autospec(StimulusTimestamps)
     mock_get_running_speed_df = create_autospec(get_running_df)
     mock_get_running_speed_df.return_value = returned_running_df
@@ -276,7 +278,7 @@ def test_running_speed_from_lims(
     with monkeypatch.context() as m:
         m.setattr(
             "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_speed.StimulusFile",
+            ".running_speed.running_speed.BehaviorStimulusFile",
             mock_stimulus_file
         )
         m.setattr(

--- a/allensdk/test/brain_observatory/behavior/data_objects/stimulus_timestamps/test_stimulus_timestamps.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/stimulus_timestamps/test_stimulus_timestamps.py
@@ -9,7 +9,7 @@ from itertools import product
 
 from allensdk.internal.api import PostgresQueryMixin
 from allensdk.brain_observatory.behavior.data_files import (
-    StimulusFile, SyncFile
+    BehaviorStimulusFile, SyncFile
 )
 from allensdk.brain_observatory.behavior.data_objects.timestamps\
     .stimulus_timestamps.timestamps_processing import (
@@ -45,7 +45,7 @@ from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 def test_stimulus_timestamps_from_json(
     monkeypatch, dict_repr, has_pkl, has_sync
 ):
-    mock_stimulus_file = create_autospec(StimulusFile)
+    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
     mock_sync_file = create_autospec(SyncFile)
 
     mock_get_behavior_stimulus_timestamps = create_autospec(
@@ -58,7 +58,8 @@ def test_stimulus_timestamps_from_json(
     with monkeypatch.context() as m:
         m.setattr(
             "allensdk.brain_observatory.behavior.data_objects"
-            ".timestamps.stimulus_timestamps.stimulus_timestamps.StimulusFile",
+            ".timestamps.stimulus_timestamps"
+            ".stimulus_timestamps.BehaviorStimulusFile",
             mock_stimulus_file
         )
         m.setattr(
@@ -107,7 +108,7 @@ def stimulus_file_fixture():
     test_data_dir = dir / 'test_data'
     sf_path = test_data_dir / 'stimulus_file.pkl'
 
-    return StimulusFile.from_json(
+    return BehaviorStimulusFile.from_json(
         dict_repr={'behavior_stimulus_file': str(sf_path)})
 
 
@@ -165,7 +166,7 @@ def test_stimulus_timestamps_from_json3(stimulus_file_fixture):
         # Test to_json with both stimulus_file and sync_file
         (
             # stimulus_file
-            create_autospec(StimulusFile, instance=True),
+            create_autospec(BehaviorStimulusFile, instance=True),
             # stimulus_file_to_json_ret
             {"behavior_stimulus_file": "stim.pkl"},
             # sync_file
@@ -181,7 +182,7 @@ def test_stimulus_timestamps_from_json3(stimulus_file_fixture):
         # Test to_json with only stimulus_file
         (
             # stimulus_file
-            create_autospec(StimulusFile, instance=True),
+            create_autospec(BehaviorStimulusFile, instance=True),
             # stimulus_file_to_json_ret
             {"behavior_stimulus_file": "stim.pkl"},
             # sync_file
@@ -250,7 +251,7 @@ def test_stimulus_timestamps_from_lims(
 ):
     mock_db_conn = create_autospec(PostgresQueryMixin, instance=True)
 
-    mock_stimulus_file = create_autospec(StimulusFile)
+    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
     mock_sync_file = create_autospec(SyncFile)
 
     mock_get_behavior_stimulus_timestamps = create_autospec(
@@ -263,7 +264,8 @@ def test_stimulus_timestamps_from_lims(
     with monkeypatch.context() as m:
         m.setattr(
             "allensdk.brain_observatory.behavior.data_objects"
-            ".timestamps.stimulus_timestamps.stimulus_timestamps.StimulusFile",
+            ".timestamps.stimulus_timestamps"
+            ".stimulus_timestamps.BehaviorStimulusFile",
             mock_stimulus_file
         )
         m.setattr(
@@ -355,7 +357,7 @@ def test_stimulus_timestamps_from_nwb_to_json(
     When writing StimulusTimestamps to_nwb, monitor delay is already
     folded into the timestamp values so that from_nwb reads the
     timestamps in and sets monitor_delay=0.0. from_json and to_json
-    depend on storing the StimulusFile and a non-zero monitor
+    depend on storing the BehaviorStimulusFile and a non-zero monitor
     delay. If we ever decide to make it possible to read a
     StimulusTimetamps from_nwb and then write it to_json, we will
     need to start writing the monitor_delay to the NWB file in a
@@ -368,5 +370,5 @@ def test_stimulus_timestamps_from_nwb_to_json(
     nwbfile = stimulus_timestamps.to_nwb(nwbfile)
     obt = StimulusTimestamps.from_nwb(nwbfile)
     with pytest.raises(RuntimeError,
-                       match="information about the StimulusFile"):
+                       match="information about the BehaviorStimulusFile"):
         obt.to_json()

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_licks.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_licks.py
@@ -6,18 +6,18 @@ import pandas as pd
 import pynwb
 import pytest
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_objects.licks import Licks
 
 
-class TestFromStimulusFile:
+class TestFromBehaviorStimulusFile:
     @classmethod
     def setup_class(cls):
         dir = Path(__file__).parent.resolve()
         test_data_dir = dir / 'test_data'
 
-        cls.stimulus_file = StimulusFile(
+        cls.stimulus_file = BehaviorStimulusFile(
             filepath=test_data_dir / 'behavior_stimulus_file.pkl')
         expected = pd.read_pickle(str(test_data_dir / 'licks.pkl'))
         cls.expected = Licks(licks=expected)
@@ -38,7 +38,7 @@ class TestFromStimulusFile:
         """
         stimulus_filepath = self._create_test_stimulus_file(
             lick_events=[12, 15, 90, 136], tmpdir=tmpdir)
-        stimulus_file = StimulusFile.from_json(
+        stimulus_file = BehaviorStimulusFile.from_json(
             dict_repr={'behavior_stimulus_file': str(stimulus_filepath)})
         timestamps = StimulusTimestamps(timestamps=np.arange(0, 2.0, 0.01),
                                         monitor_delay=0.0)
@@ -65,7 +65,7 @@ class TestFromStimulusFile:
 
         stimulus_filepath = self._create_test_stimulus_file(
             lick_events=[], tmpdir=tmpdir)
-        stimulus_file = StimulusFile.from_json(
+        stimulus_file = BehaviorStimulusFile.from_json(
             dict_repr={'behavior_stimulus_file': str(stimulus_filepath)})
         timestamps = StimulusTimestamps(timestamps=np.arange(0, 2.0, 0.01),
                                         monitor_delay=0.0)
@@ -94,7 +94,7 @@ class TestFromStimulusFile:
         stimulus_filepath = self._create_test_stimulus_file(
             lick_events=[12, 15, 90, 136, 200],  # len(timestamps) == 200,
             tmpdir=tmpdir)
-        stimulus_file = StimulusFile.from_json(
+        stimulus_file = BehaviorStimulusFile.from_json(
             dict_repr={'behavior_stimulus_file': str(stimulus_filepath)})
         timestamps = StimulusTimestamps(timestamps=np.arange(0, 2.0, 0.01),
                                         monitor_delay=0.0)
@@ -117,7 +117,7 @@ class TestFromStimulusFile:
         stimulus_filepath = self._create_test_stimulus_file(
             lick_events=[12, 15, 90, 136, 201],  # len(timestamps) == 200,
             tmpdir=tmpdir)
-        stimulus_file = StimulusFile.from_json(
+        stimulus_file = BehaviorStimulusFile.from_json(
             dict_repr={'behavior_stimulus_file': str(stimulus_filepath)})
         timestamps = StimulusTimestamps(timestamps=np.arange(0, 2.0, 0.01),
                                         monitor_delay=0.0)
@@ -158,7 +158,7 @@ class TestNWB:
         dir = Path(__file__).parent.resolve()
         test_data_dir = dir / 'test_data'
 
-        stimulus_file = StimulusFile(
+        stimulus_file = BehaviorStimulusFile(
             filepath=test_data_dir / 'behavior_stimulus_file.pkl')
         ts = StimulusTimestamps.from_stimulus_file(
             stimulus_file=stimulus_file,

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_rewards.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_rewards.py
@@ -6,14 +6,14 @@ import pandas as pd
 import pynwb
 import pytest
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_objects.rewards import Rewards
 from allensdk.test.brain_observatory.behavior.data_objects.lims_util import \
     LimsTest
 
 
-class TestFromStimulusFile(LimsTest):
+class TestFromBehaviorStimulusFile(LimsTest):
     @classmethod
     def setup_class(cls):
         cls.behavior_session_id = 994174745
@@ -26,7 +26,7 @@ class TestFromStimulusFile(LimsTest):
 
     @pytest.mark.requires_bamboo
     def test_from_stimulus_file(self):
-        stimulus_file = StimulusFile.from_lims(
+        stimulus_file = BehaviorStimulusFile.from_lims(
             behavior_session_id=self.behavior_session_id, db=self.dbconn)
         timestamps = StimulusTimestamps.from_stimulus_file(
             stimulus_file=stimulus_file,
@@ -66,7 +66,7 @@ class TestFromStimulusFile(LimsTest):
             return tmp_path
 
         stimulus_filepath = _create_dummy_stimulus_file()
-        stimulus_file = StimulusFile.from_json(
+        stimulus_file = BehaviorStimulusFile.from_json(
             dict_repr={'behavior_stimulus_file': str(stimulus_filepath)})
         timestamps = StimulusTimestamps(timestamps=np.arange(0, 2.0, 0.01),
                                         monitor_delay=0.0)

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pynwb
 import pytest
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_objects.stimuli.presentations \
     import \
@@ -19,7 +19,7 @@ from allensdk.test.brain_observatory.behavior.data_objects.lims_util import \
     LimsTest
 
 
-class TestFromStimulusFile(LimsTest):
+class TestFromBehaviorStimulusFile(LimsTest):
     @classmethod
     def setup_class(cls):
         cls.behavior_session_id = 994174745
@@ -37,7 +37,7 @@ class TestFromStimulusFile(LimsTest):
 
     @pytest.mark.requires_bamboo
     def test_from_stimulus_file(self):
-        stimulus_file = StimulusFile.from_lims(
+        stimulus_file = BehaviorStimulusFile.from_lims(
             behavior_session_id=self.behavior_session_id, db=self.dbconn)
         stimulus_timestamps = StimulusTimestamps.from_stimulus_file(
             stimulus_file=stimulus_file,
@@ -73,7 +73,7 @@ class TestNWB:
         )
 
         # Need to write stimulus timestamps first
-        bsf = StimulusFile(
+        bsf = BehaviorStimulusFile(
             filepath=self.test_data_dir / 'behavior_stimulus_file.pkl')
         ts = StimulusTimestamps.from_stimulus_file(stimulus_file=bsf,
                                                    monitor_delay=0.0)

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_task_parameters.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_task_parameters.py
@@ -5,14 +5,14 @@ import numpy as np
 import pynwb
 import pytest
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects.task_parameters import \
     TaskParameters
 from allensdk.test.brain_observatory.behavior.data_objects.lims_util import \
     LimsTest
 
 
-class TestFromStimulusFile(LimsTest):
+class TestFromBehaviorStimulusFile(LimsTest):
     @classmethod
     def setup_class(cls):
         cls.behavior_session_id = 994174745
@@ -26,7 +26,7 @@ class TestFromStimulusFile(LimsTest):
 
     @pytest.mark.requires_bamboo
     def test_from_stimulus_file(self):
-        stimulus_file = StimulusFile.from_lims(
+        stimulus_file = BehaviorStimulusFile.from_lims(
             behavior_session_id=self.behavior_session_id, db=self.dbconn)
         tp = TaskParameters.from_stimulus_file(stimulus_file=stimulus_file)
         assert tp == self.expected

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_trial_table.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_trial_table.py
@@ -6,8 +6,9 @@ import pandas as pd
 import pynwb
 import pytest
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile, \
-    SyncFile
+from allensdk.brain_observatory.behavior.data_files import (
+    BehaviorStimulusFile,
+    SyncFile)
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_objects.licks import Licks
 from allensdk.brain_observatory.behavior.data_objects.metadata\
@@ -23,7 +24,7 @@ from allensdk.test.brain_observatory.behavior.data_objects.lims_util import \
     LimsTest
 
 
-class TestFromStimulusFile(LimsTest):
+class TestFromBehaviorStimulusFile(LimsTest):
     @classmethod
     def setup_class(cls):
         cls.behavior_session_id = 994174745
@@ -57,7 +58,7 @@ class TestFromStimulusFile(LimsTest):
     def test_from_stimulus_file2(self):
         dir = Path(__file__).parent.parent.resolve()
         stimulus_filepath = dir / 'resources' / 'example_stimulus.pkl.gz'
-        stimulus_file = StimulusFile(filepath=stimulus_filepath)
+        stimulus_file = BehaviorStimulusFile(filepath=stimulus_filepath)
         stimulus_file, stimulus_timestamps, licks, rewards = \
             self._get_trial_table_data(stimulus_file=stimulus_file)
         TrialTable.from_stimulus_file(
@@ -67,11 +68,12 @@ class TestFromStimulusFile(LimsTest):
             rewards=rewards
         )
 
-    def _get_trial_table_data(self,
-                              stimulus_file: Optional[StimulusFile] = None):
+    def _get_trial_table_data(
+            self,
+            stimulus_file: Optional[BehaviorStimulusFile] = None):
         """returns data required to instantiate a TrialTable"""
         if stimulus_file is None:
-            stimulus_file = StimulusFile.from_lims(
+            stimulus_file = BehaviorStimulusFile.from_lims(
                 behavior_session_id=self.behavior_session_id, db=self.dbconn)
         stimulus_timestamps = StimulusTimestamps.from_stimulus_file(
             stimulus_file=stimulus_file,

--- a/allensdk/test/brain_observatory/behavior/test_behavior_metadata_legacy.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_metadata_legacy.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytz
 
-from allensdk.brain_observatory.behavior.data_files import StimulusFile
+from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects.metadata\
     .behavior_metadata.behavior_metadata import (
     description_dict, get_task_parameters, get_expt_description,

--- a/allensdk/test/brain_observatory/behavior/test_behavior_metadata_legacy.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_metadata_legacy.py
@@ -1,28 +1,9 @@
-import pickle
-from datetime import datetime
-
 import pytest
 import numpy as np
-import pandas as pd
-import pytz
 
-from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects.metadata\
     .behavior_metadata.behavior_metadata import (
-    description_dict, get_task_parameters, get_expt_description,
-    BehaviorMetadata)
-from allensdk.brain_observatory.behavior.data_objects.metadata\
-    .behavior_metadata.date_of_acquisition import \
-    DateOfAcquisition
-from allensdk.brain_observatory.behavior.data_objects.metadata\
-    .subject_metadata.age import \
-    Age
-from allensdk.brain_observatory.behavior.data_objects.metadata\
-    .subject_metadata.full_genotype import \
-    FullGenotype
-from allensdk.brain_observatory.behavior.data_objects.metadata\
-    .subject_metadata.reporter_line import \
-    ReporterLine
+        description_dict, get_task_parameters, get_expt_description)
 
 
 @pytest.mark.parametrize("data, expected",

--- a/allensdk/test/brain_observatory/sync_utilities/conftest.py
+++ b/allensdk/test/brain_observatory/sync_utilities/conftest.py
@@ -6,7 +6,7 @@ import json
 import numpy as np
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def sync_freq_fixture():
     """
     Frequency of test sync file in Hz
@@ -14,7 +14,7 @@ def sync_freq_fixture():
     return 100.0
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def sync_sample_fixture():
     """
     numpy array indicating the sample
@@ -27,7 +27,7 @@ def sync_sample_fixture():
     return values
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def line_name_fixture():
     """
     List of line names to use in test sync file
@@ -35,7 +35,7 @@ def line_name_fixture():
     return ['lineA', '', 'lineB', 'lineC', 'lineD']
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def line_to_edges_fixture(
         line_name_fixture,
         sync_sample_fixture):
@@ -78,7 +78,7 @@ def line_to_edges_fixture(
     return result
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def sync_metadata_fixture(
         sync_freq_fixture,
         line_name_fixture):
@@ -104,7 +104,7 @@ def sync_metadata_fixture(
     return metadata
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def sync_file_fixture(
         sync_metadata_fixture,
         line_name_fixture,
@@ -137,5 +137,8 @@ def sync_file_fixture(
 
     yield sync_path
 
-    if sync_path.exists():
-        sync_path.unlink()
+    try:
+        if sync_path.exists():
+            sync_path.unlink()
+    except PermissionError:
+        pass

--- a/allensdk/test/brain_observatory/sync_utilities/conftest.py
+++ b/allensdk/test/brain_observatory/sync_utilities/conftest.py
@@ -1,0 +1,141 @@
+import pytest
+import pathlib
+import tempfile
+import h5py
+import json
+import numpy as np
+
+
+@pytest.fixture(scope='module')
+def sync_freq_fixture():
+    """
+    Frequency of test sync file in Hz
+    """
+    return 100.0
+
+
+@pytest.fixture(scope='module')
+def sync_sample_fixture():
+    """
+    numpy array indicating the sample
+    """
+    rng = np.random.default_rng(22312)
+    indexes = np.arange(5, 10000, dtype=int)
+    values = rng.choice(indexes, 1000, replace=False)
+    values = np.sort(values)
+    values = values.astype(np.uint32)
+    return values
+
+
+@pytest.fixture(scope='module')
+def line_name_fixture():
+    """
+    List of line names to use in test sync file
+    """
+    return ['lineA', '', 'lineB', 'lineC', 'lineD']
+
+
+@pytest.fixture(scope='module')
+def line_to_edges_fixture(
+        line_name_fixture,
+        sync_sample_fixture):
+    """
+    A dict mapping line name to lists of rising and falling
+    edge indexes in the test sync file (note that the lists
+    returned are indexes in sync_sample_fixture, not the actual
+    edge sample values we expect to be returned by
+    SyncDataset.get_falling_edges or SyncDataset.get_rising_edges
+    """
+    rng = np.random.default_rng(11235813)
+    n_samples = len(sync_sample_fixture)
+
+    # leave first 20 samples blank; these will be filled
+    # with an erroneous block of "on" bits so that we can
+    # test utilities that only select falling edges
+    # after the first rising edge
+    #
+    # the increment of 3 is to make sure there is a gap
+    # between each falling edge and the subsequent
+    # rising edge
+    indexes = np.arange(20, n_samples, 3, dtype=int)
+
+    result = dict()
+    for line_name in line_name_fixture:
+        changes = rng.choice(indexes, 50, replace=False)
+        changes = np.sort(changes)
+
+        # every line starts out with some random initial
+        # samles set to 1
+        this_rising = [0, ]
+        this_falling = [rng.integers(2, 18)]
+
+        for idx in range(0, len(changes), 2):
+            this_rising.append(changes[idx])
+            this_falling.append(changes[idx+1])
+        result[line_name] = {'rising_idx': np.array(this_rising),
+                             'falling_idx': np.array(this_falling)}
+
+    return result
+
+
+@pytest.fixture(scope='module')
+def sync_metadata_fixture(
+        sync_freq_fixture,
+        line_name_fixture):
+    """
+    Dict representing 'meta' dataset in test sync file
+    """
+    metadata = {'ni_daq':
+                {'device': 'Dev1',
+                 'counter_output_freq': sync_freq_fixture,
+                 'sample_rate': sync_freq_fixture,
+                 'counter_bits': 32,
+                 'event_bits': 32},
+                'start_time': '2020-10-07 14:01:17.336502',
+                'stop_time': '2020-10-07 16:42:24.177205',
+                'line_labels': line_name_fixture,
+                'timeouts': [],
+                'version': '2.2.1+g1bc7438.b42257',
+                'sampling_type': 'frequency',
+                'file_version': '1.0.0',
+                'line_label_revision': 3,
+                'total_samples': 10000}
+
+    return metadata
+
+
+@pytest.fixture(scope='module')
+def sync_file_fixture(
+        sync_metadata_fixture,
+        line_name_fixture,
+        line_to_edges_fixture,
+        sync_sample_fixture,
+        tmp_path_factory):
+    """
+    Yields the path to a sync file for testing
+    """
+    tmpdir = pathlib.Path(tmp_path_factory.mktemp('external_sync_test'))
+    sync_path = tmpdir / tempfile.mkstemp(suffix='sync')[1]
+
+    n_samples = len(sync_sample_fixture)
+    data = np.zeros((n_samples, 2), dtype=np.uint32)
+    data[:, 0] = sync_sample_fixture
+
+    for pwr_of_2, line_name in enumerate(line_name_fixture):
+        this_rising = line_to_edges_fixture[line_name]['rising_idx']
+        this_falling = line_to_edges_fixture[line_name]['falling_idx']
+        for rising, falling in zip(this_rising, this_falling):
+            data[rising:falling, 1] += 2**pwr_of_2
+
+    with h5py.File(sync_path, 'w') as out_file:
+        out_file.create_dataset(
+            'data',
+            data=data)
+        out_file.create_dataset(
+            'meta',
+            data=json.dumps(sync_metadata_fixture).encode('utf-8'))
+
+    yield sync_path
+
+    if sync_path.exists():
+        sync_path.unlink()

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_alignment.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_alignment.py
@@ -1,0 +1,148 @@
+# This file implements tests of the sync-manipulation
+# utilities imported from ecephys_etl_pipelines. The purpose
+# of these tests is to detect if the behavior of the utilities
+# in ecephys_etl_pipelines ever changes out from under us
+
+import pytest
+import numpy as np
+
+from allensdk.brain_observatory.sync_dataset import Dataset as SyncDataset
+from allensdk.brain_observatory.sync_stim_aligner import (
+    _choose_line,
+    _get_rising_times,
+    _get_falling_times,
+    _get_line_starts_and_ends)
+
+
+def test_choose_line(
+        sync_file_fixture):
+    """
+    Test that _choose_line chooses the expected line
+    """
+    with SyncDataset(sync_file_fixture) as data:
+        assert _choose_line(data, 'lineC') == 'lineC'
+        assert _choose_line(data, ('lineB', 'lineA')) == 'lineB'
+        assert _choose_line(data, ('lineA', 'lineB')) == 'lineA'
+        assert _choose_line(data, ('xxxx', 'lineD')) == 'lineD'
+        with pytest.raises(RuntimeError, match='Could not find one of'):
+            _choose_line(data, ('xxxx', 'yyyy'))
+        with pytest.raises(RuntimeError, match='Could not find one of'):
+            _choose_line(data, 'zzzz')
+
+
+@pytest.mark.parametrize(
+        "specified_lines, expected_line",
+        [('lineD', 'lineD'),
+         (('nonsense', 'lineC'), 'lineC'),
+         (('lineC', 'lineB'), 'lineC'),
+         (('lineB', 'lineC'), 'lineB')])
+def test_get_rising_times(
+        sync_file_fixture,
+        sync_freq_fixture,
+        sync_sample_fixture,
+        line_to_edges_fixture,
+        specified_lines,
+        expected_line):
+    """
+    Test that _get_rising_times returns the expected timestamp arrays
+    """
+
+    with SyncDataset(sync_file_fixture) as data:
+        actual = _get_rising_times(
+                        data=data,
+                        sync_lines=specified_lines)
+
+        expected_idx = line_to_edges_fixture[expected_line]['rising_idx'][1:]
+        expected_time = sync_sample_fixture[expected_idx]/sync_freq_fixture
+        np.testing.assert_allclose(expected_time, actual)
+
+
+@pytest.mark.parametrize(
+        "specified_lines",
+        ['lineZ', ('lineU', 'lineW')])
+def test_get_rising_times_exception(
+        sync_file_fixture,
+        specified_lines):
+    """
+    Test that _get_rising_times raises the expected
+    exception when you specify non-existent lines
+    """
+
+    with SyncDataset(sync_file_fixture) as data:
+        with pytest.raises(RuntimeError, match="Could not find one of"):
+            _get_rising_times(
+                        data=data,
+                        sync_lines=specified_lines)
+
+
+@pytest.mark.parametrize(
+        "specified_lines, expected_line",
+        [('lineD', 'lineD'),
+         (('nonsense', 'lineC'), 'lineC'),
+         (('lineC', 'lineB'), 'lineC'),
+         (('lineB', 'lineC'), 'lineB')])
+def test_get_falling_times(
+        sync_file_fixture,
+        sync_freq_fixture,
+        sync_sample_fixture,
+        line_to_edges_fixture,
+        specified_lines,
+        expected_line):
+    """
+    Test that _get_falling_times returns the expected timestamp arrays
+    """
+
+    with SyncDataset(sync_file_fixture) as data:
+        actual = _get_falling_times(
+                        data=data,
+                        sync_lines=specified_lines)
+
+        expected_idx = line_to_edges_fixture[expected_line]['falling_idx'][1:]
+        expected_time = sync_sample_fixture[expected_idx]/sync_freq_fixture
+        np.testing.assert_allclose(expected_time, actual)
+
+
+@pytest.mark.parametrize(
+        "specified_lines, expected_line",
+        [('lineD', 'lineD'),
+         (('nonsense', 'lineC'), 'lineC'),
+         (('lineC', 'lineB'), 'lineC'),
+         (('lineB', 'lineC'), 'lineB')])
+def test_get_line_starts_and_ends(
+        sync_file_fixture,
+        sync_freq_fixture,
+        sync_sample_fixture,
+        line_to_edges_fixture,
+        specified_lines,
+        expected_line):
+    """
+    Test that _get_line_starts_and_ends works as expected
+    """
+    with SyncDataset(sync_file_fixture) as data:
+        actual = _get_line_starts_and_ends(
+                        data=data,
+                        sync_lines=specified_lines)
+        start_idx = line_to_edges_fixture[expected_line]['rising_idx'][1:]
+        end_idx = line_to_edges_fixture[expected_line]['falling_idx'][1:]
+        start_times = sync_sample_fixture[start_idx]/sync_freq_fixture
+        end_times = sync_sample_fixture[end_idx]/sync_freq_fixture
+        np.testing.assert_allclose(actual[0], start_times)
+        np.testing.assert_allclose(actual[1], end_times)
+
+
+@pytest.mark.parametrize(
+        "specified_lines",
+        ['lineZ', ('lineU', 'lineW')])
+def test_get_falling_times_exception(
+        sync_file_fixture,
+        specified_lines):
+    """
+    Test that _get_falling_times raises the expected
+    exception when you specify non-existent lines
+    """
+
+    with SyncDataset(sync_file_fixture) as data:
+        with pytest.raises(RuntimeError, match="Could not find one of"):
+            _get_falling_times(
+                        data=data,
+                        sync_lines=specified_lines)

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
@@ -2,12 +2,27 @@ import pytest
 import numpy as np
 from allensdk.brain_observatory.sync_dataset import Dataset as SyncDataset
 from allensdk.brain_observatory.sync_stim_aligner import (
-    _get_start_frames)
+    _get_start_frames,
+    get_start_frames_from_stimulus_blocks)
+
+
+class DummyStim(object):
+    """
+    A class that implements num_frames;
+    used for testing APIs that require
+    _StimulusFile objects.
+    """
+
+    def __init__(self, n_frames):
+        self._n_frames = n_frames
+
+    def num_frames(self):
+        return self._n_frames
 
 
 @pytest.fixture(scope='module')
 def line_name_fixture():
-    return ['lineA', 'stim_running', 'lineB']
+    return ['lineA', 'stim_running', 'lineB', 'vsync_stim']
 
 
 @pytest.fixture(scope='module')
@@ -32,11 +47,40 @@ def line_to_edges_fixture(
                              'falling_idx': np.array(this_falling)}
 
     # create four intentional blocks of length
-    # 44, 55, 66, 77 in the stim_running line
+    # 33, 66, 99, 132 in the stim_running line
     this_rising = [12, 100, 204, 500]
-    this_falling = [56, 155, 270, 577]
+    this_falling = [45, 166, 303, 632]
     result['stim_running'] = {'rising_idx': np.array(this_rising),
                               'falling_idx': np.array(this_falling)}
+
+    # set vsync_stim lines;
+    # because we are placing an edge every three frames,
+    # the number of frames in each stimulus block should
+    # be 1/3 that specified in the above block
+    v_rising = np.arange(4, n_samples, 3, dtype=int)
+    v_falling = v_rising + 1
+    result['vsync_stim'] = {'rising_idx': v_rising,
+                            'falling_idx': v_falling}
+
+    return result
+
+
+@pytest.fixture(scope='module')
+def expected_start_frames_fixture(
+        line_to_edges_fixture):
+    """
+    Return dict that maps 'rising', 'falling' to the expected
+    start frames for all of the stimulus blocks in our test sync file
+    """
+    result = dict()
+    for edge_type in ('rising', 'falling'):
+        frame_edges = line_to_edges_fixture['vsync_stim'][f'{edge_type}_idx']
+        stim_edge_list = line_to_edges_fixture['stim_running']['rising_idx']
+        expected_idx = []
+        for stim_edge in stim_edge_list:
+            this_idx = np.where(frame_edges >= stim_edge)[0].min()
+            expected_idx.append(this_idx)
+        result[edge_type] = expected_idx
     return result
 
 
@@ -63,8 +107,8 @@ def test_get_start_frames_exact(
 
 @pytest.mark.parametrize(
         "stimulus_frame_counts, expected",
-        [([44, 55, 77], [12, 100, 500]),
-         ([55, 77], [100, 500])])
+        [([33, 66, 132], [12, 100, 500]),
+         ([66, 132], [100, 500])])
 def test_get_start_frames_skip_one(
         sync_file_fixture,
         sync_sample_fixture,
@@ -87,9 +131,9 @@ def test_get_start_frames_skip_one(
 
 @pytest.mark.parametrize(
         "tolerance, stimulus_frame_counts, expected",
-        [(0.1, [43, 59, 84], [12, 100, 500]),
-         (0.05, [45, 53, 78], [12, 100, 500]),
-         (0.05, [53, 69], [100, 204])])
+        [(0.1, [35, 61, 127], [12, 100, 500]),
+         (0.05, [32, 68, 136], [12, 100, 500]),
+         (0.05, [67, 96], [100, 204])])
 def test_get_start_frames_tolerance(
         sync_file_fixture,
         sync_sample_fixture,
@@ -114,8 +158,8 @@ def test_get_start_frames_tolerance(
 
 @pytest.mark.parametrize(
         "tolerance, stimulus_frame_counts",
-        [(0.1, [43, 40, 84]),
-         (0.05, [45, 53, 90])])
+        [(0.1, [32, 40, 99]),
+         (0.05, [33, 66, 300])])
 def test_get_start_frames_tolerance_failures(
         sync_file_fixture,
         line_to_edges_fixture,
@@ -150,3 +194,86 @@ def test_get_start_frames_too_many_pkl(
                         raw_frame_times=sync_sample_fixture/sync_freq_fixture,
                         stimulus_frame_counts=[44, 55, 77, 100, 300, 55],
                         tolerance=0.0)
+
+
+def test_user_facing_get_stims_error(
+       sync_file_fixture):
+    """
+    Make sure that get_start_frames_from_stimulus_blocks raises
+    the expected error if you give it a bad raw_frame_time_direction
+    """
+    with pytest.raises(ValueError,
+                       match="Cannot parse raw_frame_time_direction"):
+        get_start_frames_from_stimulus_blocks(
+            stimulus_files=[DummyStim(n_frames=2),
+                            DummyStim(n_frames=4)],
+            sync_file=sync_file_fixture,
+            raw_frame_time_lines='vsync_stim',
+            raw_frame_time_direction='nonsense',
+            frame_count_tolerance=0.0)
+
+
+@pytest.mark.parametrize(
+        "edge_type", ["rising", "falling"])
+def test_user_facing_get_start_frames_smoke(
+        sync_file_fixture,
+        edge_type,
+        expected_start_frames_fixture):
+    """
+    Test user-facing get_start_frames_from_stimulus_blocks
+    in case where the number of blocks in stim_running matches
+    the expected number of stimulus blocks exactly
+    """
+
+    # note that the number of frames specified here
+    # actually doesn't matter; because the number of blocks
+    # found by analyzing stim_running matches the expected
+    # number of blocks exactly, the start_frames of those
+    # blocks will be returned
+    stim_list = [DummyStim(n_frames=44),
+                 DummyStim(n_frames=55),
+                 DummyStim(n_frames=66),
+                 DummyStim(n_frames=77)]
+
+    result = get_start_frames_from_stimulus_blocks(
+               stimulus_files=stim_list,
+               sync_file=sync_file_fixture,
+               raw_frame_time_lines='vsync_stim',
+               raw_frame_time_direction=edge_type,
+               frame_count_tolerance=0.0)
+
+    np.testing.assert_array_equal(
+                  result,
+                  expected_start_frames_fixture[edge_type])
+
+
+@pytest.mark.parametrize(
+        "edge_type, stim_frame_inputs, tolerance, expected_idx",
+        [('rising', (11, 33, 44), 0.0, [0, 2, 3]),
+         ('falling', (11, 33, 44), 0.0, [0, 2, 3]),
+         ('rising', (21, 34, 45), 0.05, [1, 2, 3]),
+         ('falling', (31, 47), 0.1, [2, 3])])
+def test_user_facing_get_start_frames(
+        sync_file_fixture,
+        edge_type,
+        stim_frame_inputs,
+        tolerance,
+        expected_idx,
+        expected_start_frames_fixture):
+    """
+    Test the user-facing get_start_frames_from_stimulus_blocks
+    in cases of differing stimulus specifications and tolerances
+    """
+
+    stim_list = [DummyStim(n_frames=n) for n in stim_frame_inputs]
+    expected = [expected_start_frames_fixture[edge_type][idx]
+                for idx in expected_idx]
+
+    result = get_start_frames_from_stimulus_blocks(
+                stimulus_files=stim_list,
+                sync_file=sync_file_fixture,
+                raw_frame_time_lines='vsync_stim',
+                raw_frame_time_direction=edge_type,
+                frame_count_tolerance=tolerance)
+
+    np.testing.assert_array_equal(result, expected)

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
@@ -20,12 +20,12 @@ class DummyStim(object):
         return self._n_frames
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def line_name_fixture():
     return ['lineA', 'stim_running', 'lineB', 'vsync_stim']
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def line_to_edges_fixture(
         sync_sample_fixture):
     n_samples = len(sync_sample_fixture)
@@ -65,7 +65,7 @@ def line_to_edges_fixture(
     return result
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def expected_start_frames_fixture(
         line_to_edges_fixture):
     """

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
@@ -1,0 +1,152 @@
+import pytest
+import numpy as np
+from allensdk.brain_observatory.sync_dataset import Dataset as SyncDataset
+from allensdk.brain_observatory.sync_stim_aligner import (
+    _get_start_frames)
+
+
+@pytest.fixture(scope='module')
+def line_name_fixture():
+    return ['lineA', 'stim_running', 'lineB']
+
+
+@pytest.fixture(scope='module')
+def line_to_edges_fixture(
+        sync_sample_fixture):
+    n_samples = len(sync_sample_fixture)
+
+    result = dict()
+
+    # fill lineA and lineB with random bits
+    rng = np.random.default_rng(66123)
+    indexes = np.arange(0, n_samples, 3)
+    for line_name in ('lineA', 'lineB'):
+        changes = rng.choice(indexes, 50, replace=False)
+        changes = np.sort(changes)
+        this_rising = []
+        this_falling = []
+        for idx in range(0, len(changes), 2):
+            this_rising.append(changes[idx])
+            this_falling.append(changes[idx+1])
+        result[line_name] = {'rising_idx': np.array(this_rising),
+                             'falling_idx': np.array(this_falling)}
+
+    # create four intentional blocks of length
+    # 44, 55, 66, 77 in the stim_running line
+    this_rising = [12, 100, 204, 500]
+    this_falling = [56, 155, 270, 577]
+    result['stim_running'] = {'rising_idx': np.array(this_rising),
+                              'falling_idx': np.array(this_falling)}
+    return result
+
+
+def test_get_start_frames_exact(
+        sync_file_fixture,
+        line_to_edges_fixture,
+        sync_sample_fixture,
+        sync_freq_fixture):
+    """
+    Test case where _get_frame_offsets is expected to return
+    exact matches
+    """
+
+    with SyncDataset(sync_file_fixture) as sync_data:
+        start_frames = _get_start_frames(
+                        data=sync_data,
+                        raw_frame_times=sync_sample_fixture/sync_freq_fixture,
+                        stimulus_frame_counts=[44, 55, 66, 77],
+                        tolerance=0.0)
+    np.testing.assert_array_equal(
+            start_frames,
+            line_to_edges_fixture['stim_running']['rising_idx'])
+
+
+@pytest.mark.parametrize(
+        "stimulus_frame_counts, expected",
+        [([44, 55, 77], [12, 100, 500]),
+         ([55, 77], [100, 500])])
+def test_get_start_frames_skip_one(
+        sync_file_fixture,
+        sync_sample_fixture,
+        sync_freq_fixture,
+        stimulus_frame_counts,
+        expected):
+    """
+    Test the case where one of the blocks in stim_running is erroneous
+    """
+    with SyncDataset(sync_file_fixture) as sync_data:
+        start_frames = _get_start_frames(
+                        data=sync_data,
+                        raw_frame_times=sync_sample_fixture/sync_freq_fixture,
+                        stimulus_frame_counts=stimulus_frame_counts,
+                        tolerance=0.0)
+    np.testing.assert_array_equal(
+            start_frames,
+            expected)
+
+
+@pytest.mark.parametrize(
+        "tolerance, stimulus_frame_counts, expected",
+        [(0.1, [43, 59, 84], [12, 100, 500]),
+         (0.05, [45, 53, 78], [12, 100, 500]),
+         (0.05, [53, 69], [100, 204])])
+def test_get_start_frames_tolerance(
+        sync_file_fixture,
+        sync_sample_fixture,
+        sync_freq_fixture,
+        tolerance,
+        stimulus_frame_counts,
+        expected):
+    """
+    Test that _get_start_frames correctly infers starting frames
+    within tolerance
+    """
+    with SyncDataset(sync_file_fixture) as sync_data:
+        start_frames = _get_start_frames(
+                        data=sync_data,
+                        raw_frame_times=sync_sample_fixture/sync_freq_fixture,
+                        stimulus_frame_counts=stimulus_frame_counts,
+                        tolerance=tolerance)
+    np.testing.assert_array_equal(
+            start_frames,
+            expected)
+
+
+@pytest.mark.parametrize(
+        "tolerance, stimulus_frame_counts",
+        [(0.1, [43, 40, 84]),
+         (0.05, [45, 53, 90])])
+def test_get_start_frames_tolerance_failures(
+        sync_file_fixture,
+        line_to_edges_fixture,
+        sync_sample_fixture,
+        sync_freq_fixture,
+        tolerance,
+        stimulus_frame_counts):
+    """
+    Test that _get_start_frames correctly fails when the best guess
+    is outside of the specified tolerance
+    """
+    with SyncDataset(sync_file_fixture) as sync_data:
+        with pytest.raises(RuntimeError, match="Could not find matching sync"):
+            _get_start_frames(
+                        data=sync_data,
+                        raw_frame_times=sync_sample_fixture/sync_freq_fixture,
+                        stimulus_frame_counts=stimulus_frame_counts,
+                        tolerance=tolerance)
+
+
+def test_get_start_frames_too_many_pkl(
+        sync_file_fixture,
+        sync_sample_fixture,
+        sync_freq_fixture):
+    """
+    Test the case where you specify too many stimulus_frame_counts
+    """
+    with SyncDataset(sync_file_fixture) as sync_data:
+        with pytest.raises(RuntimeError, match="more pkl frame count entries"):
+            _get_start_frames(
+                        data=sync_data,
+                        raw_frame_times=sync_sample_fixture/sync_freq_fixture,
+                        stimulus_frame_counts=[44, 55, 77, 100, 300, 55],
+                        tolerance=0.0)


### PR DESCRIPTION
This PR ultimately adds the utility function
```
allensdk.brain_observatory.sync_stim_aligner.get_start_frames_from_stimulus_blocks
```
which is needed to scan a single sync file and find the indices of the starting frames for the behavior_, mapping_, and replay_ stimulus blocks from a single sync file. It is, ultimately, a re-implementation of the method here

https://github.com/AllenInstitute/ecephys_etl_pipelines/blob/main/src/ecephys_etl/modules/vbn_create_stimulus_table/create_stim_table.py#L132-L225

I chose not to make ecephys_etl_pipelines a dependency of the SDK because

1) I believe we are going to need the flexibility to `get_vsyncs` from either the rising (in the case of things like running speed or rewards) or falling (in the case of stimulus presentations) edges of the sync file. The ecephys_etl code as implemented does not afford that flexibility

2) I wasn't sure how to guard against the ecephys_etl implementation changing out from under the SDK unexpectedly.

If it makes anyone feel better, ecephys_etl just copied `sync_dataset.py` from the SDK (which copied `sync_dataset.py` from some BitBucket repository somewhere).

In order to support this work, I had to break up our StimulusFile data objects into three classes.

```
BehaviorStimulusFile
ReplayStimulusFile
MappingStimulusFile
```
to represent the three varieties of stimulus file in the VBN experiments. The differences between the three come in how they are represented in our JSON serializations and how `num_frames` is accessed.

`BehaviorStimulusFile` corresponds to the `StimulusFile` class that was implemented for the VBO release.

The proper use of `get_start_frames_from_stimulus_blocks` is something like

```
from allensdk.brain_observatory.sync_stim_aligner import (
    _get_rising_times,
    get_start_frames_from_stimulus_blocks)

with SyncDataset(sync_path) as sync_data:
    frame_times = _get_rising_times(sync_data, sync_lines='vsync_stim')

start_frames = get_start_frames_from_stimulus_blocks(
                                    stimulus_files=[behavior_stim, mapping_stim, replay_stim],
                                    sync_file=sync_path,
                                    ...)

timesteps_for_behavior = frame_times[start_frames[0]: start_frames[0]+behavior_stim.num_frames()]
timesteps_for_replay = frame_times[start_frames[2]:start_frames[2]+replay_stim.num_frames()]
```
