### PR TITLE
Ticket/2375/eye/tracking/timestamps

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -21,6 +21,8 @@ from allensdk.brain_observatory.behavior.data_files.stimulus_file import (
 
 from allensdk.brain_observatory.behavior.data_files.eye_tracking_file import \
     EyeTrackingFile
+from allensdk.brain_observatory.behavior.\
+    data_files.eye_tracking_metadata_file import EyeTrackingMetadataFile
 from allensdk.brain_observatory.behavior.data_objects.eye_tracking \
     .eye_tracking_table import \
     EyeTrackingTable, get_lost_frames
@@ -265,9 +267,15 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
             eye_tracking_file = EyeTrackingFile.from_json(
                                     dict_repr=session_data)
+            try:
+                eye_tracking_metadata_file = EyeTrackingMetadataFile.from_json(
+                                    dict_repr=session_data)
+            except KeyError:
+                eye_tracking_metadata_file = None
 
             eye_tracking_table = cls._read_eye_tracking_table(
                     eye_tracking_file=eye_tracking_file,
+                    eye_tracking_metadata_file=eye_tracking_metadata_file,
                     sync_file=sync_file,
                     z_threshold=eye_tracking_z_threshold,
                     dilation_frames=eye_tracking_dilation_frames,
@@ -403,8 +411,11 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                     db=lims_db,
                     behavior_session_id=behavior_session_id.value)
 
+            eye_tracking_metadata_file = None
+
             eye_tracking_table = cls._read_eye_tracking_table(
                 eye_tracking_file=eye_tracking_file,
+                eye_tracking_metadata_file=eye_tracking_metadata_file,
                 sync_file=sync_file,
                 z_threshold=eye_tracking_z_threshold,
                 dilation_frames=eye_tracking_dilation_frames,
@@ -1372,6 +1383,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
     def _read_eye_tracking_table(
             cls,
             eye_tracking_file: EyeTrackingFile,
+            eye_tracking_metadata_file: EyeTrackingMetadataFile,
             sync_file: SyncFile,
             z_threshold: float,
             dilation_frames: int,

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -1401,7 +1401,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             trim_after_spike=False)
 
         stimulus_timestamps = StimulusTimestamps(
-                timestamps=frame_times,
+                timestamps=frame_times.to_numpy(),
                 monitor_delay=0.0)
 
         return EyeTrackingTable.from_data_file(

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -24,8 +24,7 @@ from allensdk.brain_observatory.behavior.data_files.eye_tracking_file import \
 from allensdk.brain_observatory.behavior.\
     data_files.eye_tracking_metadata_file import EyeTrackingMetadataFile
 from allensdk.brain_observatory.behavior.data_objects.eye_tracking \
-    .eye_tracking_table import \
-    EyeTrackingTable, get_lost_frames
+    .eye_tracking_table import EyeTrackingTable
 from allensdk.brain_observatory.behavior.data_objects.eye_tracking\
     .rig_geometry import \
     RigGeometry as EyeTrackingRigGeometry
@@ -278,8 +277,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                     eye_tracking_metadata_file=eye_tracking_metadata_file,
                     sync_file=sync_file,
                     z_threshold=eye_tracking_z_threshold,
-                    dilation_frames=eye_tracking_dilation_frames,
-                    drop_frames=eye_tracking_drop_frames)
+                    dilation_frames=eye_tracking_dilation_frames)
 
             eye_tracking_rig_geometry = EyeTrackingRigGeometry.from_json(
                 dict_repr=session_data)
@@ -418,8 +416,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                 eye_tracking_metadata_file=eye_tracking_metadata_file,
                 sync_file=sync_file,
                 z_threshold=eye_tracking_z_threshold,
-                dilation_frames=eye_tracking_dilation_frames,
-                drop_frames=False)
+                dilation_frames=eye_tracking_dilation_frames)
 
             eye_tracking_rig_geometry = EyeTrackingRigGeometry.from_lims(
                 behavior_session_id=behavior_session_id.value, lims_db=lims_db)
@@ -1386,8 +1383,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             eye_tracking_metadata_file: EyeTrackingMetadataFile,
             sync_file: SyncFile,
             z_threshold: float,
-            dilation_frames: int,
-            drop_frames: bool) -> EyeTrackingTable:
+            dilation_frames: int) -> EyeTrackingTable:
 
         # this is possible if instantiating from_lims
         if sync_file is None:
@@ -1401,7 +1397,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
         frame_times = sync_utilities.get_synchronized_frame_times(
             session_sync_file=sync_path,
             sync_line_label_keys=SyncDataset.EYE_TRACKING_KEYS,
-            drop_frames=drop_frames,
+            drop_frames=None,
             trim_after_spike=False)
 
         stimulus_timestamps = StimulusTimestamps(
@@ -1412,8 +1408,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                     data_file=eye_tracking_file,
                     stimulus_timestamps=stimulus_timestamps,
                     z_threshold=z_threshold,
-                    dilation_frames=dilation_frames,
-                    drop_frames=drop_frames)
+                    dilation_frames=dilation_frames)
 
     def _get_metadata(self, behavior_metadata: BehaviorMetadata) -> dict:
         """Returns dict of metadata"""

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -1408,7 +1408,8 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                     data_file=eye_tracking_file,
                     stimulus_timestamps=stimulus_timestamps,
                     z_threshold=z_threshold,
-                    dilation_frames=dilation_frames)
+                    dilation_frames=dilation_frames,
+                    empty_on_fail=True)
 
     def _get_metadata(self, behavior_metadata: BehaviorMetadata) -> dict:
         """Returns dict of metadata"""

--- a/allensdk/brain_observatory/behavior/data_files/eye_tracking_metadata_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/eye_tracking_metadata_file.py
@@ -1,0 +1,42 @@
+from typing import Union
+import pathlib
+import json
+from allensdk.internal.core import DataFile
+from allensdk.internal.core.lims_utilities import safe_system_path
+
+
+class EyeTrackingMetadataFile(DataFile):
+    """
+    Datafile for tracking the metadata file associated with the
+    eye tracking camera
+    """
+
+    def __init__(self, filepath: Union[str, pathlib.Path]):
+        super().__init__(filepath=filepath)
+
+    @staticmethod
+    def load_data(filepath: Union[str, pathlib.Path]) -> dict:
+        filepath = safe_system_path(file_name=filepath)
+        with open(filepath, 'rb') as in_file:
+            return json.load(in_file)
+
+    @classmethod
+    def file_path_key(cls) -> str:
+        return "raw_eye_tracking_video_meta_data"
+
+    @classmethod
+    def from_lims(cls):
+        raise NotImplementedError(
+                "from_lims not yet supported for EyeTrackingMetadataFile")
+
+    @classmethod
+    def to_json(cls):
+        raise NotImplementedError(
+                "from_json not yet supported for EyeTrackingMetadataFile")
+
+    @classmethod
+    def from_json(
+            cls,
+            dict_repr: dict) -> "EyeTrackingMetadataFile":
+        filepath = dict_repr[cls.file_path_key()]
+        return cls(filepath=filepath)

--- a/allensdk/brain_observatory/behavior/data_files/eye_tracking_metadata_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/eye_tracking_metadata_file.py
@@ -2,7 +2,6 @@ from typing import Union
 import pathlib
 import json
 from allensdk.internal.core import DataFile
-from allensdk.internal.core.lims_utilities import safe_system_path
 
 
 class EyeTrackingMetadataFile(DataFile):
@@ -16,7 +15,6 @@ class EyeTrackingMetadataFile(DataFile):
 
     @staticmethod
     def load_data(filepath: Union[str, pathlib.Path]) -> dict:
-        filepath = safe_system_path(file_name=filepath)
         with open(filepath, 'rb') as in_file:
             return json.load(in_file)
 

--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import warnings
 from typing import Optional, List

--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -197,7 +197,8 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
             data_file: EyeTrackingFile,
             stimulus_timestamps: StimulusTimestamps,
             z_threshold: float = 3.0,
-            dilation_frames: int = 2) -> "EyeTrackingTable":
+            dilation_frames: int = 2,
+            empty_on_fail: bool = False) -> "EyeTrackingTable":
         """
         Parameters
         ----------
@@ -208,6 +209,11 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
             See EyeTracking.from_lims
         dilation_frames : int, optional
              See EyeTracking.from_lims
+        empyt_on_fail: bool
+            If True, this method will return an empty dataframe
+            if an EyeTrackingError is raised (usually because
+            timestamps and eye tracking video frames do not
+            align). If false, the error will get raised.
         """
         cls._logger.info(f"Getting eye_tracking_data with "
                          f"'z_threshold={z_threshold}', "
@@ -220,10 +226,13 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
                                      z_threshold,
                                      dilation_frames)
         except EyeTrackingError as err:
-            msg = f"{str(err)}\n"
-            msg += "returning empty eye_tracking DataFrame"
-            warnings.warn(msg)
-            eye_tracking_data = cls._get_empty_df()
+            if empty_on_fail:
+                msg = f"{str(err)}\n"
+                msg += "returning empty eye_tracking DataFrame"
+                warnings.warn(msg)
+                eye_tracking_data = cls._get_empty_df()
+            else:
+                raise
 
         return EyeTrackingTable(eye_tracking=eye_tracking_data)
 

--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -10,6 +10,8 @@ from allensdk.brain_observatory.behavior.data_objects import (
     StimulusTimestamps)
 from allensdk.brain_observatory.behavior.data_files.eye_tracking_file import \
     EyeTrackingFile
+from allensdk.brain_observatory.behavior.\
+    data_files.eye_tracking_metadata_file import EyeTrackingMetadataFile
 from allensdk.core import DataObject
 from allensdk.core import \
     NwbReadableInterface, DataFileReadableInterface
@@ -232,7 +234,8 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
         return EyeTrackingTable(eye_tracking=eye_tracking_data)
 
 
-def get_lost_frames(file_path: str) -> List[int]:
+def get_lost_frames(
+        eye_tracking_metadata: EyeTrackingMetadataFile) -> List[int]:
     """
     Get lost frames from the video metadata json
     Must subtract one since the json starts indexing at 1
@@ -246,8 +249,7 @@ def get_lost_frames(file_path: str) -> List[int]:
 
     Parameters
     ----------
-    file_path: str
-        Path to the metadata json
+    eye_tracking_metadata_file: EyeTrackingMetadataFile
 
     Returns
     -------
@@ -259,8 +261,7 @@ def get_lost_frames(file_path: str) -> List[int]:
     https://github.com/corbennett/NP_pipeline_QC/blob/6a66f195c4cd6b300776f089773577db542fe7eb/probeSync_qc.py
     """
 
-    with open(file_path, 'rb') as in_file:
-        camera_metadata = json.load(in_file)
+    camera_metadata = eye_tracking_metadata.data
 
     lost_count = camera_metadata['RecordingReport']['FramesLostCount']
     if lost_count == 0:

--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -197,7 +197,6 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
             cls,
             data_file: EyeTrackingFile,
             stimulus_timestamps: StimulusTimestamps,
-            drop_frames: Optional[List[int]] = None,
             z_threshold: float = 3.0,
             dilation_frames: int = 2) -> "EyeTrackingTable":
         """
@@ -206,10 +205,6 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
         data_file
         stimulus_timestamps: StimulusTimestamps
             The timestamps associated with this eye tracking table
-        drop_frames : List[int], optional
-            List of frame indices to be dropped from the table.
-            If provided, will drop the corresponding frame frame times read
-            from the sync file to synchronize frame times and frames.
         z_threshold : float, optional
             See EyeTracking.from_lims
         dilation_frames : int, optional

--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Optional, List
+from typing import Optional
 import numpy as np
 import pandas as pd
 from pynwb import NWBFile, TimeSeries
@@ -238,7 +238,7 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
 
 
 def get_lost_frames(
-        eye_tracking_metadata: EyeTrackingMetadataFile) -> List[int]:
+        eye_tracking_metadata: EyeTrackingMetadataFile) -> np.ndarray:
     """
     Get lost frames from the video metadata json
     Must subtract one since the json starts indexing at 1

--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -252,7 +252,7 @@ def get_lost_frames(
 
     Parameters
     ----------
-    eye_tracking_metadata_file: EyeTrackingMetadataFile
+    eye_tracking_metadata: EyeTrackingMetadataFile
 
     Returns
     -------

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -156,8 +156,7 @@ class VBNBehaviorSession(BehaviorSession):
             eye_tracking_metadata_file: EyeTrackingMetadataFile,
             sync_file: SyncFile,
             z_threshold: float,
-            dilation_frames: int,
-            drop_frames: bool) -> EyeTrackingTable:
+            dilation_frames: int) -> EyeTrackingTable:
         """
         Notes
         -----

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -189,7 +189,8 @@ class VBNBehaviorSession(BehaviorSession):
                     data_file=eye_tracking_file,
                     stimulus_timestamps=stimulus_timestamps,
                     z_threshold=z_threshold,
-                    dilation_frames=dilation_frames)
+                    dilation_frames=dilation_frames,
+                    empty_on_fail=False)
 
 
 class BehaviorEcephysSession(BehaviorSession):

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from pynwb import NWBFile
 
+from allensdk.brain_observatory import sync_utilities
 from allensdk.brain_observatory.behavior.behavior_session import \
     BehaviorSession
 from allensdk.brain_observatory.ecephys._behavior_ecephys_metadata import \
@@ -18,6 +19,14 @@ from allensdk.brain_observatory.behavior.behavior_session import (
     StimulusFileLookup)
 from allensdk.brain_observatory.behavior.data_objects.stimuli.stimuli import (
     Stimuli)
+from allensdk.brain_observatory.behavior.data_files.eye_tracking_file import \
+    EyeTrackingFile
+from allensdk.brain_observatory.behavior.\
+    data_files.eye_tracking_metadata_file import EyeTrackingMetadataFile
+
+
+from allensdk.brain_observatory.behavior.data_objects.eye_tracking \
+    .eye_tracking_table import EyeTrackingTable, get_lost_frames
 
 
 class VBNBehaviorSession(BehaviorSession):
@@ -139,6 +148,49 @@ class VBNBehaviorSession(BehaviorSession):
         df = pd.DataFrame({"timestamps": lick_times,
                            "frame": lick_frames})
         return Licks(licks=df)
+
+    @classmethod
+    def _read_eye_tracking_table(
+            cls,
+            eye_tracking_file: EyeTrackingFile,
+            eye_tracking_metadata_file: EyeTrackingMetadataFile,
+            sync_file: SyncFile,
+            z_threshold: float,
+            dilation_frames: int,
+            drop_frames: bool) -> EyeTrackingTable:
+        """
+        Notes
+        -----
+        more or less copied from
+        https://github.com/corbennett/NP_pipeline_QC/blob/6a66f195c4cd6b300776f089773577db542fe7eb/probeSync_qc.py
+        """
+
+        eye_metadata = eye_tracking_metadata_file.data
+        camera_label = eye_metadata['RecordingReport']['CameraLabel']
+        exposure_sync_line_label_dict = {
+            'Eye': 'eye_cam_exposing',
+            'Face': 'face_cam_exposing',
+            'Behavior': 'beh_cam_exposing'}
+        camera_line = exposure_sync_line_label_dict[camera_label]
+
+        lost_frames = get_lost_frames(
+                        eye_tracking_metadata=eye_tracking_metadata_file)
+
+        frame_times = sync_utilities.get_synchronized_frame_times(
+            session_sync_file=sync_file.filepath,
+            sync_line_label_keys=(camera_line,),
+            drop_frames=lost_frames,
+            trim_after_spike=False)
+
+        stimulus_timestamps = StimulusTimestamps(
+                                timestamps=frame_times,
+                                monitor_delay=0.0)
+
+        return EyeTrackingTable.from_data_file(
+                    data_file=eye_tracking_file,
+                    stimulus_timestamps=stimulus_timestamps,
+                    z_threshold=z_threshold,
+                    dilation_frames=dilation_frames)
 
 
 class BehaviorEcephysSession(BehaviorSession):

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -359,7 +359,7 @@ class BehaviorEcephysSession(BehaviorSession):
         instantiated `BehaviorEcephysSession`
         """
         kwargs['add_is_change_to_stimulus_presentations_table'] = False
-        behavior_session = VBNBehaviorSession.from_nwb(
+        behavior_session = cls.behavior_data_class().from_nwb(
             nwbfile=nwbfile,
             **kwargs
         )

--- a/allensdk/test/brain_observatory/behavior/data_files/test_eye_tracking_metadata_file.py
+++ b/allensdk/test/brain_observatory/behavior/data_files/test_eye_tracking_metadata_file.py
@@ -1,0 +1,34 @@
+import json
+import tempfile
+import pathlib
+
+from allensdk.brain_observatory.behavior.\
+    data_files.eye_tracking_metadata_file import (
+        EyeTrackingMetadataFile)
+
+
+def test_eye_tracking_metadata_file(
+        tmp_path_factory,
+        helper_functions):
+    """
+    Just a smoke test for EyeTrackingMetadataFile.from_json
+    """
+
+    json_path = pathlib.Path(tempfile.mkstemp(suffix='.json')[1])
+
+    data = {'a': [1, {'b': 3}],
+            'c': 'x'}
+
+    with open(json_path, 'w') as out_file:
+        out_file.write(json.dumps(data))
+
+    dict_repr = {'raw_eye_tracking_video_meta_data':
+                 str(json_path.resolve().absolute())}
+
+    data_file = EyeTrackingMetadataFile.from_json(
+                    dict_repr=dict_repr)
+
+    assert isinstance(data_file, EyeTrackingMetadataFile)
+    assert data_file.data == data
+
+    helper_functions.windows_safe_cleanup(file_path=json_path)

--- a/allensdk/test/brain_observatory/behavior/data_objects/eye_tracking/test_eye_tracking_utils.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/eye_tracking/test_eye_tracking_utils.py
@@ -1,0 +1,45 @@
+import pytest
+import tempfile
+import json
+import pathlib
+import numpy as np
+
+from allensdk.brain_observatory.behavior.\
+    data_objects.eye_tracking.eye_tracking_table import (
+        get_lost_frames)
+
+
+@pytest.mark.parametrize(
+        "input_str, lost_count, expected_array",
+        [('', 0, []),
+         ('13-19', 1, [12, 13, 14, 15, 16, 17, 18]),
+         ('5-7,100-103', 1, [4, 5, 6, 99, 100, 101, 102]),
+         ('77', 1, [76]),
+         ('3-5,21-25,201-204', 1,
+          [2, 3, 4, 20, 21, 22, 23, 24, 200, 201, 202, 203])])
+def test_get_lost_frames(
+        input_str,
+        lost_count,
+        expected_array,
+        tmp_path_factory,
+        helper_functions):
+    """
+    Test performance of get_lost_frames by constructing an
+    example camera metadata json file with records of lost
+    frames and running it through the method.
+    """
+
+    metadata = {'RecordingReport':
+                {'FramesLostCount': lost_count,
+                 'LostFrames': [input_str]}}
+
+    tmpdir = pathlib.Path(tmp_path_factory.mktemp('get_lost_frames'))
+    json_path = pathlib.Path(
+                    tempfile.mkstemp(dir=tmpdir, suffix='.json')[1])
+    with open(json_path, 'w') as output_file:
+        output_file.write(json.dumps(metadata))
+
+    actual = get_lost_frames(file_path=json_path)
+    np.testing.assert_array_equal(actual, np.array(expected_array))
+
+    helper_functions.windows_safe_cleanup_dir(dir_path=tmpdir)

--- a/allensdk/test/brain_observatory/behavior/data_objects/eye_tracking/test_eye_tracking_utils.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/eye_tracking/test_eye_tracking_utils.py
@@ -4,6 +4,9 @@ import json
 import pathlib
 import numpy as np
 
+from allensdk.brain_observatory.behavior.data_files.\
+    eye_tracking_metadata_file import EyeTrackingMetadataFile
+
 from allensdk.brain_observatory.behavior.\
     data_objects.eye_tracking.eye_tracking_table import (
         get_lost_frames)
@@ -39,7 +42,13 @@ def test_get_lost_frames(
     with open(json_path, 'w') as output_file:
         output_file.write(json.dumps(metadata))
 
-    actual = get_lost_frames(file_path=json_path)
+    dict_repr = {'raw_eye_tracking_video_meta_data':
+                 str(json_path.resolve().absolute())}
+
+    metadata = EyeTrackingMetadataFile.from_json(
+                    dict_repr=dict_repr)
+
+    actual = get_lost_frames(eye_tracking_metadata=metadata)
     np.testing.assert_array_equal(actual, np.array(expected_array))
 
     helper_functions.windows_safe_cleanup_dir(dir_path=tmpdir)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_ophys_experiment.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_ophys_experiment.py
@@ -2,54 +2,21 @@ import os
 import datetime
 import uuid
 import pytest
-import pandas as pd
 import pytz
 import numpy as np
-from unittest.mock import create_autospec
 
 from pynwb import NWBHDF5IO
 
 from allensdk.brain_observatory.behavior.behavior_ophys_experiment import \
     BehaviorOphysExperiment
-from allensdk.brain_observatory.behavior.behavior_session import \
-    BehaviorSession
-from allensdk.brain_observatory.behavior.data_files import SyncFile
-from allensdk.brain_observatory.behavior.data_files.eye_tracking_file import \
-    EyeTrackingFile
-from allensdk.brain_observatory.behavior.data_files\
-    .rigid_motion_transform_file import \
-    RigidMotionTransformFile
+
 from allensdk.brain_observatory.behavior.data_objects import \
-    BehaviorSessionId, StimulusTimestamps
-from allensdk.brain_observatory.behavior.data_objects.cell_specimens\
-    .cell_specimens import \
-    CellSpecimens
-from allensdk.brain_observatory.behavior.data_objects.eye_tracking\
-    .eye_tracking_table import \
-    EyeTrackingTable
-from allensdk.brain_observatory.behavior.data_objects.eye_tracking\
-    .rig_geometry import \
-    RigGeometry as EyeTrackingRigGeometry
-from allensdk.brain_observatory.behavior.data_objects.metadata \
-    .behavior_metadata.date_of_acquisition import \
-    DateOfAcquisitionOphys
+    BehaviorSessionId
+
 from allensdk.brain_observatory.behavior.data_objects.metadata\
     .behavior_metadata.foraging_id import \
     ForagingId
-from allensdk.brain_observatory.behavior.data_objects.metadata\
-    .behavior_ophys_metadata import \
-    BehaviorOphysMetadata
-from allensdk.brain_observatory.behavior.data_objects.metadata\
-    .ophys_experiment_metadata.multi_plane_metadata.imaging_plane_group \
-    import \
-    ImagingPlaneGroup
-from allensdk.brain_observatory.behavior.data_objects.projections import \
-    Projections
-from allensdk.brain_observatory.behavior.data_objects.stimuli.util import \
-    calculate_monitor_delay
-from allensdk.brain_observatory.behavior.data_objects.timestamps\
-    .ophys_timestamps import \
-    OphysTimestamps
+
 from allensdk.brain_observatory.session_api_utils import (
     sessions_are_equal)
 from allensdk.brain_observatory.stimulus_info import MONITOR_DIMENSIONS
@@ -197,126 +164,6 @@ def test_stimulus_presentations_omitted(ophys_experiment_id, number_omitted):
     session = BehaviorOphysExperiment.from_lims(ophys_experiment_id)
     df = session.stimulus_presentations
     assert df['omitted'].sum() == number_omitted
-
-
-@pytest.mark.parametrize(
-    "dilation_frames, z_threshold", [
-        (5, 9),
-        (1, 2)
-    ])
-def test_eye_tracking(dilation_frames, z_threshold, monkeypatch):
-    """A very long test just to test that eye tracking arguments are sent to
-    EyeTrackingTable factory method from BehaviorOphysExperiment.from_lims"""
-    expected = EyeTrackingTable(eye_tracking=pd.DataFrame([1, 2, 3]))
-    EyeTrackingTable_mock = create_autospec(EyeTrackingTable)
-    EyeTrackingTable_mock.from_data_file.return_value = expected
-
-    etf = create_autospec(EyeTrackingFile, instance=True)
-    sf = create_autospec(SyncFile, instance=True)
-
-    with monkeypatch.context() as ctx:
-        ctx.setattr('allensdk.brain_observatory.behavior.'
-                    'behavior_ophys_experiment.db_connection_creator',
-                    create_autospec(db_connection_creator, instance=True))
-        ctx.setattr(
-            SyncFile, 'from_lims',
-            lambda db, behavior_session_id: sf)
-        ctx.setattr(
-            StimulusTimestamps, 'from_sync_file',
-            lambda sync_file, monitor_delay:
-            create_autospec(StimulusTimestamps,
-                            instance=True))
-        ctx.setattr(
-            BehaviorSessionId, 'from_lims',
-            lambda db, ophys_experiment_id: create_autospec(BehaviorSessionId,
-                                                            instance=True))
-        ctx.setattr(
-            ImagingPlaneGroup, 'from_lims',
-            lambda lims_db, ophys_experiment_id: None)
-        ctx.setattr(
-            BehaviorOphysMetadata, 'from_lims',
-            lambda lims_db, ophys_experiment_id,
-            is_multiplane: create_autospec(BehaviorOphysMetadata,
-                                           instance=True))
-        ctx.setattr('allensdk.brain_observatory.behavior.'
-                    'behavior_ophys_experiment.calculate_monitor_delay',
-                    create_autospec(calculate_monitor_delay))
-        ctx.setattr(
-            DateOfAcquisitionOphys, 'from_lims',
-            lambda lims_db, ophys_experiment_id: create_autospec(
-                DateOfAcquisitionOphys, instance=True))
-        ctx.setattr(
-            BehaviorSession, 'from_lims',
-            lambda lims_db, behavior_session_id,
-            sync_file, monitor_delay, date_of_acquisition,
-            skip_eye_tracking, eye_tracking_z_threshold,
-            eye_tracking_dilation_frames:
-            BehaviorSession(
-                behavior_session_id=None,
-                stimulus_timestamps=None,
-                running_acquisition=None,
-                raw_running_speed=None,
-                running_speed=None,
-                licks=None,
-                rewards=None,
-                stimuli=None,
-                task_parameters=None,
-                trials=None,
-                metadata=None,
-                date_of_acquisition=None,
-                eye_tracking_table=EyeTrackingTable.from_data_file(
-                    data_file=EyeTrackingFile.from_lims(
-                        db=lims_db,
-                        behavior_session_id=behavior_session_id.value),
-                    sync_file=SyncFile.from_lims(
-                        db=lims_db,
-                        behavior_session_id=behavior_session_id.value),
-                    z_threshold=eye_tracking_z_threshold,
-                    dilation_frames=eye_tracking_dilation_frames)
-            )
-        )
-        ctx.setattr(
-            OphysTimestamps, 'from_sync_file',
-            lambda sync_file: create_autospec(OphysTimestamps,
-                                              instance=True))
-        ctx.setattr(
-            Projections, 'from_lims',
-            lambda lims_db, ophys_experiment_id: create_autospec(
-                Projections, instance=True))
-        ctx.setattr(
-            CellSpecimens, 'from_lims',
-            lambda lims_db, ophys_experiment_id, ophys_timestamps,
-            segmentation_mask_image_spacing, events_params,
-            exclude_invalid_rois: create_autospec(
-                     BehaviorSession, instance=True))
-        ctx.setattr(
-            RigidMotionTransformFile, 'from_lims',
-            lambda db, ophys_experiment_id: create_autospec(
-                RigidMotionTransformFile, instance=True))
-        ctx.setattr(
-            EyeTrackingFile, 'from_lims',
-            lambda db, behavior_session_id: etf)
-        ctx.setattr(
-            EyeTrackingTable, 'from_data_file',
-            lambda data_file, sync_file, z_threshold, dilation_frames:
-            EyeTrackingTable_mock.from_data_file(
-                data_file=data_file, sync_file=sync_file,
-                z_threshold=z_threshold, dilation_frames=dilation_frames))
-        ctx.setattr(
-            EyeTrackingRigGeometry, 'from_lims',
-            lambda lims_db, behavior_session_id: create_autospec(
-                EyeTrackingRigGeometry, instance=True))
-        boe = BehaviorOphysExperiment.from_lims(
-            ophys_experiment_id=1, eye_tracking_z_threshold=z_threshold,
-            eye_tracking_dilation_frames=dilation_frames)
-
-        obtained = boe.eye_tracking
-        assert obtained.equals(expected.value)
-        EyeTrackingTable_mock.from_data_file.assert_called_with(
-            data_file=etf,
-            sync_file=sf,
-            z_threshold=z_threshold,
-            dilation_frames=dilation_frames)
 
 
 @pytest.mark.requires_bamboo

--- a/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
+++ b/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
@@ -13,6 +13,11 @@ class TestBehaviorEcephysSession:
                   'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
+
+        # trim down the number of probes to reduce memory footprint of test
+        input_data['session_data']['probes'] = (
+                input_data['session_data']['probes'][:3])
+
         cls._session_from_json = BehaviorEcephysSession.from_json(
             session_data=input_data
         )

--- a/allensdk/test/brain_observatory/ecephys/test_probes.py
+++ b/allensdk/test/brain_observatory/ecephys/test_probes.py
@@ -15,6 +15,11 @@ class TestProbes:
                   'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
+
+        # trim down the number of probes to reduce memory footprint of test
+        input_data['session_data']['probes'] = (
+                input_data['session_data']['probes'][:3])
+
         cls.input_data = input_data['session_data']['probes']
         probes = Probe().load(cls.input_data, many=True)
         cls._probes_from_json = Probes.from_json(probes=probes)

--- a/allensdk/test/conftest.py
+++ b/allensdk/test/conftest.py
@@ -21,6 +21,43 @@ class HelperFunctions(object):
                 else:
                     raise
 
+    @staticmethod
+    def _first_pass_safe_cleanup_dir(dir_path: pathlib.Path):
+        """
+        Unlink all of the files in the directory, then remove the directory.
+        If a PermissionError is raised, ignore if the system is Windows
+        (this has been observed on our CI systems)
+        """
+        contents_list = [n for n in dir_path.iterdir()]
+        for this_path in contents_list:
+            if this_path.is_file():
+                HelperFunctions.windows_safe_cleanup(file_path=this_path)
+            elif this_path.is_dir():
+                HelperFunctions.windows_safe_cleanup_dir(
+                        dir_path=this_path)
+                try:
+                    this_path.rmdir()
+                except Exception:
+                    pass
+
+    @staticmethod
+    def windows_safe_cleanup_dir(dir_path: pathlib.Path):
+        """
+        Unlink all of the files in the directory, then remove the directory.
+        If a PermissionError is raised, ignore if the system is Windows
+        (this has been observed on our CI systems)
+        """
+        HelperFunctions._first_pass_safe_cleanup_dir(
+                dir_path=dir_path)
+
+        contents_list = [n for n in dir_path.iterdir()]
+        for this_path in contents_list:
+            if this_path.is_dir():
+                try:
+                    this_path.rmdir()
+                except Exception:
+                    raise
+
 
 @pytest.fixture(scope='session')
 def helper_functions():


### PR DESCRIPTION
This PR incorporate's Corbett's first-draft eye tracking algorithm (see discussion in  #2375) into the BehaviorEcephysSession. It does so by factoring out the construction of the EyeTrackingTable in BehaviorSession into its own classmethod and then overriding that method in VBNBehavior session.

**Note:** Since we did not worry about dropped frames before the current effort, I have effectively removed the support for dropped frames from BehaviorSession (the VBO version). This is because I did not have time to implement `EyeTrackingMetadataFile.from_lims` (the eye tracking metadata file is required to find the dropped frames). In the interest of speed, I propose leaving BehaviorSession as-is (without any knowledge of dropped frames) and doubling back to round out this functionality when we are not under so much time pressure. (see #2379)

**Validation**

Running this script

```
from allensdk.brain_observatory.ecephys.\
    behavior_ecephys_session import VBNBehaviorSession, BehaviorEcephysSession

import json

json_path = ("/allen/aibs/technology/sergeyg/Projects/vbn/"
             "programs/braintv/production/visualbehavior/prod0/"
             "specimen_1087519262/ecephys_session_1111216934/"
             "BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json")


with open(json_path, "rb") as in_file:
    json_data = json.load(in_file)

session = VBNBehaviorSession.from_json(
        session_data=json_data['session_data'],
        read_stimulus_presentations_table_from_file=True,
        stimulus_presentation_exclude_columns=None,
        sync_file_permissive=True,
        eye_tracking_drop_frames=True,
        running_speed_load_from_multiple_stimulus_files=True)

print(session.eye_tracking)
```
on `vbn_2022_dev` before this PR gives

```
/home/scott.daniel/AllenSDK/allensdk/brain_observatory/behavior/data_objects/running_speed/running_processing.py:368: UserWarning: Time array is 1 value shorter than encoder array. Last encoder value removed

  "value removed\n", UserWarning, stacklevel=1)
/home/scott.daniel/AllenSDK/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/date_of_acquisition.py:80: UserWarning: The `date_of_acquisition` field in LIMS (2021-06-24 20:58:50+00:00) for behavior session (1111250074) deviates by more than an hour from the `start_time` (2021-06-24 13:59:17.563000+00:00) specified in the associated stimulus *.pkl file: /allen/programs/braintv/production/visualbehavior/prod0/specimen_1087519262/ecephys_session_1111216934/1111340373/1111216934_568963_20210624.behavior.pkl
  "The `date_of_acquisition` field in LIMS "
/home/scott.daniel/AllenSDK/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py:238: UserWarning: 
in sync_file: /allen/programs/braintv/production/visualbehavior/prod0/specimen_1087519262/ecephys_session_1111216934/1111340373/1111216934_568963_20210624.sync
Error! The number of sync file frame times (566292) does not match the number of eye tracking frames (566294)!
returning empty eye_tracking DataFrame
  warnings.warn(msg)
Empty DataFrame
Columns: [timestamps, cr_area, eye_area, pupil_area, likely_blink, pupil_area_raw, cr_area_raw, eye_area_raw, cr_center_x, cr_center_y, cr_width, cr_height, cr_phi, eye_center_x, eye_center_y, eye_width, eye_height, eye_phi, pupil_center_x, pupil_center_y, pupil_width, pupil_height, pupil_phi]
Index: []
```

After this PR, we get
```
/home/scott.daniel/AllenSDK/allensdk/brain_observatory/behavior/data_objects/running_speed/running_processing.py:368: UserWarning: Time array is 1 value shorter than encoder array. Last encoder value removed

  "value removed\n", UserWarning, stacklevel=1)
/home/scott.daniel/AllenSDK/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/date_of_acquisition.py:80: UserWarning: The `date_of_acquisition` field in LIMS (2021-06-24 20:58:50+00:00) for behavior session (1111250074) deviates by more than an hour from the `start_time` (2021-06-24 13:59:17.563000+00:00) specified in the associated stimulus *.pkl file: /allen/programs/braintv/production/visualbehavior/prod0/specimen_1087519262/ecephys_session_1111216934/1111340373/1111216934_568963_20210624.behavior.pkl
  "The `date_of_acquisition` field in LIMS "
        timestamps     cr_area      eye_area  ...  pupil_height  pupil_phi  pupil_width
frame                                         ...                                      
0          2.11392         NaN           NaN  ...           NaN        NaN          NaN
1          2.13059         NaN           NaN  ...           NaN        NaN          NaN
2          2.14726         NaN           NaN  ...           NaN        NaN          NaN
3          2.16392         NaN           NaN  ...           NaN        NaN          NaN
4          2.18059         NaN           NaN  ...           NaN        NaN          NaN
...            ...         ...           ...  ...           ...        ...          ...
566289  9440.06852   97.595603  69232.084713  ...     36.938059  -0.479331    41.377261
566290  9440.08518   97.542771  69239.439986  ...     36.785913  -0.488713    41.642540
566291  9440.10184  103.408267  69424.398290  ...     36.689502  -0.525353    41.136327
566292  9440.11851   98.232210  69541.591904  ...     36.454211  -0.525852    41.183257
566293  9440.13517  102.659974  69383.447784  ...     36.622726  -0.509094    41.003462

[566294 rows x 23 columns]
```