### PR TITLE
add behavior ecephys metadata

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_metadata.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_metadata.py
@@ -223,7 +223,7 @@ class BehaviorMetadata(DataObject, LimsReadableInterface,
                       foraging_id=foraging_id.value,
                       stimulus_file=stimulus_file)
 
-        return cls(
+        return BehaviorMetadata(
             subject_metadata=subject_metadata,
             behavior_session_id=behavior_session_id,
             equipment=equipment,
@@ -246,7 +246,7 @@ class BehaviorMetadata(DataObject, LimsReadableInterface,
         session_uuid = BehaviorSessionUUID.from_stimulus_file(
             stimulus_file=stimulus_file)
 
-        return cls(
+        return BehaviorMetadata(
             subject_metadata=subject_metadata,
             behavior_session_id=behavior_session_id,
             equipment=equipment,
@@ -265,7 +265,7 @@ class BehaviorMetadata(DataObject, LimsReadableInterface,
         session_type = SessionType.from_nwb(nwbfile=nwbfile)
         session_uuid = BehaviorSessionUUID.from_nwb(nwbfile=nwbfile)
 
-        return cls(
+        return BehaviorMetadata(
             subject_metadata=subject_metadata,
             behavior_session_id=behavior_session_id,
             equipment=equipment,

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_session_uuid.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_session_uuid.py
@@ -30,8 +30,11 @@ class BehaviorSessionUUID(DataObject, StimulusFileReadableInterface,
     @classmethod
     def from_nwb(cls, nwbfile: NWBFile) -> "BehaviorSessionUUID":
         metadata = nwbfile.lab_meta_data['metadata']
-        id = uuid.UUID(metadata.behavior_session_uuid)
-        return cls(behavior_session_uuid=id)
+        behavior_session_uuid = metadata.behavior_session_uuid
+        behavior_session_uuid = \
+            uuid.UUID(behavior_session_uuid) \
+            if behavior_session_uuid != 'None' else None
+        return cls(behavior_session_uuid=behavior_session_uuid)
 
     def validate(self, behavior_session_id: int,
                  foraging_id: int,

--- a/allensdk/brain_observatory/ecephys/_behavior_ecephys_metadata.py
+++ b/allensdk/brain_observatory/ecephys/_behavior_ecephys_metadata.py
@@ -1,0 +1,75 @@
+from pynwb import NWBFile
+
+from allensdk.brain_observatory.behavior.data_objects import BehaviorSessionId
+from allensdk.brain_observatory.behavior.data_objects.metadata\
+    .behavior_metadata.behavior_metadata import \
+    BehaviorMetadata
+from allensdk.brain_observatory.behavior.data_objects.metadata\
+    .behavior_metadata.behavior_session_uuid import \
+    BehaviorSessionUUID
+from allensdk.brain_observatory.behavior.data_objects.metadata\
+    .behavior_metadata.equipment import \
+    Equipment
+from allensdk.brain_observatory.behavior.data_objects.metadata\
+    .behavior_metadata.session_type import \
+    SessionType
+from allensdk.brain_observatory.behavior.data_objects.metadata\
+    .behavior_metadata.stimulus_frame_rate import \
+    StimulusFrameRate
+from allensdk.brain_observatory.behavior.data_objects.metadata\
+    .subject_metadata.subject_metadata import \
+    SubjectMetadata
+from allensdk.core import JsonReadableInterface, NwbReadableInterface
+
+
+class BehaviorEcephysMetadata(BehaviorMetadata, JsonReadableInterface,
+                              NwbReadableInterface):
+    def __init__(
+            self,
+            ecephys_session_id: int,
+            subject_metadata: SubjectMetadata,
+            behavior_session_id: BehaviorSessionId,
+            behavior_session_uuid: BehaviorSessionUUID,
+            equipment: Equipment,
+            session_type: SessionType,
+            stimulus_frame_rate: StimulusFrameRate
+    ):
+        super().__init__(
+            subject_metadata=subject_metadata,
+            behavior_session_id=behavior_session_id,
+            behavior_session_uuid=behavior_session_uuid,
+            equipment=equipment,
+            session_type=session_type,
+            stimulus_frame_rate=stimulus_frame_rate
+        )
+        self._ecephys_session_id = ecephys_session_id
+
+    @property
+    def ecephys_session_id(self) -> int:
+        return self._ecephys_session_id
+
+    @classmethod
+    def from_json(cls, dict_repr: dict) -> "BehaviorEcephysMetadata":
+        behavior_metadata = super().from_json(dict_repr=dict_repr)
+        return BehaviorEcephysMetadata(
+            ecephys_session_id=dict_repr['ecephys_session_id'],
+            subject_metadata=behavior_metadata.subject_metadata,
+            behavior_session_id=behavior_metadata._behavior_session_id,
+            behavior_session_uuid=behavior_metadata._behavior_session_uuid,
+            equipment=behavior_metadata.equipment,
+            session_type=behavior_metadata._session_type,
+            stimulus_frame_rate=behavior_metadata._stimulus_frame_rate
+        )
+
+    @classmethod
+    def from_nwb(cls, nwbfile: NWBFile) -> "BehaviorEcephysMetadata":
+        behavior_metadata = super().from_nwb(nwbfile=nwbfile)
+        return BehaviorEcephysMetadata(
+            ecephys_session_id=int(nwbfile.identifier),
+            behavior_session_id=behavior_metadata._behavior_session_id,
+            behavior_session_uuid=behavior_metadata._behavior_session_uuid,
+            equipment=behavior_metadata.equipment,
+            session_type=behavior_metadata._session_type,
+            stimulus_frame_rate=behavior_metadata._stimulus_frame_rate,
+            subject_metadata=behavior_metadata.subject_metadata
+        )

--- a/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_metadata.py
+++ b/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_metadata.py
@@ -1,0 +1,45 @@
+import datetime
+import json
+
+import pytest
+from pynwb import NWBFile
+
+from allensdk.brain_observatory.ecephys._behavior_ecephys_metadata import \
+    BehaviorEcephysMetadata
+
+
+class TestBehaviorEcephysMetadata:
+    @classmethod
+    def setup_class(cls):
+        with open('/allen/aibs/informatics/module_test_data/ecephys/'
+                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                as f:
+            input_data = json.load(f)
+        input_data = input_data['session_data']
+        cls._ecephys_session_id = input_data['ecephys_session_id']
+        cls._meta_from_json = BehaviorEcephysMetadata.from_json(
+            dict_repr=input_data)
+
+    def setup_method(self, method):
+        self._nwbfile = NWBFile(
+            session_description='foo',
+            identifier=str(self._ecephys_session_id),
+            session_id='foo',
+            session_start_time=datetime.datetime.now(),
+            institution="Allen Institute"
+        )
+
+    @pytest.mark.requires_bamboo
+    @pytest.mark.parametrize('roundtrip', [True, False])
+    def test_read_write_nwb(self, roundtrip,
+                            data_object_roundtrip_fixture):
+        self._meta_from_json.to_nwb(nwbfile=self._nwbfile)
+
+        if roundtrip:
+            obt = data_object_roundtrip_fixture(
+                nwbfile=self._nwbfile,
+                data_object_cls=BehaviorEcephysMetadata)
+        else:
+            obt = BehaviorEcephysMetadata.from_nwb(nwbfile=self._nwbfile)
+
+        assert obt == self._meta_from_json


### PR DESCRIPTION
Addresses #2347

This PR adds a class `BehaviorEcephysMetadata`. It is a subclass of `BehaviorMetadata` and adds 1 field: `ecephys_session_id`. 