### PR TITLE
Create VBN EyeTracking data object

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -1,8 +1,7 @@
 import logging
 import warnings
 from pathlib import Path
-from typing import Optional
-
+from typing import Optional, List
 import numpy as np
 import pandas as pd
 from pynwb import NWBFile, TimeSeries
@@ -195,13 +194,19 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
     @classmethod
     def from_data_file(cls, data_file: EyeTrackingFile,
                        sync_file: SyncFile,
-                       z_threshold: float = 3.0, dilation_frames: int = 2
+                       drop_frames: Optional[List[int]] = None,
+                       z_threshold: float = 3.0,
+                       dilation_frames: int = 2,
                        ) -> "EyeTrackingTable":
         """
         Parameters
         ----------
         data_file
         sync_file
+        drop_frames : List[int], optional
+            List of frame indices to be dropped from the table.
+            If provided, will drop the corresponding frame frame times read
+            from the sync file to syncronize frame times and frames.
         z_threshold : float, optional
             See EyeTracking.from_lims
         dilation_frames : int, optional
@@ -216,6 +221,7 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
         frame_times = sync_utilities.get_synchronized_frame_times(
             session_sync_file=sync_path,
             sync_line_label_keys=Dataset.EYE_TRACKING_KEYS,
+            drop_frames=drop_frames,
             trim_after_spike=False)
 
         try:

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -103,6 +103,7 @@ class Dataset(object):
                          # previous line label for eye tracking
                          # (prior to ~ Oct. 2018)
                          "eyetracking",
+                         "eye_cam_exposing",
                          "eye_tracking")  # An undocumented, but possible eye tracking line label  # NOQA E114
     BEHAVIOR_TRACKING_KEYS = ("beh_frame_received",  # Expected behavior line label after 3/27/2020  # NOQA E127
                                                     # clocks behavior tracking frame # NOQA E127

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_utilities.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_utilities.py
@@ -41,76 +41,139 @@ def test_trim_discontiguous_vsyncs(vs_times, expected):
     assert np.allclose(obtained, expected)
 
 
-@pytest.mark.parametrize("mock_dataset_fixture,sync_line_label_keys,expected", [
-    ({"eye_tracking_timings": [0.020, 0.030, 0.040, 0.050, 3.0]},
-     Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 0.040, 0.050]),
+@pytest.mark.parametrize(
+    "mock_dataset_fixture,sync_line_label_keys,expected",
+    [
+        ({"eye_tracking_timings": [0.020, 0.030, 0.040, 0.050, 3.0]},
+         Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 0.040, 0.050]),
 
-    ({"behavior_tracking_timings": [0.080, 0.090, 0.100, 0.110, 8.0]},
-     Dataset.BEHAVIOR_TRACKING_KEYS, [0.08, 0.090, 0.100, 0.110])
-], indirect=["mock_dataset_fixture"])
+        ({"behavior_tracking_timings": [0.080, 0.090, 0.100, 0.110, 8.0]},
+         Dataset.BEHAVIOR_TRACKING_KEYS, [0.08, 0.090, 0.100, 0.110])
+    ],
+    indirect=["mock_dataset_fixture"])
 def test_get_synchronized_frame_times(monkeypatch, mock_dataset_fixture,
                                       sync_line_label_keys, expected):
     monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
 
-    obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys)
+    obtained = su.get_synchronized_frame_times(
+        "dummy_path",
+        sync_line_label_keys
+    )
     assert np.allclose(obtained, expected)
 
 
-@pytest.mark.parametrize("mock_dataset_fixture,sync_line_label_keys,expected", [
-    ({"eye_tracking_timings": [0.020, 0.030, 0.040, 0.050, 3.0]},
-     Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 0.040, 0.050, 3.0]),
+@pytest.mark.parametrize(
+    "mock_dataset_fixture,sync_line_label_keys,expected",
+    [
+        ({"eye_tracking_timings": [0.020, 0.030, 0.040, 0.050, 3.0]},
+         Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 0.040, 0.050, 3.0]),
 
-    ({"behavior_tracking_timings": [0.080, 0.090, 0.100, 0.110, 8.0]},
-     Dataset.BEHAVIOR_TRACKING_KEYS, [0.08, 0.090, 0.100, 0.110, 8.0])
-], indirect=["mock_dataset_fixture"])
-def test_get_synchronized_frame_times_no_trim(monkeypatch, mock_dataset_fixture,
-                                      sync_line_label_keys, expected):
+        ({"behavior_tracking_timings": [0.080, 0.090, 0.100, 0.110, 8.0]},
+         Dataset.BEHAVIOR_TRACKING_KEYS, [0.08, 0.090, 0.100, 0.110, 8.0])
+    ], indirect=["mock_dataset_fixture"])
+def test_get_synchronized_frame_times_no_trim(
+    monkeypatch, mock_dataset_fixture, sync_line_label_keys, expected
+):
     monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
 
-    obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys, trim_after_spike=False)
+    obtained = su.get_synchronized_frame_times(
+        "dummy_path",
+        sync_line_label_keys,
+        trim_after_spike=False
+    )
     assert np.allclose(obtained, expected)
 
 
-@pytest.mark.parametrize("mock_dataset_fixture,sync_line_label_keys,expected", [
-    ({"eye_tracking_timings": [0.020, 0.030, 3.0, 0.040, 0.050, 0.040]},
-     Dataset.EYE_TRACKING_KEYS, [0.020, 0.030]),
+@pytest.mark.parametrize(
+    "mock_dataset_fixture,sync_line_label_keys,expected",
+    [
+        ({"eye_tracking_timings":
+            [0.020, 0.030, 3.0, 0.040, 0.050, 0.040]},
+         Dataset.EYE_TRACKING_KEYS, [0.020, 0.030]),
 
-    ({"behavior_tracking_timings": [0.080, 8.0, 0.090, 0.100, 0.110, 0.150, 0.085, 0.110, 0.13]},
-     Dataset.BEHAVIOR_TRACKING_KEYS, [0.08])
-], indirect=["mock_dataset_fixture"])
-def test_get_synchronized_frame_times_trim_with_spike(monkeypatch, mock_dataset_fixture,
-                                      sync_line_label_keys, expected):
+        ({"behavior_tracking_timings":
+            [0.080, 8.0, 0.090, 0.100, 0.110, 0.150, 0.085, 0.110, 0.13]},
+         Dataset.BEHAVIOR_TRACKING_KEYS, [0.08])
+    ], indirect=["mock_dataset_fixture"])
+def test_get_synchronized_frame_times_trim_with_spike(
+    monkeypatch, mock_dataset_fixture, sync_line_label_keys, expected
+):
     monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
 
-    obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys)
+    obtained = su.get_synchronized_frame_times(
+        "dummy_path", sync_line_label_keys
+    )
     assert np.allclose(obtained, expected)
 
 
-@pytest.mark.parametrize("mock_dataset_fixture,sync_line_label_keys,expected", [
-    ({"eye_tracking_timings": [3.0, 0.030, 0.040, 0.050]},
-     Dataset.EYE_TRACKING_KEYS, []),
+@pytest.mark.parametrize(
+    "mock_dataset_fixture,sync_line_label_keys,expected",
+    [
+        ({"eye_tracking_timings": [3.0, 0.030, 0.040, 0.050]},
+         Dataset.EYE_TRACKING_KEYS, []),
 
-    ({"behavior_tracking_timings": [8.0, 0.080, 0.090, 0.100, 0.110]},
-     Dataset.BEHAVIOR_TRACKING_KEYS, [])
-], indirect=["mock_dataset_fixture"])
-def test_get_synchronized_frame_times_trim_all(monkeypatch, mock_dataset_fixture,
-                                      sync_line_label_keys, expected):
+        ({"behavior_tracking_timings": [8.0, 0.080, 0.090, 0.100, 0.110]},
+         Dataset.BEHAVIOR_TRACKING_KEYS, [])
+    ], indirect=["mock_dataset_fixture"])
+def test_get_synchronized_frame_times_trim_all(
+    monkeypatch,
+    mock_dataset_fixture,
+    sync_line_label_keys,
+    expected
+):
+
     monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
 
-    obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys)
+    obtained = su.get_synchronized_frame_times(
+        "dummy_path",
+        sync_line_label_keys
+    )
     assert np.allclose(obtained, expected)
 
 
-@pytest.mark.parametrize("mock_dataset_fixture,sync_line_label_keys,expected", [
-    ({"eye_tracking_timings": [0.020, 0.030, 3.0, 0.050, 0.040]},
-     Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 3.0, 0.050, 0.040]),
+@pytest.mark.parametrize(
+    "mock_dataset_fixture,sync_line_label_keys,expected",
+    [
+        ({"eye_tracking_timings": [0.020, 0.030, 3.0, 0.050, 0.040]},
+         Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 3.0, 0.050, 0.040]),
 
-    ({"behavior_tracking_timings": [0.080, 8.0, 0.090, 0.100, 0.110]},
-     Dataset.BEHAVIOR_TRACKING_KEYS, [0.080, 8.0, 0.090, 0.100, 0.110])
-], indirect=["mock_dataset_fixture"])
-def test_get_synchronized_frame_times_no_trim_with_spike(monkeypatch, mock_dataset_fixture,
-                                      sync_line_label_keys, expected):
+        ({"behavior_tracking_timings": [0.080, 8.0, 0.090, 0.100, 0.110]},
+         Dataset.BEHAVIOR_TRACKING_KEYS, [0.080, 8.0, 0.090, 0.100, 0.110])
+    ],
+    indirect=["mock_dataset_fixture"])
+def test_get_synchronized_frame_times_no_trim_with_spike(
+    monkeypatch,
+    mock_dataset_fixture,
+    sync_line_label_keys,
+    expected
+):
     monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
 
-    obtained = su.get_synchronized_frame_times("dummy_path", sync_line_label_keys, trim_after_spike=False)
+    obtained = su.get_synchronized_frame_times(
+        "dummy_path",
+        sync_line_label_keys,
+        trim_after_spike=False
+    )
+    assert np.allclose(obtained, expected)
+
+
+@pytest.mark.parametrize(
+    "mock_dataset_fixture,sync_line_label_keys,expected",
+    [
+        ({"eye_tracking_timings": [0.020, 0.030, 0.040, 0.050, 3.0]},
+         Dataset.EYE_TRACKING_KEYS, [0.020, 0.030, 0.050]),
+
+        ({"behavior_tracking_timings": [0.080, 0.090, 0.100, 0.110, 8.0]},
+         Dataset.BEHAVIOR_TRACKING_KEYS, [0.080, 0.090, 0.110])
+    ], indirect=["mock_dataset_fixture"])
+def test_get_synchronized_frame_times_drop_frame(
+    monkeypatch, mock_dataset_fixture, sync_line_label_keys, expected
+):
+    monkeypatch.setattr(su, "Dataset", mock_dataset_fixture)
+
+    obtained = su.get_synchronized_frame_times(
+        "dummy_path",
+        sync_line_label_keys,
+        drop_frames=[2]
+    )
     assert np.allclose(obtained, expected)


### PR DESCRIPTION
**Problem:**
Be able to Create VBN EyeTracking data object and roundtrip it via nwb file.

Addresses: #2340  

**Solution:**
Reuse the existing` EyeTrackignTable` class but extend it to
pass `session_data` to `EeyTrackignTable.from_data_file` that includes a path to the video metadata json. Use metadata to remove times corresponding to dropped frames

**Validation:** updated an existing unit test that does roundtripping
