### PR TITLE
Makes Presentations class compatible with VBN

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -889,7 +889,15 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             stimulus_timestamps=stimulus_timestamps)
         stimuli = Stimuli.from_stimulus_file(
             stimulus_file=stimulus_file,
-            stimulus_timestamps=stimulus_timestamps)
+            stimulus_timestamps=stimulus_timestamps,
+            presentation_columns=[
+                'start_time', 'stop_time',
+                'duration',
+                'image_name', 'image_index',
+                'is_change', 'omitted',
+                'start_frame', 'end_frame',
+                'image_set']
+        )
         task_parameters = TaskParameters.from_stimulus_file(
             stimulus_file=stimulus_file)
         trials = TrialTable.from_stimulus_file(

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
@@ -1,4 +1,6 @@
-from typing import Optional, List
+import collections
+from pathlib import Path
+from typing import Optional, List, Dict, Union
 
 import pandas as pd
 from pynwb import NWBFile
@@ -15,31 +17,59 @@ from allensdk.core import \
 from allensdk.brain_observatory.behavior.stimulus_processing import \
     get_stimulus_presentations, get_stimulus_metadata, is_change_event
 from allensdk.brain_observatory.nwb import \
-    create_stimulus_presentation_time_interval, get_column_name
-from allensdk.brain_observatory.nwb.nwb_api import NwbApi
+    create_stimulus_presentation_time_interval
 
 
 class Presentations(DataObject, StimulusFileReadableInterface,
                     NwbReadableInterface, NwbWritableInterface):
     """Stimulus presentations"""
-    def __init__(self, presentations: pd.DataFrame):
+    def __init__(self, presentations: pd.DataFrame,
+                 columns_to_rename: Optional[Dict[str, str]] = None,
+                 column_list: Optional[List[str]] = None,
+                 sort_columns: bool = True):
+        """
+
+        Parameters
+        ----------
+        presentations: The stimulus presentations table
+        columns_to_rename: Optional dict mapping
+            old column name -> new column name
+        column_list: Optional list of columns to include.
+            This will reorder the columns.
+        sort_columns: Whether to sort the columns by name
+        """
+        if columns_to_rename is not None:
+            presentations = presentations.rename(columns=columns_to_rename)
+        if column_list is not None:
+            presentations = presentations[column_list]
+        if sort_columns:
+            presentations = presentations[sorted(presentations.columns)]
+        presentations = presentations.reset_index(drop=True)
+        presentations.index = pd.Int64Index(
+            range(presentations.shape[0]), name='stimulus_presentations_id')
         super().__init__(name='presentations', value=presentations)
 
-    def to_nwb(self, nwbfile: NWBFile) -> NWBFile:
+    def to_nwb(self,
+               nwbfile: NWBFile,
+               stimulus_name_column='stimulus_name') -> NWBFile:
         """Adds a stimulus table (defining stimulus characteristics for each
         time point in a session) to an nwbfile as TimeIntervals.
+
+        Parameters
+        ----------
+        nwbfile
+        stimulus_name_column: The column in the dataframe denoting the
+            stimulus name
         """
         stimulus_table = self.value.copy()
 
         ts = nwbfile.processing['stimulus'].get_data_interface('timestamps')
-        possible_names = {'stimulus_name', 'image_name'}
-        stimulus_name_column = get_column_name(stimulus_table.columns,
-                                               possible_names)
         stimulus_names = stimulus_table[stimulus_name_column].unique()
 
         for stim_name in sorted(stimulus_names):
-            specific_stimulus_table = stimulus_table[stimulus_table[
-                                                         stimulus_name_column] == stim_name]  # noqa: E501
+            specific_stimulus_table = \
+                stimulus_table[
+                    stimulus_table[stimulus_name_column] == stim_name]
             # Drop columns where all values in column are NaN
             cleaned_table = specific_stimulus_table.dropna(axis=1, how='all')
             # For columns with mixed strings and NaNs, fill NaNs with 'N/A'
@@ -72,27 +102,62 @@ class Presentations(DataObject, StimulusFileReadableInterface,
         return nwbfile
 
     @classmethod
-    def from_nwb(cls, nwbfile: NWBFile) -> "Presentations":
-        # Note: using NwbApi class because ecephys uses this method
-        # TODO figure out how behavior and ecephys can share this method
-        nwbapi = NwbApi.from_nwbfile(nwbfile=nwbfile)
-        df = nwbapi.get_stimulus_presentations()
+    def from_nwb(cls, nwbfile: NWBFile, add_is_change: bool = True,
+                 column_list: Optional[List[str]] = None) -> "Presentations":
+        """
 
-        df['is_change'] = is_change_event(stimulus_presentations=df)
-        df = cls._postprocess(presentations=df, fill_omitted_values=False)
-        return Presentations(presentations=df)
+        Parameters
+        ----------
+        nwbfile
+        add_is_change: Whether to add a column denoting whether the current
+            row represents a stimulus in which there was a change event
+        column_list: The columns and order of columns
+            in the final dataframe.
+
+        Returns
+        -------
+        `Presentations` instance
+        """
+        columns_to_ignore = {'tags', 'timeseries', 'tags_index',
+                             'timeseries_index'}
+
+        presentation_dfs = []
+        for interval_name, interval in nwbfile.intervals.items():
+            if interval_name.endswith('_presentations'):
+                presentations = collections.defaultdict(list)
+                for col in interval.columns:
+                    if col.name not in columns_to_ignore:
+                        presentations[col.name].extend(col.data[:])
+                df = pd.DataFrame(presentations).replace({'N/A': ''})
+                presentation_dfs.append(df)
+
+        table = pd.concat(presentation_dfs, sort=False)
+        table = table.astype(
+            {c: 'int64' for c in table.select_dtypes(include='int')})
+        table = table.sort_values(by=["start_time"])
+
+        if add_is_change:
+            table['is_change'] = is_change_event(stimulus_presentations=table)
+        return Presentations(presentations=table, column_list=column_list)
 
     @classmethod
     def from_stimulus_file(
             cls, stimulus_file: BehaviorStimulusFile,
             stimulus_timestamps: StimulusTimestamps,
-            limit_to_images: Optional[List] = None) -> "Presentations":
+            limit_to_images: Optional[List] = None,
+            column_list: Optional[List[str]] = None,
+            fill_omitted_values=True
+    ) -> "Presentations":
         """Get stimulus presentation data.
 
         :param stimulus_file
         :param limit_to_images
             Only return images given by these image names
         :param stimulus_timestamps
+        :param column_list: The columns and order of columns
+            in the final dataframe
+        :param fill_omitted_values: Whether to fill stop_time and duration
+            for omitted frames
 
 
         :returns: pd.DataFrame --
@@ -104,6 +169,7 @@ class Presentations(DataObject, StimulusFileReadableInterface,
         data = stimulus_file.data
         raw_stim_pres_df = get_stimulus_presentations(
             data, stimulus_timestamps)
+        raw_stim_pres_df = raw_stim_pres_df.drop(columns=['index'])
 
         # Fill in nulls for image_name
         # This makes two assumptions:
@@ -116,8 +182,8 @@ class Presentations(DataObject, StimulusFileReadableInterface,
                     raw_stim_pres_df["orientation"]
                     .apply(lambda x: f"gratings_{x}"))
             else:
-                raise ValueError("All values for 'orentation' and 'image_name'"
-                                 " are null.")
+                raise ValueError("All values for 'orientation' and "
+                                 "'image_name are null.")
 
         stimulus_metadata_df = get_stimulus_metadata(data)
 
@@ -125,7 +191,8 @@ class Presentations(DataObject, StimulusFileReadableInterface,
         stimulus_index_df = (
             raw_stim_pres_df
             .reset_index()
-            .merge(stimulus_metadata_df.reset_index(), on=["image_name"])
+            .merge(stimulus_metadata_df.reset_index(),
+                   on=["image_name"])
             .set_index(idx_name))
         stimulus_index_df = (
             stimulus_index_df[["image_set", "image_index", "start_time",
@@ -152,8 +219,40 @@ class Presentations(DataObject, StimulusFileReadableInterface,
                 stim_pres_df[stim_pres_df['image_name'].isin(limit_to_images)]
             stim_pres_df.index = pd.Int64Index(
                 range(stim_pres_df.shape[0]), name=stim_pres_df.index.name)
-        stim_pres_df = cls._postprocess(presentations=stim_pres_df)
-        return Presentations(presentations=stim_pres_df)
+        stim_pres_df = cls._postprocess(
+            presentations=stim_pres_df,
+            fill_omitted_values=fill_omitted_values)
+        return Presentations(presentations=stim_pres_df,
+                             column_list=column_list)
+
+    @classmethod
+    def from_path(cls,
+                  path: Union[str, Path],
+                  exclude_columns: Optional[List[str]] = None,
+                  columns_to_rename: Optional[Dict[str, str]] = None,
+                  sort_columns: bool = True
+                  ) -> "Presentations":
+        """
+        Reads the table directly from a precomputed csv
+
+        Parameters
+        -----------
+        path: Path to load table from
+        exclude_columns: Columns to exclude
+        columns_to_rename: Optional d ict mapping
+            old column name -> new column name
+        sort_columns: Whether to sort the columns by name
+        Returns
+        -------
+        Presentations instance
+        """
+        path = Path(path)
+        df = pd.read_csv(path)
+        exclude_columns = exclude_columns if exclude_columns else []
+        df = df[[c for c in df if c not in exclude_columns]]
+        return Presentations(presentations=df,
+                             columns_to_rename=columns_to_rename,
+                             sort_columns=sort_columns)
 
     @classmethod
     def _postprocess(cls, presentations: pd.DataFrame,
@@ -161,8 +260,7 @@ class Presentations(DataObject, StimulusFileReadableInterface,
                      omitted_time_duration: float = 0.25) \
             -> pd.DataFrame:
         """
-        1. Filter/rearrange columns
-        2. Optionally fill missing values for omitted flashes (no need when
+        Optionally fill missing values for omitted flashes (no need when
             reading from NWB since already filled)
 
         Parameters
@@ -173,18 +271,7 @@ class Presentations(DataObject, StimulusFileReadableInterface,
             Whether to fill stop time and duration for omitted flashes
         omitted_time_duration
             Amount of time a stimuli is omitted for in seconds"""
-
-        def _filter_arrange_columns(df: pd.DataFrame):
-            df = df.drop(['index'], axis=1, errors='ignore')
-            df = df[['start_time', 'stop_time',
-                     'duration',
-                     'image_name', 'image_index',
-                     'is_change', 'omitted',
-                     'start_frame', 'end_frame',
-                     'image_set']]
-            return df
-
-        df = _filter_arrange_columns(df=presentations)
+        df = presentations
         if fill_omitted_values:
             cls._fill_missing_values_for_omitted_flashes(
                 df=df, omitted_time_duration=omitted_time_duration)

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/stimuli.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/stimuli.py
@@ -35,7 +35,10 @@ class Stimuli(DataObject, StimulusFileReadableInterface,
         return self._templates
 
     @classmethod
-    def from_nwb(cls, nwbfile: NWBFile) -> "Stimuli":
+    def from_nwb(cls,
+                 nwbfile: NWBFile,
+                 presentation_columns: Optional[List[str]] = None,
+                 presentation_fill_omitted_values: bool = True) -> "Stimuli":
         p = Presentations.from_nwb(nwbfile=nwbfile)
         t = Templates.from_nwb(nwbfile=nwbfile)
         return Stimuli(presentations=p, templates=t)
@@ -44,18 +47,55 @@ class Stimuli(DataObject, StimulusFileReadableInterface,
     def from_stimulus_file(
             cls, stimulus_file: BehaviorStimulusFile,
             stimulus_timestamps: StimulusTimestamps,
-            limit_to_images: Optional[List] = None) -> "Stimuli":
+            limit_to_images: Optional[List] = None,
+            presentation_columns: Optional[List[str]] = None,
+            presentation_fill_omitted_values: bool = True
+    ) -> "Stimuli":
+        """
+
+        Parameters
+        ----------
+        stimulus_file
+        stimulus_timestamps
+        limit_to_images: limit to certain images. Used for testing.
+        presentation_columns: The columns and order of columns
+            in the final presentations dataframe
+        presentation_fill_omitted_values: Whether to fill stop_time and
+            duration for omitted frames
+
+        Returns
+        -------
+
+        """
         p = Presentations.from_stimulus_file(
             stimulus_file=stimulus_file,
             stimulus_timestamps=stimulus_timestamps,
-            limit_to_images=limit_to_images)
+            limit_to_images=limit_to_images,
+            column_list=presentation_columns,
+            fill_omitted_values=presentation_fill_omitted_values
+        )
         t = Templates.from_stimulus_file(stimulus_file=stimulus_file,
                                          limit_to_images=limit_to_images)
         return Stimuli(presentations=p, templates=t)
 
-    def to_nwb(self, nwbfile: NWBFile) -> NWBFile:
+    def to_nwb(self, nwbfile: NWBFile,
+               presentations_stimulus_column_name='image_set') -> NWBFile:
+        """
+
+        Parameters
+        ----------
+        nwbfile
+        presentations_stimulus_column_name: Name of the column in the
+            presentations table that denotes the stimulus name
+
+        Returns
+        -------
+        NWBFile
+        """
         nwbfile = self._templates.to_nwb(
             nwbfile=nwbfile, stimulus_presentations=self._presentations)
-        nwbfile = self._presentations.to_nwb(nwbfile=nwbfile)
+        nwbfile = self._presentations.to_nwb(
+            nwbfile=nwbfile,
+            stimulus_name_column=presentations_stimulus_column_name)
 
         return nwbfile

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -17,6 +17,7 @@ from allensdk.brain_observatory.nwb import check_nwbfile_version
 from .._channels import Channels
 from ..optotagging import OptotaggingTable
 from ..probes import Probes
+from ...behavior.data_objects.stimuli.presentations import Presentations
 
 color_triplet_re = re.compile(r"\[(-{0,1}\d*\.\d*,\s*)*(-{0,1}\d*\.\d*)\]")
 
@@ -78,7 +79,9 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
         return self.nwbfile.session_start_time
 
     def get_stimulus_presentations(self):
-        table = super(EcephysNwbSessionApi, self).get_stimulus_presentations()
+        table = Presentations.from_nwb(nwbfile=self.nwbfile,
+                                       add_is_change=False)
+        table = table.value
 
         if "color" in table.columns:
             # the color column actually contains two parameters. One is

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -20,7 +20,6 @@ from pynwb.ophys import (
 from allensdk.brain_observatory.behavior.data_objects.stimuli\
     .stimulus_templates import StimulusTemplate
 from allensdk.brain_observatory.behavior.write_nwb.extensions.stimulus_template.ndx_stimulus_template import StimulusTemplateExtension  # noqa: E501
-from allensdk.brain_observatory.nwb.nwb_utils import (get_column_name)
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
 from allensdk.brain_observatory.behavior.image_api import ImageApi
@@ -503,70 +502,6 @@ def create_stimulus_presentation_time_interval(
             interval.add_column(name=column_name, description=description)
 
     return interval
-
-
-def add_stimulus_presentations(nwbfile, stimulus_table,
-                               tag='stimulus_time_interval'):
-    """Adds a stimulus table (defining stimulus characteristics for each
-    time point in a session) to an nwbfile as TimeIntervals.
-
-    Parameters
-    ----------
-    nwbfile : pynwb.NWBFile
-    stimulus_table: pd.DataFrame
-        Each row corresponds to an interval of time. Columns define the
-        interval (start and stop time) and its characteristics.
-        Nans in columns with string data will be replaced with the empty
-        strings.
-        Required columns are:
-            start_time :: the time at which this interval started
-            stop_time :: the time  at which this interval ended
-    tag : str, optional
-        Each interval in an nwb file has one or more tags. This string will be
-        applied as a tag to all TimeIntervals created here
-
-    Returns
-    -------
-    nwbfile : pynwb.NWBFile
-
-    """
-    stimulus_table = stimulus_table.copy()
-    ts = nwbfile.processing['stimulus'].get_data_interface('timestamps')
-    possible_names = {'stimulus_name', 'image_name'}
-    stimulus_name_column = get_column_name(stimulus_table.columns,
-                                           possible_names)
-    stimulus_names = stimulus_table[stimulus_name_column].unique()
-
-    for stim_name in sorted(stimulus_names):
-        specific_stimulus_table = stimulus_table[stimulus_table[stimulus_name_column] == stim_name]  # noqa: E501
-        # Drop columns where all values in column are NaN
-        cleaned_table = specific_stimulus_table.dropna(axis=1, how='all')
-        # For columns with mixed strings and NaNs, fill NaNs with 'N/A'
-        for colname, series in cleaned_table.items():
-            types = set(series.map(type))
-            if len(types) > 1 and str in types:
-                series.fillna('N/A', inplace=True)
-                cleaned_table[colname] = series.transform(str)
-
-        interval_description = (f"Presentation times and stimuli details "
-                                f"for '{stim_name}' stimuli. "
-                                f"\n"
-                                f"Note: image_name references "
-                                f"control_description in stimulus/templates")
-        presentation_interval = create_stimulus_presentation_time_interval(
-            name=f"{stim_name}_presentations",
-            description=interval_description,
-            columns_to_add=cleaned_table.columns
-        )
-
-        for row in cleaned_table.itertuples(index=False):
-            row = row._asdict()
-
-            presentation_interval.add_interval(**row, tags=tag, timeseries=ts)
-
-        nwbfile.add_time_intervals(presentation_interval)
-
-    return nwbfile
 
 
 def add_invalid_times(nwbfile, epochs):

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
@@ -1,15 +1,17 @@
+import json
 from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
 import pynwb
 import pytest
+from pynwb import NWBFile
 
 from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_objects.stimuli.presentations \
     import \
-    Presentations as StimulusPresentations
+    Presentations as StimulusPresentations, Presentations
 from allensdk.brain_observatory.behavior.data_objects.stimuli.stimuli import \
     Stimuli
 from allensdk.brain_observatory.behavior.data_objects.stimuli.templates \
@@ -48,6 +50,49 @@ class TestFromBehaviorStimulusFile(LimsTest):
             limit_to_images=['im065'])
         assert stimuli.presentations == self.expected_presentations
         assert stimuli.templates == self.expected_templates
+
+
+class TestPresentations:
+    @classmethod
+    def setup_class(cls):
+        with open('/allen/aibs/informatics/module_test_data/ecephys/'
+                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                as f:
+            cls.input_data = json.load(f)['session_data']
+        cls._table_from_json = Presentations.from_path(
+            path=cls.input_data['stim_table_file'])
+
+    def setup_method(self, method):
+        self._nwbfile = NWBFile(
+            session_description='foo',
+            identifier='foo',
+            session_id='foo',
+            session_start_time=datetime.now(),
+            institution="Allen Institute"
+        )
+        # Need to write stimulus timestamps first
+        bsf = BehaviorStimulusFile.from_json(dict_repr=self.input_data)
+        ts = StimulusTimestamps.from_stimulus_file(stimulus_file=bsf,
+                                                   monitor_delay=0.0)
+        ts.to_nwb(nwbfile=self._nwbfile)
+
+    @pytest.mark.requires_bamboo
+    @pytest.mark.parametrize('roundtrip', [True, False])
+    def test_read_write_nwb(self, roundtrip,
+                            data_object_roundtrip_fixture):
+        self._table_from_json.to_nwb(nwbfile=self._nwbfile)
+
+        if roundtrip:
+            obt = data_object_roundtrip_fixture(
+                nwbfile=self._nwbfile,
+                data_object_cls=Presentations,
+                add_is_change=False
+            )
+        else:
+            obt = Presentations.from_nwb(nwbfile=self._nwbfile,
+                                         add_is_change=False)
+
+        assert obt == self._table_from_json
 
 
 class TestNWB:


### PR DESCRIPTION
Addresses #2349

This PR makes it so that VBN can reuse the existing `Presentations` class. 
In AllenSDK, VBO computed the stimulus presentations table. However in VBN, it is computed outside of AllenSDK. This adds a method `Presentations.from_path` to load a precomputed table. 

This PR also moves logic from ecephys into `Presentations` class to reduce code duplication. 

Addresses #2332: it is expected for `omitted` column to contain nans. `is_change` has already been precomputed, so the problem code block used to calculate `is_change` does not need to be called for VBN. 