### PR TITLE
ticket/2337/multi/stim/running/speed

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/multi_stim_running_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/multi_stim_running_processing.py
@@ -1,0 +1,336 @@
+from typing import Tuple, Dict
+import numpy as np
+import pandas as pd
+
+from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
+    BehaviorStimulusFile,
+    MappingStimulusFile,
+    ReplayStimulusFile,
+    _StimulusFile)
+
+from allensdk.brain_observatory.sync_stim_aligner import (
+    get_stim_timestamps_from_stimulus_blocks)
+
+from allensdk.brain_observatory.behavior.data_objects.\
+    running_speed.running_processing import (
+        get_running_df
+    )
+
+
+def _extract_dx_info(
+        frame_times: np.ndarray,
+        stimulus_file: _StimulusFile,
+        zscore_threshold: float = 10.0,
+        use_lowpass_filter: bool = True
+) -> pd.core.frame.DataFrame:
+    """
+    Extract all of the running speed data
+
+    Parameters
+    ----------
+    frame_times: numpy.ndarray
+        list of the vsync times corresponding to this
+        stimulus block
+    stimulus_file: _StimulusFile
+        _StimulusFile object from which to get running data
+    zscore_threshold: float
+        The threshold to use for removing outlier
+        running speeds which might be noise and not true signal
+    use_lowpass_filter: bool
+        whther or not to apply a low pass filter to the
+        running speed results
+
+    Returns
+    -------
+    velocities: pd.DataFrame
+
+    Notes
+    -----
+    see allensdk.brain_observatory.behavior.data_objects.\
+        running_speed.running_processing.get_running_df
+
+    for detailed contents of output dataframe
+    """
+
+    stim_file = stimulus_file.data
+
+    velocities = get_running_df(
+                    stim_file,
+                    frame_times,
+                    use_lowpass_filter,
+                    zscore_threshold
+    )
+
+    return velocities
+
+
+def _merge_dx_data(
+    mapping_velocities: pd.core.frame.DataFrame,
+    behavior_velocities: pd.core.frame.DataFrame,
+    replay_velocities: pd.core.frame.DataFrame,
+    frame_times: np.ndarray,
+    behavior_start_frame: int
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Concatenate all of the running speed data
+
+    Parameters
+    ----------
+    mapping_velocities: pandas.core.frame.DataFrame
+        Velocity data from mapping stimulus
+    behavior_velocities: pandas.core.frame.DataFrame
+       Velocity data from behavior stimulus
+    replay_velocities: pandas.core.frame.DataFrame
+        Velocity data from replay stimulus
+    frame_times: numpy.ndarray
+        list of the vsync times for all three stimulus blocks
+        together
+    behavior_start_frame: int
+        frame on which behavior data starts
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, pd.DataFrame]
+        concatenated velocity data, raw data
+    """
+
+    speed = np.concatenate(
+        (
+            behavior_velocities['speed'],
+            mapping_velocities['speed'],
+            replay_velocities['speed']),
+        axis=None
+        )
+
+    dx = np.concatenate(
+        (
+            behavior_velocities['dx'],
+            mapping_velocities['dx'],
+            replay_velocities['dx']),
+        axis=None
+    )
+
+    vsig = np.concatenate(
+        (
+            behavior_velocities['v_sig'],
+            mapping_velocities['v_sig'],
+            replay_velocities['v_sig']),
+        axis=None
+    )
+
+    vin = np.concatenate(
+        (
+            behavior_velocities['v_in'],
+            mapping_velocities['v_in'],
+            replay_velocities['v_in']),
+        axis=None
+    )
+
+    frame_indexes = list(
+        range(behavior_start_frame,
+              behavior_start_frame+len(frame_times))
+    )
+
+    velocities = pd.DataFrame(
+        {
+            "velocity": speed,
+            "net_rotation": dx,
+            "frame_indexes": frame_indexes,
+            "frame_time": frame_times
+        }
+    )
+
+    # Warning - the 'isclose' line below needs to be refactored
+    # is it exists in multiple places
+
+    # due to an acquisition bug (the buffer of raw orientations
+    # may be updated more slowly than it is read, leading to
+    # a 0 value for the change in orientation over an interval)
+    # there may be exact zeros in the velocity.
+    velocities = velocities[~(np.isclose(velocities["net_rotation"], 0.0))]
+
+    raw_data = pd.DataFrame(
+        {"vsig": vsig, "vin": vin, "frame_time": frame_times, "dx": dx}
+    )
+
+    return (velocities, raw_data)
+
+
+def multi_stim_running_df_from_raw_data(
+    sync_path: str,
+    behavior_stimulus_file: BehaviorStimulusFile,
+    mapping_stimulus_file: MappingStimulusFile,
+    replay_stimulus_file: ReplayStimulusFile,
+    use_lowpass_filter: bool,
+    zscore_threshold: float,
+    behavior_start_frame: int
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Derive running speed data frames from sync file and
+    pickle files
+
+    Parameters
+    ----------
+    sync_path: str
+        The path to the sync file
+    behavior_stimulus_file: BehaviorStimulusFile
+        stimulus file for the behavior stimulus block
+    mapping_stimulus_file: MappingStimulusFile
+        stimulus file for the mapping stimulus block
+    replay_stimulus_file: ReplayStimulusFile
+        stimulus file for the replay stimulus block
+    use_lowpass_filter: bool
+        whther or not to apply a low pass filter to the
+        running speed results
+    zscore_threshold: float
+        The threshold to use for removing outlier
+        running speeds which might be noise and not true signal
+    behavior_start_frame: int
+        the frame on which behavior data starts
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, pd.DataFrame]
+        concatenated velocity data, raw data
+
+
+    Notes
+    -----
+    velocities pd.DataFrame:
+        columns:
+            "velocity": computed running speed
+            "net_rotation": dx in radians
+            "frame_indexes": frame indexes into
+                the full vsync times list
+
+    raw data pd.DataFrame:
+        Dataframe with an index of timestamps and the following
+        columns:
+            "vsig": voltage signal from the encoder
+            "vin": the theoretical maximum voltage that the encoder
+                will reach prior to "wrapping". This should
+                theoretically be 5V (after crossing
+                5V goes to 0V, or vice versa). In
+                practice the encoder does not always
+                reach this value before wrapping, which can cause
+                transient spikes in speed at the voltage "wraps".
+            "frame_time": list of the vsync times
+            "dx": angular change, computed during data collection
+        The raw data are provided so that the user may compute
+        their own speed from source, if desired.
+    """
+
+    timestamp_results = get_stim_timestamps_from_stimulus_blocks(
+                              stimulus_files=[behavior_stimulus_file,
+                                              mapping_stimulus_file,
+                                              replay_stimulus_file],
+                              sync_file=sync_path,
+                              raw_frame_time_lines=['frames',
+                                                    'stim_vsync',
+                                                    'vsync_stim'],
+                              raw_frame_time_direction='rising',
+                              frame_count_tolerance=0.0)
+
+    behavior_timestamps = timestamp_results["timestamps"][0]
+    mapping_timestamps = timestamp_results["timestamps"][1]
+    replay_timestamps = timestamp_results["timestamps"][2]
+
+    start_frame = timestamp_results["start_frames"][0]
+
+    behavior_velocities = _extract_dx_info(
+        frame_times=behavior_timestamps,
+        stimulus_file=behavior_stimulus_file,
+        zscore_threshold=zscore_threshold,
+        use_lowpass_filter=use_lowpass_filter
+    )
+
+    mapping_velocities = _extract_dx_info(
+        frame_times=mapping_timestamps,
+        stimulus_file=mapping_stimulus_file,
+        zscore_threshold=zscore_threshold,
+        use_lowpass_filter=use_lowpass_filter
+    )
+
+    replay_velocities = _extract_dx_info(
+        frame_times=replay_timestamps,
+        stimulus_file=replay_stimulus_file,
+        zscore_threshold=zscore_threshold,
+        use_lowpass_filter=use_lowpass_filter
+    )
+
+    all_frame_times = np.concatenate(
+            [behavior_timestamps,
+             mapping_timestamps,
+             replay_timestamps])
+
+    velocities, raw_data = _merge_dx_data(
+        mapping_velocities=mapping_velocities,
+        behavior_velocities=behavior_velocities,
+        replay_velocities=replay_velocities,
+        frame_times=all_frame_times,
+        behavior_start_frame=start_frame
+    )
+
+    return (velocities, raw_data)
+
+
+def _get_multi_stim_running_df(
+        sync_path: str,
+        behavior_stimulus_file: BehaviorStimulusFile,
+        mapping_stimulus_file: MappingStimulusFile,
+        replay_stimulus_file: ReplayStimulusFile,
+        use_lowpass_filter: bool,
+        zscore_threshold: float) -> Dict[str, pd.DataFrame]:
+    """
+    Parameters
+    ----------
+    sync_path: str
+        The path to the sync file
+
+    behavior_stimulus_file: BehaviorStimulusFile
+
+    mapping_stimulus_file: MappingStimulusFile
+
+    replay_stimulus_file: ReplayStimulusFile
+
+    use_lowpass_filter: bool
+        whther or not to apply a low pass filter to the
+        running speed results
+
+    zscore_threshold: float
+        The threshold to use for removing outlier
+        running speeds which might be noise and not true signal
+
+    Returns
+    -------
+    A dict containing two data frames.
+        'running_speed': A dataframe with mapping time to speed
+        'running_acquisition': A dataframe mapping time to raw data
+                               coming off the running wheel
+    """
+    (velocity_data,
+     acq_data) = multi_stim_running_df_from_raw_data(
+                    sync_path=sync_path,
+                    behavior_stimulus_file=behavior_stimulus_file,
+                    mapping_stimulus_file=mapping_stimulus_file,
+                    replay_stimulus_file=replay_stimulus_file,
+                    use_lowpass_filter=use_lowpass_filter,
+                    zscore_threshold=zscore_threshold,
+                    behavior_start_frame=0)
+
+    running_speed = pd.DataFrame(
+                      data={
+                            'timestamps': velocity_data.frame_time.values,
+                            'speed': velocity_data.velocity.values
+                      })
+
+    running_acq = pd.DataFrame(
+                     data={
+                         'dx': acq_data.dx.values,
+                         'timestamps': acq_data.frame_time.values,
+                         'v_in': acq_data.vin.values,
+                         'v_sig': acq_data.vsig.values
+                     }).set_index('timestamps')
+
+    return {'running_speed': running_speed,
+            'running_acquisition': running_acq}

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
@@ -1,9 +1,5 @@
 
-import json
 from typing import Optional
-
-from cachetools import cached, LRUCache
-from cachetools.keys import hashkey
 
 import pandas as pd
 import numpy as np
@@ -28,23 +24,6 @@ from allensdk.brain_observatory.behavior.data_objects.running_speed.running_proc
 from allensdk.brain_observatory.behavior.data_objects.\
     running_speed.multi_stim_running_processing import (
         _get_multi_stim_running_df)
-
-def from_json_cache_key(
-    cls,
-    dict_repr: dict,
-):
-    return hashkey(json.dumps(dict_repr))
-
-
-def from_lims_cache_key(
-    cls,
-    db,
-    behavior_session_id: int,
-    ophys_experiment_id: Optional[int] = None
-):
-    return hashkey(
-        behavior_session_id, ophys_experiment_id
-    )
 
 
 class RunningAcquisition(DataObject,

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_speed.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_speed.py
@@ -13,11 +13,18 @@ from allensdk.core import DataObject
 from allensdk.brain_observatory.behavior.data_files import SyncFile
 from allensdk.brain_observatory.behavior.data_objects import StimulusTimestamps
 from allensdk.brain_observatory.behavior.data_files import (
-    BehaviorStimulusFile
+    BehaviorStimulusFile,
+    ReplayStimulusFile,
+    MappingStimulusFile
 )
 from allensdk.brain_observatory.behavior.data_objects.running_speed.running_processing import (  # noqa: E501
     get_running_df
 )
+
+
+from allensdk.brain_observatory.behavior.data_objects.\
+    running_speed.multi_stim_running_processing import (
+        _get_multi_stim_running_df)
 
 
 class RunningSpeed(DataObject,
@@ -85,6 +92,10 @@ class RunningSpeed(DataObject,
             sync_file: Optional[SyncFile] = None,
             filtered: bool = True,
             zscore_threshold: float = 10.0) -> "RunningSpeed":
+        """
+        sync_file is used for generating timestamps. If None, timestamps
+        will be generated from the stimulus file.
+        """
 
         if sync_file is not None:
             stimulus_timestamps = StimulusTimestamps.from_sync_file(
@@ -107,6 +118,39 @@ class RunningSpeed(DataObject,
             stimulus_file=behavior_stimulus_file,
             stimulus_timestamps=stimulus_timestamps,
             filtered=filtered)
+
+    @classmethod
+    def from_multiple_stimulus_files(
+            cls,
+            behavior_stimulus_file: BehaviorStimulusFile,
+            mapping_stimulus_file: MappingStimulusFile,
+            replay_stimulus_file: ReplayStimulusFile,
+            sync_file: SyncFile,
+            filtered: bool = True,
+            zscore_threshold: float = 10.0) -> "RunningSpeed":
+        """
+        sync_file is used for generating timestamps.
+
+        Stimulus blocks are assumed to be presented in the order
+        behavior_stimulus_file
+        mapping_stimulus_file
+        replay_stimulus_file
+        """
+
+        df = _get_multi_stim_running_df(
+                sync_path=sync_file.filepath,
+                behavior_stimulus_file=behavior_stimulus_file,
+                mapping_stimulus_file=mapping_stimulus_file,
+                replay_stimulus_file=replay_stimulus_file,
+                use_lowpass_filter=filtered,
+                zscore_threshold=zscore_threshold)['running_speed']
+
+        return cls(
+               running_speed=df,
+               filtered=filtered,
+               sync_file=None,
+               stimulus_file=None,
+               stimulus_timestamps=None)
 
     @classmethod
     def from_nwb(

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
@@ -197,8 +197,9 @@ class StimulusTimestamps(DataObject,
                         frame_count_tolerance=frame_count_tolerance)
 
         to_concatenate = \
-            [t for t in stimulus_times] if stims_of_interest is None else \
-            [stimulus_times[idx] for idx in stims_of_interest]
+            [t for t in stimulus_times["timestamps"]] \
+            if stims_of_interest is None else  \
+            [stimulus_times["timestamps"][idx] for idx in stims_of_interest]
 
         timestamps = np.concatenate(to_concatenate)
 

--- a/allensdk/brain_observatory/multi_stimulus_running_speed/multi_stimulus_running_speed.py
+++ b/allensdk/brain_observatory/multi_stimulus_running_speed/multi_stimulus_running_speed.py
@@ -1,9 +1,18 @@
-import numpy as np
+"""
+This file defines an ArgSchemaParser for generating an HDF5 file
+containing all of the running speed data from a session in which
+multiple stimulus blocks (behavior, mapping, replay) were presented
+to the mouse and need to be registered to the sync file.
+"""
+
 import pandas as pd
-from allensdk.brain_observatory.sync_dataset import Dataset as SyncDataset
-from allensdk.brain_observatory import sync_utilities
 import argschema
 import json
+
+from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
+    BehaviorStimulusFile,
+    MappingStimulusFile,
+    ReplayStimulusFile)
 
 from allensdk.brain_observatory.multi_stimulus_running_speed._schemas import (
     MultiStimulusRunningSpeedInputParameters,
@@ -11,9 +20,8 @@ from allensdk.brain_observatory.multi_stimulus_running_speed._schemas import (
 )
 
 from allensdk.brain_observatory.behavior.data_objects.\
-    running_speed.running_processing import (
-        get_running_df
-    )
+    running_speed.multi_stim_running_processing import (
+        multi_stim_running_df_from_raw_data)
 
 
 class MultiStimulusRunningSpeed(argschema.ArgSchemaParser):
@@ -21,250 +29,6 @@ class MultiStimulusRunningSpeed(argschema.ArgSchemaParser):
     default_output_schema = MultiStimulusRunningSpeedOutputParameters
 
     START_FRAME = 0
-
-    def _extract_dx_info(
-        self,
-        frame_times: np.ndarray,
-        start_index: int,
-        end_index: int,
-        pkl_path: str
-    ) -> pd.core.frame.DataFrame:
-        """
-        Extract all of the running speed data
-
-        Parameters
-        ----------
-        frame_times: numpy.ndarray
-            list of the vsync times
-        start_index: int
-            Index to the first frame of the stimulus
-        end_index: int
-           Index to the last frame of the stimulus
-        pkl_path: string
-            Path to the stimulus pickle file
-
-        Returns
-        -------
-        pd.DataFrame
-
-        Notes
-        -------
-            velocity pd.DataFrame:
-                columns:
-                    "velocity": computed running speed
-                    "net_rotation": dx in radians
-                    "frame_indexes": frame indexes into
-                        the full vsync times list
-
-            raw data pd.DataFrame:
-                Dataframe with an index of timestamps and the following
-                columns:
-                    "vsig": voltage signal from the encoder
-                    "vin": the theoretical maximum voltage that the encoder
-                        will reach prior to "wrapping". This should
-                        theoretically be 5V (after crossing
-                        5V goes to 0V, or vice versa). In
-                        practice the encoder does not always
-                        reach this value before wrapping, which can cause
-                        transient spikes in speed at the voltage "wraps".
-                    "frame_time": list of the vsync times
-                    "dx": angular change, computed during data collection
-                The raw data are provided so that the user may compute
-                their own speed from source, if desired.
-
-        """
-
-        stim_file = pd.read_pickle(pkl_path)
-        frame_times = frame_times[start_index:end_index]
-
-        # occasionally an extra set of frame times are acquired
-        # after the rest of the signals. We detect and remove these
-        frame_times = sync_utilities.trim_discontiguous_times(frame_times)
-
-        velocities = get_running_df(
-                        stim_file,
-                        frame_times,
-                        self.args['use_lowpass_filter'],
-                        self.args['zscore_threshold']
-        )
-
-        return velocities
-
-    def _get_behavior_frame_count(
-        self,
-        pkl_file_path: str
-    ) -> int:
-        """
-        Get the number of frames in a behavior pickle file
-
-        Parameters
-        ----------
-        pkl_file_path: string
-            A path to a behavior pickle file
-        """
-        data = pd.read_pickle(pkl_file_path)
-
-        return len(data["items"]["behavior"]['intervalsms']) + 1
-
-    def _get_frame_count(
-        self,
-        pkl_file_path: str
-    ) -> int:
-        """
-        Get the number of frames in a mapping or replay pickle file
-
-        Parameters
-        ----------
-        pkl_file_path: string
-            A path to a mapping or replay pickle file
-        """
-
-        data = pd.read_pickle(pkl_file_path)
-
-        return len(data['intervalsms']) + 1
-
-    def _get_frame_counts(
-        self
-    ) -> list:
-        """
-        Get the number of frames for each stimulus
-        """
-
-        behavior_frame_count = self._get_behavior_frame_count(
-            self.args['behavior_pkl_path']
-        )
-
-        mapping_frame_count = self._get_frame_count(
-            self.args['mapping_pkl_path']
-        )
-
-        replay_frames_count = self._get_frame_count(
-            self.args['replay_pkl_path']
-        )
-
-        return behavior_frame_count, mapping_frame_count, replay_frames_count
-
-    def _get_frame_times(
-        self
-    ) -> np.ndarray:
-        """
-        Get the vsync frame times
-        """
-        sync_data = SyncDataset(self.args['sync_h5_path'])
-
-        return sync_data.get_edges(
-            "rising", SyncDataset.FRAME_KEYS, units="seconds"
-        )
-
-    def _get_stimulus_starts_and_ends(self) -> list:
-        """
-        Get the start and stop frame indexes for each stimulus
-        """
-
-        (
-            behavior_frame_count,
-            mapping_frame_count,
-            replay_frames_count
-        ) = self._get_frame_counts()
-
-        behavior_start = MultiStimulusRunningSpeed.START_FRAME
-        mapping_start = behavior_frame_count
-        replay_start = mapping_start + mapping_frame_count
-        replay_end = replay_start + replay_frames_count
-
-        return (
-            behavior_start,
-            mapping_start,
-            replay_start,
-            replay_end
-        )
-
-    def _merge_dx_data(
-        self,
-        mapping_velocities: pd.core.frame.DataFrame,
-        behavior_velocities: pd.core.frame.DataFrame,
-        replay_velocities: pd.core.frame.DataFrame,
-        frame_times: np.ndarray
-    ) -> list:
-        """
-        Concatenate all of the running speed data
-
-        Parameters
-        ----------
-        mapping_velocities: pandas.core.frame.DataFrame
-            Velocity data from mapping stimulus
-        behavior_velocities: pandas.core.frame.DataFrame
-           Velocity data from behavior stimulus
-        replay_velocities: pandas.core.frame.DataFrame
-            Velocity data from replay stimulus
-        frame_times: numpy.ndarray
-            list of the vsync times
-
-        Returns
-        -------
-        list[pd.DataFrame, pd.DataFrame]
-            concatenated velocity data, raw data
-        """
-
-        speed = np.concatenate(
-            (
-                behavior_velocities['speed'],
-                mapping_velocities['speed'],
-                replay_velocities['speed']),
-            axis=None
-        )
-
-        dx = np.concatenate(
-            (
-                behavior_velocities['dx'],
-                mapping_velocities['dx'],
-                replay_velocities['dx']),
-            axis=None
-        )
-
-        vsig = np.concatenate(
-            (
-                behavior_velocities['v_sig'],
-                mapping_velocities['v_sig'],
-                replay_velocities['v_sig']),
-            axis=None
-        )
-
-        vin = np.concatenate(
-            (
-                behavior_velocities['v_in'],
-                mapping_velocities['v_in'],
-                replay_velocities['v_in']),
-            axis=None
-        )
-
-        frame_indexes = list(
-            range(MultiStimulusRunningSpeed.START_FRAME, len(frame_times))
-        )
-
-        velocities = pd.DataFrame(
-            {
-                "velocity": speed,
-                "net_rotation": dx,
-                "frame_indexes": frame_indexes,
-                "frame_time": frame_times
-            }
-        )
-
-        # Warning - the 'isclose' line below needs to be refactored
-        # is it exists in multiple places
-
-        # due to an acquisition bug (the buffer of raw orientations
-        # may be updated more slowly than it is read, leading to
-        # a 0 value for the change in orientation over an interval)
-        # there may be exact zeros in the velocity.
-        velocities = velocities[~(np.isclose(velocities["net_rotation"], 0.0))]
-
-        raw_data = pd.DataFrame(
-            {"vsig": vsig, "vin": vin, "frame_time": frame_times, "dx": dx}
-        )
-
-        return velocities, raw_data
 
     def _write_output_json(self):
         """
@@ -285,42 +49,27 @@ class MultiStimulusRunningSpeed(argschema.ArgSchemaParser):
         Process an experiment with a three stimulus sessions
         """
 
-        (
-            behavior_start,
-            mapping_start,
-            replay_start,
-            replay_end
-        ) = self._get_stimulus_starts_and_ends()
+        bstim = BehaviorStimulusFile.from_json(
+               dict_repr={'behavior_stimulus_file':
+                          self.args['behavior_pkl_path']})
 
-        frame_times = self._get_frame_times()
+        mstim = MappingStimulusFile.from_json(
+               dict_repr={'mapping_stimulus_file':
+                          self.args['mapping_pkl_path']})
 
-        behavior_velocities = self._extract_dx_info(
-            frame_times,
-            behavior_start,
-            mapping_start,
-            self.args['behavior_pkl_path']
-        )
+        rstim = ReplayStimulusFile.from_json(
+               dict_repr={'replay_stimulus_file':
+                          self.args['replay_pkl_path']})
 
-        mapping_velocities = self._extract_dx_info(
-            frame_times,
-            mapping_start,
-            replay_start,
-            self.args['mapping_pkl_path']
-        )
-
-        replay_velocities = self._extract_dx_info(
-            frame_times,
-            replay_start,
-            replay_end,
-            self.args['replay_pkl_path']
-        )
-
-        velocities, raw_data = self._merge_dx_data(
-            mapping_velocities,
-            behavior_velocities,
-            replay_velocities,
-            frame_times
-        )
+        (velocities,
+         raw_data) = multi_stim_running_df_from_raw_data(
+                 sync_path=self.args['sync_h5_path'],
+                 behavior_stimulus_file=bstim,
+                 mapping_stimulus_file=mstim,
+                 replay_stimulus_file=rstim,
+                 use_lowpass_filter=self.args['use_lowpass_filter'],
+                 zscore_threshold=self.args['zscore_threshold'],
+                 behavior_start_frame=MultiStimulusRunningSpeed.START_FRAME)
 
         store = pd.HDFStore(self.args['output_path'])
         store.put("running_speed", velocities)

--- a/allensdk/brain_observatory/sync_stim_aligner.py
+++ b/allensdk/brain_observatory/sync_stim_aligner.py
@@ -1,7 +1,7 @@
 # Here we will define a class for aligning the timesteps in a sync
 # file with the frames listed in a stimulus pickle file.
 
-from typing import Tuple, Union, List
+from typing import Tuple, Union, List, Dict, Any
 import numpy as np
 import logging
 import pathlib
@@ -306,7 +306,7 @@ def get_stim_timestamps_from_stimulus_blocks(
         sync_file: Union[str, pathlib.Path],
         raw_frame_time_lines: Union[str, List[str]],
         raw_frame_time_direction: str,
-        frame_count_tolerance: float) -> List[np.ndarray]:
+        frame_count_tolerance: float) -> Dict[str, Any]:
     """
     Find the timestamps associated a set of stimulus blocks
     that have to be aligned with a single sync file
@@ -330,10 +330,17 @@ def get_stim_timestamps_from_stimulus_blocks(
 
     Returns
     -------
-    list_of_timestamps: List[np.ndarray]
+    A dict in which
+
+    "timestamps" -> List[np.ndarray]
         The list of timestamp arrays corresponding to the provided
-        _StimulusFiles. **The order of stimulus_files will dictate
-        the order of start_frames**.
+        _StimulusFiles.
+
+    "start_frames" -> List[int]
+        The list of starting frames for the provided _StimulusFiles
+
+     **The order of stimulus_files will dictate the order of these
+     lists.**
 
     Notes
     -----
@@ -378,4 +385,6 @@ def get_stim_timestamps_from_stimulus_blocks(
         for f0, nf in zip(start_frames, frame_count_list):
             this_array = raw_frame_times[f0:f0+nf]
             list_of_timestamps.append(this_array)
-    return list_of_timestamps
+
+    return {"timestamps": list_of_timestamps,
+            "start_frames": start_frames}

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/conftest.py
@@ -1,0 +1,432 @@
+import pytest
+import numpy as np
+import pathlib
+import tempfile
+import pandas as pd
+import h5py
+import json
+
+from allensdk.brain_observatory.behavior.data_files.sync_file import (
+    SyncFile)
+
+from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
+    BehaviorStimulusFile,
+    ReplayStimulusFile,
+    MappingStimulusFile)
+
+
+@pytest.fixture
+def basic_running_stim_file_fixture():
+    rng = np.random.default_rng()
+    return {
+        "items": {
+            "behavior": {
+                "encoders": [
+                    {
+                        "dx": rng.random((100,)),
+                        "vsig": rng.uniform(low=0.0, high=5.1, size=(100,)),
+                        "vin": rng.uniform(low=4.9, high=5.0, size=(100,)),
+                    }]}}}
+
+
+@pytest.fixture(scope='session')
+def stimulus_file_frame_fixture(
+        tmp_path_factory,
+        helper_functions):
+    """
+    Writes some skeletal stimulus files (really only good for getting
+    frame counts) to disk. Yields a tuple of dicts
+
+    frame_count_lookup maps the type of file to the number
+    of expected frames (type of file is 'behavior', 'mapping',
+    or 'replay')
+
+    pkl_path_lookup maps the type of file to the path to the
+    temporary pickle file
+    """
+
+    tmpdir = tmp_path_factory.mktemp('all_frame_count_test')
+    pkl_path_lookup = dict()
+    pkl_path_lookup['behavior'] = pathlib.Path(
+                          tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    pkl_path_lookup['mapping'] = pathlib.Path(
+                          tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    pkl_path_lookup['replay'] = pathlib.Path(
+                          tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    frame_count_lookup = {'behavior': 13, 'mapping': 44, 'replay': 76}
+
+    data = {'items':
+            {'behavior':
+             {'intervalsms':
+              list(range(frame_count_lookup['behavior']-1))}}}
+    pd.to_pickle(data, pkl_path_lookup['behavior'])
+
+    for key in ('mapping', 'replay'):
+        data = {'intervalsms': list(range(frame_count_lookup[key]-1))}
+        pd.to_pickle(data, pkl_path_lookup[key])
+
+    output_pkl_path = dict()
+    for key in pkl_path_lookup:
+        val = pkl_path_lookup[key]
+        val = str(val.resolve().absolute())
+        output_pkl_path[key] = val
+
+    yield (frame_count_lookup, output_pkl_path)
+
+    for key in pkl_path_lookup:
+        helper_functions.windows_safe_cleanup(
+                    file_path=pkl_path_lookup[key])
+
+
+@pytest.fixture(scope='session')
+def merge_data_fixture():
+    """
+    Return a dict keyed on
+    'behavior', 'mapping', 'replay'
+    each pointing to dx, speed, v_sig, and v_in data, along
+    with a dataframe containing those columns
+
+    'kept_mask' will be boolean mask for timesteps
+    with dx != 0.0
+
+    n_timesteps
+    """
+
+    output = dict()
+    rng = np.random.default_rng(229988)
+    n_total = 0
+    for key in ('behavior', 'mapping', 'replay'):
+        nt = rng.integers(20, 40, 1)[0]
+        n_total += nt
+        this_entry = dict()
+        speed = rng.random(nt)
+        dx = rng.random(nt)+0.1
+        v_in = rng.random(nt)
+        v_sig = rng.random(nt)
+
+        n_skip = rng.integers(nt//4, nt//3, 1)[0]
+        skipped = np.sort(rng.choice(np.arange(nt, dtype=int),
+                                     n_skip,
+                                     replace=False))
+        dx[skipped] = 0.0
+
+        df = pd.DataFrame(data={'dx': dx,
+                                'v_in': v_in,
+                                'v_sig': v_sig,
+                                'speed': speed})
+
+        kept_mask = np.ones(nt, dtype=bool)
+        kept_mask[skipped] = False
+
+        this_entry['speed'] = speed
+        this_entry['dx'] = dx
+        this_entry['v_in'] = v_in
+        this_entry['v_sig'] = v_sig
+        this_entry['dataframe'] = df
+        this_entry['kept_mask'] = kept_mask
+        output[key] = this_entry
+
+    output['n_timesteps'] = n_total
+    return output
+
+
+# Below here we define a self-consistent set of stimulus datasets for testing
+
+@pytest.fixture(scope='session')
+def pkl_tmp_dir_fixture(
+        tmp_path_factory):
+    """
+    A directory where the temporary data files can be written
+    """
+    tmpdir = pathlib.Path(tmp_path_factory.mktemp(
+                               'self_consistent_multi_stim'))
+    return tmpdir
+
+
+@pytest.fixture(scope='session')
+def behavior_pkl_fixture(
+        pkl_tmp_dir_fixture,
+        helper_functions):
+    """
+    Write a pkl file for behavior data.
+
+    Return a dict with
+        path_to_pkl
+        dx
+        vsig
+        vin
+        n_frames
+    """
+
+    rng = np.random.default_rng(77123412)
+
+    pkl_path = pathlib.Path(
+                    tempfile.mkstemp(
+                        dir=pkl_tmp_dir_fixture,
+                        prefix='behavior_',
+                        suffix='.pkl')[1])
+    n_frames = 77
+
+    n_skip = rng.integers(10, n_frames//2, 1)[0]
+    to_skip = rng.choice(np.arange(n_frames, dtype=int),
+                         n_skip,
+                         replace=False)
+    kept_mask = np.ones(n_frames, dtype=bool)
+    kept_mask[to_skip] = False
+
+    dx = rng.random((n_frames,))
+    dx[to_skip] = 0.0
+    vsig = rng.uniform(low=0.0, high=5.1, size=(n_frames,))
+    vin = rng.uniform(low=4.9, high=5.0, size=(n_frames,))
+
+    data = {
+        "items": {
+            "behavior": {
+                "encoders": [
+                    {
+                        "dx": dx,
+                        "vsig": vsig,
+                        "vin": vin,
+                    }]}}}
+
+    data['items']['behavior']['intervalsms'] = list(range(n_frames-1))
+
+    pd.to_pickle(data, pkl_path)
+
+    output = {
+        'path_to_pkl': str(pkl_path.resolve().absolute()),
+        'dx': dx,
+        'vsig': vsig,
+        'vin': vin,
+        'n_frames': n_frames,
+        'kept_mask': kept_mask}
+
+    yield output
+    helper_functions.windows_safe_cleanup(file_path=pkl_path)
+
+
+@pytest.fixture(scope='session')
+def behavior_stim_file_fixture(behavior_pkl_fixture):
+    yield BehaviorStimulusFile.from_json(
+        dict_repr={'behavior_stimulus_file':
+                   behavior_pkl_fixture['path_to_pkl']})
+
+
+@pytest.fixture(scope='session')
+def mapping_pkl_fixture(
+        pkl_tmp_dir_fixture,
+        helper_functions):
+    """
+    Write a pkl file for mapping data.
+
+    Return a dict with
+        path_to_pkl
+        dx
+        vsig
+        vin
+        n_frames
+    """
+
+    rng = np.random.default_rng(442138)
+
+    pkl_path = pathlib.Path(
+                    tempfile.mkstemp(
+                        dir=pkl_tmp_dir_fixture,
+                        prefix='mapping_',
+                        suffix='.pkl')[1])
+    n_frames = 53
+
+    n_skip = rng.integers(10, n_frames//2, 1)[0]
+    to_skip = rng.choice(np.arange(n_frames, dtype=int),
+                         n_skip,
+                         replace=False)
+    kept_mask = np.ones(n_frames, dtype=bool)
+    kept_mask[to_skip] = False
+
+    dx = rng.random((n_frames,))
+    dx[to_skip] = 0.0
+    vsig = rng.uniform(low=0.0, high=5.1, size=(n_frames,))
+    vin = rng.uniform(low=4.9, high=5.0, size=(n_frames,))
+
+    data = {
+        "items": {
+            "behavior": {
+                "encoders": [
+                    {
+                        "dx": dx,
+                        "vsig": vsig,
+                        "vin": vin,
+                    }]}}}
+
+    data['intervalsms'] = list(range(n_frames-1))
+
+    pd.to_pickle(data, pkl_path)
+
+    output = {
+        'path_to_pkl': str(pkl_path.resolve().absolute()),
+        'dx': dx,
+        'vsig': vsig,
+        'vin': vin,
+        'n_frames': n_frames,
+        'kept_mask': kept_mask}
+
+    yield output
+    helper_functions.windows_safe_cleanup(file_path=pkl_path)
+
+
+@pytest.fixture(scope='session')
+def mapping_stim_file_fixture(mapping_pkl_fixture):
+    yield MappingStimulusFile.from_json(
+         dict_repr={'mapping_stimulus_file':
+                    mapping_pkl_fixture['path_to_pkl']})
+
+
+@pytest.fixture(scope='session')
+def replay_pkl_fixture(
+        pkl_tmp_dir_fixture,
+        helper_functions):
+    """
+    Write a pkl file for replay data.
+
+    Return a dict with
+        path_to_pkl
+        dx
+        vsig
+        vin
+        n_frames
+    """
+
+    rng = np.random.default_rng(55332211)
+
+    pkl_path = pathlib.Path(
+                    tempfile.mkstemp(
+                        dir=pkl_tmp_dir_fixture,
+                        prefix='replay_',
+                        suffix='.pkl')[1])
+    n_frames = 47
+
+    n_skip = rng.integers(10, n_frames//2, 1)[0]
+    to_skip = rng.choice(np.arange(n_frames, dtype=int),
+                         n_skip,
+                         replace=False)
+    kept_mask = np.ones(n_frames, dtype=bool)
+    kept_mask[to_skip] = False
+
+    dx = rng.random((n_frames,))
+    dx[to_skip] = 0.0
+    vsig = rng.uniform(low=0.0, high=5.1, size=(n_frames,))
+    vin = rng.uniform(low=4.9, high=5.0, size=(n_frames,))
+
+    data = {
+        "items": {
+            "behavior": {
+                "encoders": [
+                    {
+                        "dx": dx,
+                        "vsig": vsig,
+                        "vin": vin,
+                    }]}}}
+
+    data['intervalsms'] = list(range(n_frames-1))
+
+    pd.to_pickle(data, pkl_path)
+
+    output = {
+        'path_to_pkl': str(pkl_path.resolve().absolute()),
+        'dx': dx,
+        'vsig': vsig,
+        'vin': vin,
+        'n_frames': n_frames,
+        'kept_mask': kept_mask}
+
+    yield output
+    helper_functions.windows_safe_cleanup(file_path=pkl_path)
+
+
+@pytest.fixture(scope='session')
+def replay_stim_file_fixture(replay_pkl_fixture):
+    yield ReplayStimulusFile.from_json(
+        dict_repr={'replay_stimulus_file':
+                   replay_pkl_fixture['path_to_pkl']})
+
+
+@pytest.fixture(scope='session')
+def sync_path_fixture(
+        behavior_pkl_fixture,
+        replay_pkl_fixture,
+        mapping_pkl_fixture,
+        pkl_tmp_dir_fixture,
+        helper_functions):
+    """
+    path to test sync file that can go with these pickle files
+    """
+
+    metadata = {'ni_daq':
+                {'device': 'Dev1',
+                 'counter_output_freq': 100.0,
+                 'sample_rate': 100.0,
+                 'counter_bits': 32,
+                 'event_bits': 32},
+                'start_time': '2020-10-07 14:01:17.336502',
+                'stop_time': '2020-10-07 16:42:24.177205',
+                'line_labels': ['vsync_stim',
+                                'stim_running',
+                                'vsync_2p',
+                                'lick_sensor',
+                                'eye_tracking',
+                                'behavior_monitoring',
+                                'stim_photodiode'],
+                'timeouts': [],
+                'version': '2.2.1+g1bc7438.b42257',
+                'sampling_type': 'frequency',
+                'file_version': '1.0.0',
+                'line_label_revision': 3,
+                'total_samples': 10000}
+
+    sync_path = pathlib.Path(
+                    tempfile.mkstemp(
+                        dir=pkl_tmp_dir_fixture,
+                        prefix='example_',
+                        suffix='.sync')[1])
+
+    nb = behavior_pkl_fixture['n_frames']
+    nm = mapping_pkl_fixture['n_frames']
+    nr = replay_pkl_fixture['n_frames']
+    nframes = nb + nm + nr
+
+    n_lines = 5*nframes
+    data = np.zeros((n_lines, 2), dtype=np.uint32)
+    data[:, 0] = np.arange(n_lines, dtype=np.uint32)+1
+
+    for i_beh in range(2, 2+3*nb, 3):
+        data[i_beh:i_beh+1, 1] += 1
+    data[1:i_beh+1, 1] += 2
+
+    for i_map in range(i_beh+3, i_beh+1+3*nm, 3):
+        data[i_map:i_map+1, 1] += 1
+    data[i_beh+2:i_map+1] += 2
+
+    for i_replay in range(i_map+4, i_map+1+3*nb, 3):
+        data[i_replay: i_replay+1, 1] += 1
+    data[i_map+4: i_replay+1] += 2
+
+    with h5py.File(sync_path, 'w') as out_file:
+        out_file.create_dataset(
+            'data', data=data)
+        out_file.create_dataset(
+            'meta',
+            data=json.dumps(metadata).encode('utf-8'))
+
+    yield sync_path
+
+    helper_functions.windows_safe_cleanup(file_path=sync_path)
+
+
+@pytest.fixture(scope='session')
+def sync_file_fixture(sync_path_fixture):
+    return SyncFile.from_json(
+        dict_repr={'sync_file':
+                   str(sync_path_fixture.resolve().absolute())})

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_multi_stim_running_processing.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_multi_stim_running_processing.py
@@ -1,0 +1,215 @@
+import pytest
+from itertools import product
+import copy
+import numpy as np
+import tempfile
+import pathlib
+import pandas as pd
+from unittest.mock import patch
+
+from allensdk.brain_observatory.behavior.\
+    data_objects.running_speed.running_processing import (
+        get_running_df)
+
+from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
+    BehaviorStimulusFile,
+    ReplayStimulusFile,
+    MappingStimulusFile)
+
+from allensdk.brain_observatory.behavior.\
+    data_objects.running_speed.multi_stim_running_processing import (
+        _extract_dx_info,
+        _merge_dx_data,
+        multi_stim_running_df_from_raw_data)
+
+
+@pytest.mark.parametrize(
+        "use_lowpass, zscore",
+        product((True, False),
+                (5.0, 10.0)))
+def test_extract_dx_basic(
+        basic_running_stim_file_fixture,
+        use_lowpass,
+        zscore,
+        tmp_path_factory,
+        helper_functions):
+    """
+    Test that _extract_dx_info behaves like get_running_df with
+    start_index and end_index handled correctly
+    """
+    tmpdir = tmp_path_factory.mktemp('extract_dx_test')
+
+    stim_file = basic_running_stim_file_fixture
+
+    n_time = len(stim_file['items']['behavior']['encoders'][0]['dx'])
+    time_array = np.linspace(0., 10., n_time)
+
+    expected_stim = copy.deepcopy(stim_file)
+    for key in ('dx', 'vsig', 'vin'):
+        raw = expected_stim['items']['behavior']['encoders'][0].pop(key)
+        expected_stim['items']['behavior']['encoders'][0][key] = raw
+
+    expected = get_running_df(
+                  data=expected_stim,
+                  time=time_array,
+                  lowpass=use_lowpass,
+                  zscore_threshold=zscore)
+
+    pkl_path = pathlib.Path(
+                    tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    pd.to_pickle(expected_stim, pkl_path)
+
+    class DummyStimFile(object):
+        def __init__(self, pkl_path):
+            self.data = pd.read_pickle(pkl_path)
+
+    actual = _extract_dx_info(
+                frame_times=time_array,
+                stimulus_file=DummyStimFile(pkl_path.resolve().absolute()),
+                zscore_threshold=zscore,
+                use_lowpass_filter=use_lowpass)
+
+    pd.testing.assert_frame_equal(actual, expected)
+
+    helper_functions.windows_safe_cleanup(file_path=pkl_path)
+
+
+def test_extract_dx_time_mismatch(
+        basic_running_stim_file_fixture,
+        tmp_path_factory,
+        helper_functions):
+    """
+    Test that an exception gets thrown if frame_times is not of the
+    correct length
+    """
+
+    tmpdir = tmp_path_factory.mktemp('extract_dx_test')
+
+    stim_file = basic_running_stim_file_fixture
+
+    n_time = len(stim_file['items']['behavior']['encoders'][0]['dx'])
+    time_array = np.linspace(0., 10., n_time-5)
+
+    pkl_path = pathlib.Path(
+                    tempfile.mkstemp(dir=tmpdir, suffix='.pkl')[1])
+
+    pd.to_pickle(stim_file, pkl_path)
+
+    class DummyStimFile(object):
+        def __init__(self, pkl_path):
+            self.data = pd.read_pickle(pkl_path)
+
+    with pytest.raises(ValueError, match="length of v_in"):
+        _extract_dx_info(
+                frame_times=time_array,
+                stimulus_file=DummyStimFile(pkl_path.resolve().absolute()),
+                zscore_threshold=10.0,
+                use_lowpass_filter=True)
+
+    helper_functions.windows_safe_cleanup(file_path=pkl_path)
+
+
+@pytest.mark.parametrize('start_frame', [0, 15])
+def test_merge_dx_data(merge_data_fixture,
+                       start_frame):
+    """
+    Test that _merge_dx_data correctly merges dataframes
+    """
+
+    frame_times = np.linspace(0.,
+                              10.,
+                              merge_data_fixture['n_timesteps'])
+
+    (velocity_df,
+     raw_df) = _merge_dx_data(
+        mapping_velocities=merge_data_fixture['mapping']['dataframe'],
+        behavior_velocities=merge_data_fixture['behavior']['dataframe'],
+        replay_velocities=merge_data_fixture['replay']['dataframe'],
+        frame_times=frame_times,
+        behavior_start_frame=start_frame)
+
+    assert set(velocity_df.columns) == set(['velocity',
+                                            'net_rotation',
+                                            'frame_indexes',
+                                            'frame_time'])
+
+    assert set(raw_df.columns) == set(['vsig', 'vin', 'frame_time', 'dx'])
+
+    # make sure that velocity_df skipped some timesteps
+    assert len(velocity_df.velocity.values) < len(raw_df.dx.values)
+
+    # check that velocity_df has the expected values, having
+    # skipped the right timesteps
+    for in_key, out_key in zip(('dx', 'speed'),
+                               ('net_rotation', 'velocity')):
+        expected = []
+        for pkl_key in ('behavior', 'mapping', 'replay'):
+            kept = merge_data_fixture[pkl_key]['kept_mask']
+            expected.append(merge_data_fixture[pkl_key][in_key][kept])
+        expected = np.concatenate(expected)
+        np.testing.assert_array_equal(velocity_df[out_key].values, expected)
+
+    # check contents of frame_time and frame_indexes
+    global_kept = np.concatenate([merge_data_fixture['behavior']['kept_mask'],
+                                  merge_data_fixture['mapping']['kept_mask'],
+                                  merge_data_fixture['replay']['kept_mask']])
+    np.testing.assert_array_equal(
+            frame_times[global_kept],
+            velocity_df.frame_time.values)
+
+    np.testing.assert_array_equal(
+            np.arange(start_frame,
+                      merge_data_fixture['n_timesteps']+start_frame,
+                      dtype=int)[global_kept],
+            velocity_df.frame_indexes.values)
+
+    # check contents of raw_df
+    for in_key, out_key in zip(('dx', 'v_in', 'v_sig'),
+                               ('dx', 'vin', 'vsig')):
+        expected = []
+        for pkl_key in ('behavior', 'mapping', 'replay'):
+            expected.append(merge_data_fixture[pkl_key][in_key])
+        expected = np.concatenate(expected)
+        np.testing.assert_array_equal(expected, raw_df[out_key].values)
+
+    np.testing.assert_array_equal(raw_df.frame_time.values,
+                                  frame_times)
+
+
+@pytest.mark.parametrize("start_frame", [0, ])
+def test_multi_stim_running_df_from_raw_data(
+        start_frame,
+        behavior_pkl_fixture,
+        replay_pkl_fixture,
+        mapping_pkl_fixture,
+        sync_path_fixture):
+    """
+    test that multi_stim_running_df_from_raw_data
+    can properly process stimulus pickle files
+    """
+
+    use_lowpass = True
+    zscore = 10.0
+
+    b_stim = BehaviorStimulusFile.from_json(
+                dict_repr={'behavior_stimulus_file':
+                           behavior_pkl_fixture['path_to_pkl']})
+
+    r_stim = ReplayStimulusFile.from_json(
+                dict_repr={'replay_stimulus_file':
+                           replay_pkl_fixture['path_to_pkl']})
+
+    m_stim = MappingStimulusFile.from_json(
+                dict_repr={'mapping_stimulus_file':
+                           mapping_pkl_fixture['path_to_pkl']})
+
+    (velocities_df,
+     raw_df) = multi_stim_running_df_from_raw_data(
+                sync_path=sync_path_fixture,
+                behavior_stimulus_file=b_stim,
+                mapping_stimulus_file=m_stim,
+                replay_stimulus_file=r_stim,
+                use_lowpass_filter=use_lowpass,
+                zscore_threshold=zscore,
+                behavior_start_frame=start_frame)

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_multi_stim_running_processing.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_multi_stim_running_processing.py
@@ -5,7 +5,6 @@ import numpy as np
 import tempfile
 import pathlib
 import pandas as pd
-from unittest.mock import patch
 
 from allensdk.brain_observatory.behavior.\
     data_objects.running_speed.running_processing import (

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_acquisition.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_acquisition.py
@@ -3,7 +3,6 @@ from unittest.mock import create_autospec
 
 import pandas as pd
 
-from allensdk.internal.api import PostgresQueryMixin
 from allensdk.brain_observatory.behavior.data_files import BehaviorStimulusFile
 from allensdk.brain_observatory.behavior.data_objects.running_speed.running_processing import (  # noqa: E501
     get_running_df
@@ -97,25 +96,17 @@ def test_running_acquisition_from_json(
             ".running_speed.running_acquisition.get_running_df",
             mock_get_running_df
         )
-        obt = RunningAcquisition.from_json(dict_repr)
+        obt = RunningAcquisition.from_stimulus_file(
+                    behavior_stimulus_file=mock_stimulus_file)
 
-    mock_stimulus_file.from_json.assert_called_once_with(dict_repr)
     mock_stimulus_file_instance = mock_stimulus_file.from_json(dict_repr)
-    assert obt._stimulus_file == mock_stimulus_file_instance
 
-    mock_stimulus_timestamps.from_json.assert_called_once_with(
-            dict_repr, monitor_delay=0.0)
     mock_stimulus_timestamps_instance = \
         mock_stimulus_timestamps.from_stimulus_file(
             stimulus_file=mock_stimulus_file_instance,
             monitor_delay=0.0
         )
     assert obt._stimulus_timestamps == mock_stimulus_timestamps_instance
-
-    mock_get_running_df.assert_called_once_with(
-        data=mock_stimulus_file_instance.data,
-        time=mock_stimulus_timestamps_instance.value,
-    )
 
     pd.testing.assert_frame_equal(obt.value, expected_running_acq_df)
 
@@ -198,131 +189,6 @@ def test_running_acquisition_to_json(
     else:
         obt = running_acq.to_json()
         assert obt == expected
-
-
-@pytest.mark.parametrize(
-    "behavior_session_id, ophys_experiment_id, "
-    "returned_running_acq_df, expected_running_acq_df",
-    [
-        (
-            # behavior_session_id
-            12345,
-            # ophys_experiment_id
-            None,
-            # returned_running_acq_df
-            pd.DataFrame(
-                {
-                    "timestamps": [1, 2],
-                    "speed": [3, 4],
-                    "dx": [5, 6],
-                    "v_sig": [7, 8],
-                    "v_in": [9, 10]
-                }
-            ).set_index("timestamps"),
-            # expected_running_acq_df
-            pd.DataFrame(
-                {
-                    "timestamps": [1, 2],
-                    "dx": [5, 6],
-                    "v_sig": [7, 8],
-                    "v_in": [9, 10]
-                }
-            ).set_index("timestamps")
-        ),
-        (
-            # behavior_session_id
-            1234,
-            # ophys_experiment_id
-            5678,
-            # returned_running_acq_df
-            pd.DataFrame(
-                {
-                    "timestamps": [2, 4],
-                    "speed": [6, 8],
-                    "dx": [10, 12],
-                    "v_sig": [14, 16],
-                    "v_in": [18, 20]
-                }
-            ).set_index("timestamps"),
-            # expected_running_acq_df
-            pd.DataFrame(
-                {
-                    "timestamps": [2, 4],
-                    "dx": [10, 12],
-                    "v_sig": [14, 16],
-                    "v_in": [18, 20]
-                }
-            ).set_index("timestamps")
-        )
-    ]
-)
-def test_running_acquisition_from_lims(
-    monkeypatch, behavior_session_id, ophys_experiment_id,
-    returned_running_acq_df, expected_running_acq_df
-):
-    mock_db_conn = create_autospec(PostgresQueryMixin, instance=True)
-
-    mock_stimulus_file = create_autospec(BehaviorStimulusFile)
-    mock_stimulus_timestamps = create_autospec(StimulusTimestamps)
-
-    class DummyTimestamps(object):
-        monitor_delay = 0.0
-        value = 0.0
-    dummy_ts = DummyTimestamps()
-
-    mock_stimulus_timestamps.from_stimulus_file.return_value = dummy_ts
-
-    mock_get_running_df = create_autospec(get_running_df)
-
-    mock_get_running_df.return_value = returned_running_acq_df
-
-    with monkeypatch.context() as m:
-        m.setattr(
-            "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_acquisition.BehaviorStimulusFile",
-            mock_stimulus_file
-        )
-        m.setattr(
-            "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_acquisition.StimulusTimestamps",
-            mock_stimulus_timestamps
-        )
-        m.setattr(
-            "allensdk.brain_observatory.behavior.data_objects"
-            ".running_speed.running_acquisition.get_running_df",
-            mock_get_running_df
-        )
-        obt = RunningAcquisition.from_lims(
-            mock_db_conn,
-            behavior_session_id=behavior_session_id,
-            ophys_experiment_id=ophys_experiment_id
-        )
-
-    mock_stimulus_file.from_lims.assert_called_once_with(
-        mock_db_conn, behavior_session_id
-    )
-    mock_stimulus_file_instance = mock_stimulus_file.from_lims(
-        mock_db_conn, behavior_session_id
-    )
-    assert obt._stimulus_file == mock_stimulus_file_instance
-
-    mock_stimulus_timestamps.from_stimulus_file.assert_called_once_with(
-        mock_stimulus_file_instance,
-        monitor_delay=0.0
-    )
-    mock_stimulus_timestamps_instance = mock_stimulus_timestamps.\
-        from_stimulus_file(stimulus_file=mock_stimulus_file,
-                           monitor_delay=0.0)
-    assert obt._stimulus_timestamps == mock_stimulus_timestamps_instance
-
-    mock_get_running_df.assert_called_once_with(
-        data=mock_stimulus_file_instance.data,
-        time=mock_stimulus_timestamps_instance.value,
-    )
-
-    pd.testing.assert_frame_equal(
-        obt.value, expected_running_acq_df, check_like=True
-    )
 
 
 # Fixtures:

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_speed_from_multi_stim.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_speed_from_multi_stim.py
@@ -1,13 +1,10 @@
 import pytest
-import numpy as np
 import pandas as pd
 from pynwb import NWBHDF5IO, NWBFile
 import tempfile
 import pathlib
 import pytz
 import datetime
-
-from unittest.mock import patch
 
 from allensdk.brain_observatory.behavior.data_objects.\
     running_speed.running_speed import (

--- a/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_speed_from_multi_stim.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/running_speed/test_running_speed_from_multi_stim.py
@@ -1,0 +1,106 @@
+import pytest
+import numpy as np
+import pandas as pd
+from pynwb import NWBHDF5IO, NWBFile
+import tempfile
+import pathlib
+import pytz
+import datetime
+
+from unittest.mock import patch
+
+from allensdk.brain_observatory.behavior.data_objects.\
+    running_speed.running_speed import (
+        RunningSpeed)
+
+from allensdk.brain_observatory.behavior.data_objects.\
+    running_speed.running_acquisition import (
+        RunningAcquisition)
+
+
+@pytest.mark.parametrize('filtered', [True, False])
+def test_vbn_running_speed_round_trip(
+        behavior_stim_file_fixture,
+        replay_stim_file_fixture,
+        mapping_stim_file_fixture,
+        sync_file_fixture,
+        tmp_path_factory,
+        helper_functions,
+        filtered):
+    """
+    Test that we can round trip VBNRunningSpeed between from_json, to_json,
+    from_nwb, and to_nwb
+    """
+    tmpdir = tmp_path_factory.mktemp('vbn_running_roundtrip')
+    nwb_path = pathlib.Path(
+                tempfile.mkstemp(
+                    dir=tmpdir,
+                    suffix='.nwb')[1])
+
+    running_obj = RunningSpeed.from_multiple_stimulus_files(
+                        behavior_stimulus_file=behavior_stim_file_fixture,
+                        mapping_stimulus_file=mapping_stim_file_fixture,
+                        replay_stimulus_file=replay_stim_file_fixture,
+                        sync_file=sync_file_fixture,
+                        filtered=filtered,
+                        zscore_threshold=10.0)
+
+    start_time = pytz.utc.localize(datetime.datetime(2020, 7, 11))
+    nwbfile = NWBFile(
+                   session_description='running',
+                   identifier='00001',
+                   session_start_time=start_time)
+
+    running_obj.to_nwb(nwbfile=nwbfile)
+    with NWBHDF5IO(nwb_path, 'w') as out_file:
+        out_file.write(nwbfile)
+
+    with NWBHDF5IO(nwb_path, 'r') as in_file:
+        new_obj = RunningSpeed.from_nwb(
+                        nwbfile=in_file.read(),
+                        filtered=filtered)
+
+    pd.testing.assert_frame_equal(new_obj.value, running_obj.value)
+    helper_functions.windows_safe_cleanup(file_path=nwb_path)
+
+
+def test_vbn_running_acq_round_trip(
+        behavior_stim_file_fixture,
+        replay_stim_file_fixture,
+        mapping_stim_file_fixture,
+        sync_file_fixture,
+        helper_functions,
+        tmp_path_factory):
+    """
+    Test that we can round trip VBNRunningAcquistion
+    between from_json, to_json, from_nwb, and to_nwb
+    """
+    tmpdir = tmp_path_factory.mktemp('vbn_running_acq_roundtrip')
+    nwb_path = pathlib.Path(
+                tempfile.mkstemp(
+                    dir=tmpdir,
+                    suffix='.nwb')[1])
+
+    running_obj = RunningAcquisition.from_multiple_stimulus_files(
+                    behavior_stimulus_file=behavior_stim_file_fixture,
+                    mapping_stimulus_file=mapping_stim_file_fixture,
+                    replay_stimulus_file=replay_stim_file_fixture,
+                    sync_file=sync_file_fixture)
+
+    start_time = pytz.utc.localize(datetime.datetime(202, 7, 11))
+    nwbfile = NWBFile(
+                   session_description='running',
+                   identifier='00001',
+                   session_start_time=start_time)
+
+    running_obj.to_nwb(nwbfile=nwbfile)
+    with NWBHDF5IO(nwb_path, 'w') as out_file:
+        out_file.write(nwbfile)
+
+    with NWBHDF5IO(nwb_path, 'r') as in_file:
+        new_obj = RunningAcquisition.from_nwb(
+                        nwbfile=in_file.read())
+
+    pd.testing.assert_frame_equal(new_obj.value, running_obj.value)
+
+    helper_functions.windows_safe_cleanup(file_path=nwb_path)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_experiment.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_experiment.py
@@ -114,8 +114,13 @@ def test_visbeh_ophys_data_set():
     assert len(data_set.corrected_fluorescence_traces) == 258 and \
         set(data_set.corrected_fluorescence_traces.columns) == \
         set(['cell_roi_id', 'corrected_fluorescence'])
-    np.testing.assert_array_almost_equal(data_set.running_speed.timestamps,
-                                         data_set.stimulus_timestamps)
+
+    monitor_delay = data_set._stimulus_timestamps.monitor_delay
+
+    np.testing.assert_array_almost_equal(
+        data_set.running_speed.timestamps,
+        data_set.stimulus_timestamps-monitor_delay)
+
     assert len(data_set.cell_specimen_table) == len(data_set.dff_traces)
     assert data_set.average_projection.data.shape == \
         data_set.max_projection.data.shape

--- a/allensdk/test/brain_observatory/sync_utilities/conftest.py
+++ b/allensdk/test/brain_observatory/sync_utilities/conftest.py
@@ -115,8 +115,7 @@ def sync_file_fixture(
     Yields the path to a sync file for testing
     """
     tmpdir = pathlib.Path(tmp_path_factory.mktemp('external_sync_test'))
-    sync_path = tmpdir / tempfile.mkstemp(suffix='sync')[1]
-
+    sync_path = pathlib.Path(tempfile.mkstemp(dir=tmpdir, suffix='sync')[1])
     n_samples = len(sync_sample_fixture)
     data = np.zeros((n_samples, 2), dtype=np.uint32)
     data[:, 0] = sync_sample_fixture

--- a/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
+++ b/allensdk/test/brain_observatory/sync_utilities/test_sync_stim_get_start_frames.py
@@ -245,14 +245,18 @@ def test_user_facing_get_stim_timestamps_smoke(
                raw_frame_time_direction=edge_type,
                frame_count_tolerance=0.0)
 
-    assert len(result) == 4
-    for ii, (this_array, this_stim) in enumerate(zip(result,
-                                                     stim_list)):
+    assert len(result["timestamps"]) == 4
+    for ii, (this_array,
+             this_start_frame,
+             this_stim) in enumerate(zip(result["timestamps"],
+                                         result["start_frames"],
+                                         stim_list)):
         raw_idx = line_to_edges_fixture['vsync_stim'][f'{edge_type}_idx']
         raw_times = sync_sample_fixture[raw_idx]/sync_freq_fixture
         idx0 = expected_start_frames_fixture[edge_type][ii]
         expected = raw_times[idx0: idx0+this_stim.num_frames()]
         np.testing.assert_array_equal(this_array, expected)
+        assert this_start_frame == expected_start_frames_fixture[edge_type][ii]
 
 
 @pytest.mark.parametrize(
@@ -287,11 +291,15 @@ def test_user_facing_get_stim_timestamps(
                 raw_frame_time_direction=edge_type,
                 frame_count_tolerance=tolerance)
 
-    assert len(result) == len(expected_idx)
-    for ii, (this_array, this_stim) in enumerate(zip(result,
-                                                     stim_list)):
+    assert len(result["timestamps"]) == len(expected_idx)
+    for ii, (this_array,
+             this_start_frame,
+             this_stim) in enumerate(zip(result["timestamps"],
+                                         result["start_frames"],
+                                         stim_list)):
         raw_idx = line_to_edges_fixture['vsync_stim'][f'{edge_type}_idx']
         raw_times = sync_sample_fixture[raw_idx]/sync_freq_fixture
         idx0 = expected_start[ii]
         expected = raw_times[idx0: idx0+this_stim.num_frames()]
         np.testing.assert_array_equal(this_array, expected)
+        assert this_start_frame == expected_start[ii]

--- a/allensdk/test/conftest.py
+++ b/allensdk/test/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+import pathlib
+import platform
+
+
+class HelperFunctions(object):
+
+    @staticmethod
+    def windows_safe_cleanup(file_path: pathlib.Path):
+        """
+        Try to unlink the specified path. If a PermissionError is raised,
+        ignore if the system is Windows (this has been observed on our CI
+        systems)
+        """
+        if file_path.exists():
+            try:
+                file_path.unlink()
+            except PermissionError:
+                if platform.system() == "Windows":
+                    pass
+                else:
+                    raise
+
+
+@pytest.fixture(scope='session')
+def helper_functions():
+    """
+    See solution to making helper functions available across
+    a pytest module in
+    https://stackoverflow.com/questions/33508060/create-and-import-helper-functions-in-tests-without-creating-packages-in-test-di
+    """
+    return HelperFunctions


### PR DESCRIPTION
This PR updates the RunningSpeed and RunningAcquisition data objects so that they can be instantiated from multiple stimulus files that have been registered to a single sync file.

Things to note:
- `from_lims`, `from_json`, and `to_json` have been removed from RunningSpeed and RunningAcquisition, since the meaning of those operations is now ambiguious.
- The existing `multi_stimulus_running_speed` processing module is preserved in a refactored state. I do not think we want to keep that module as an independent LIMS queue, but, in the interest of speed, I do not want to do the work of unwinding whatever LIMS work was done to add that queue to our pipelines.
- Insomuch as it uses a SyncFile, the `from_multiple_stimulus_files` class method for RunningSpeed and RunningAcquisition only really wants the path to the SyncFile. This is because our current SyncFile data file does some very VBO-specific processing on instantiation. I will open a new ticket to create a more generalized SyncFile data file (#2369).

I have validated that the `multi_stimulus_running_speed` module produces identical outputs to Corbett's prototype in #2331. Since the RunningSpeed and RunningAcquisition `from_multiple_stimulus_files` implementation uses the same processing code under the hood, I think this means that the data objects are ready to be integrated into the VBN session object.