### PR TITLE
Add ability to write stimulus templates to NWB for VBN

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/stimuli.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/stimuli.py
@@ -35,11 +35,13 @@ class Stimuli(DataObject, StimulusFileReadableInterface,
         return self._templates
 
     @classmethod
-    def from_nwb(cls,
-                 nwbfile: NWBFile,
-                 presentation_columns: Optional[List[str]] = None,
-                 presentation_fill_omitted_values: bool = True) -> "Stimuli":
-        p = Presentations.from_nwb(nwbfile=nwbfile)
+    def from_nwb(
+            cls,
+            nwbfile: NWBFile,
+            presentation_columns: Optional[List[str]] = None
+    ) -> "Stimuli":
+        p = Presentations.from_nwb(nwbfile=nwbfile,
+                                   column_list=presentation_columns)
         t = Templates.from_nwb(nwbfile=nwbfile)
         return Stimuli(presentations=p, templates=t)
 

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/templates.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/templates.py
@@ -4,8 +4,8 @@ from typing import Optional, List
 
 import imageio
 from pynwb import NWBFile
+from pynwb.image import IndexSeries
 
-from allensdk.brain_observatory import nwb
 from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.core import DataObject
 from allensdk.core import \
@@ -128,12 +128,31 @@ class Templates(DataObject, StimulusFileReadableInterface,
 
         nwbfile.add_stimulus_template(visual_stimulus_image_series)
 
-        # Add index for this template to NWB in-memory object:
+        if 'image_index' in stimulus_presentations.value:
+            nwbfile = self._add_image_index_to_nwb(
+                nwbfile=nwbfile, presentations=stimulus_presentations)
+
+        return nwbfile
+
+    def _add_image_index_to_nwb(
+            self, nwbfile: NWBFile, presentations: Presentations):
+        """Adds the image index and start_time for all stimulus templates
+        to NWB"""
+        stimulus_templates = self.value
+        presentations = presentations.value
+
         nwb_template = nwbfile.stimulus_template[
             stimulus_templates.image_set_name]
-        stimulus_index = stimulus_presentations.value[
-            stimulus_presentations.value[
-                'image_set'] == nwb_template.name]
-        nwb.add_stimulus_index(nwbfile, stimulus_index, nwb_template)
+        stimulus_name = 'image_set' \
+            if 'image_set' in presentations else 'stimulus_name'
+        stimulus_index = presentations[
+            presentations[stimulus_name] == nwb_template.name]
 
+        image_index = IndexSeries(
+            name=nwb_template.name,
+            data=stimulus_index['image_index'].values,
+            unit='None',
+            indexed_timeseries=nwb_template,
+            timestamps=stimulus_index['start_time'].values)
+        nwbfile.add_stimulus(image_index)
         return nwbfile

--- a/allensdk/brain_observatory/nwb/__init__.py
+++ b/allensdk/brain_observatory/nwb/__init__.py
@@ -13,13 +13,10 @@ import SimpleITK as sitk
 import pynwb
 from pynwb.base import TimeSeries, Images
 from pynwb import ProcessingModule, NWBFile
-from pynwb.image import GrayscaleImage, IndexSeries
+from pynwb.image import GrayscaleImage
 from pynwb.ophys import (
     DfOverF, ImageSegmentation, OpticalChannel, Fluorescence)
 
-from allensdk.brain_observatory.behavior.data_objects.stimuli\
-    .stimulus_templates import StimulusTemplate
-from allensdk.brain_observatory.behavior.write_nwb.extensions.stimulus_template.ndx_stimulus_template import StimulusTemplateExtension  # noqa: E501
 from allensdk.brain_observatory import dict_to_indexed_array
 from allensdk.brain_observatory.behavior.image_api import Image
 from allensdk.brain_observatory.behavior.image_api import ImageApi
@@ -431,34 +428,6 @@ def add_running_speed_to_nwbfile(nwbfile, running_speed,
     return nwbfile
 
 
-def add_stimulus_template(nwbfile: NWBFile,
-                          stimulus_template: StimulusTemplate):
-    unwarped_images = []
-    warped_images = []
-    image_names = []
-    for image_name, image_data in stimulus_template.items():
-        image_names.append(image_name)
-        unwarped_images.append(image_data.unwarped)
-        warped_images.append(image_data.warped)
-
-    image_index = np.zeros(len(image_names))
-    image_index[:] = np.nan
-
-    visual_stimulus_image_series = \
-        StimulusTemplateExtension(
-            name=stimulus_template.image_set_name,
-            data=warped_images,
-            unwarped=unwarped_images,
-            control=list(range(len(image_names))),
-            control_description=image_names,
-            unit='NA',
-            format='raw',
-            timestamps=image_index)
-
-    nwbfile.add_stimulus_template(visual_stimulus_image_series)
-    return nwbfile
-
-
 def create_stimulus_presentation_time_interval(
         name: str, description: str,
         columns_to_add: Iterable) -> pynwb.epoch.TimeIntervals:
@@ -744,18 +713,6 @@ def add_segmentation_mask_image(nwbfile,
               'ophys',
               'Ophys processing module',
               image_api=image_api)
-
-
-def add_stimulus_index(nwbfile, stimulus_index, nwb_template):
-
-    image_index = IndexSeries(
-        name=nwb_template.name,
-        data=stimulus_index['image_index'].values,
-        unit='None',
-        indexed_timeseries=nwb_template,
-        timestamps=stimulus_index['start_time'].values)
-
-    nwbfile.add_stimulus(image_index)
 
 
 def add_metadata(nwbfile, metadata: dict, behavior_only: bool):


### PR DESCRIPTION
Addresses #2363

The main thing that needed to be addressed to add support for the `Stimuli` class is that in VBN there is no "image_index" column in the presentations table. This means that the image index shouldn't be written to nwb.

Moves some code from `nwb/__init__` into `Templates` class.

`Stimuli` can be instantiated like this
```
stimuli = Stimuli(
  presentations=Presentations.from_path(...),
  templates=Templates.from_stimulus_file(...)
)
```