### PR TITLE
Fix reporter line

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/reporter_line.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/reporter_line.py
@@ -45,7 +45,11 @@ class ReporterLine(DataObject, LimsReadableInterface, JsonReadableInterface,
 
     @classmethod
     def from_nwb(cls, nwbfile: NWBFile) -> "ReporterLine":
-        return cls(reporter_line=nwbfile.subject.reporter_line)
+        if nwbfile.subject.reporter_line == "None":
+            reporter_line = None
+        else:
+            reporter_line = nwbfile.subject.reporter_line
+        return cls(reporter_line=reporter_line)
 
     @staticmethod
     def parse(reporter_line: Union[Optional[List[str]], str],

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/subject_metadata.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/subject_metadata/subject_metadata.py
@@ -125,7 +125,7 @@ class SubjectMetadata(DataObject, LimsReadableInterface, NwbReadableInterface,
             driver_line=self.driver_line,
             genotype=self.full_genotype,
             subject_id=str(self.mouse_id),
-            reporter_line=self.reporter_line,
+            reporter_line=str(self.reporter_line),
             sex=self.sex,
             species='Mus musculus')
         nwbfile.subject = nwb_subject

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -359,7 +359,6 @@ class BehaviorEcephysSession(BehaviorSession):
         -------
         Instantiated `BehaviorEcephysSession`
         """
-        session_data = session_data['session_data']
 
         behavior_session = cls.behavior_data_class().from_json(
             session_data=session_data,

--- a/allensdk/brain_observatory/ecephys/write_nwb/schemas.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/schemas.py
@@ -187,6 +187,11 @@ class BaseNeuropixelsSchema(ArgSchema):
         help="""file at this path contains information about the optogenetic
                 stimulation applied during this experiment"""
     )
+    running_speed_path = String(
+        required=False,
+        help="""data collected about the running behavior of the experiment's
+                subject""",
+    )
     eye_tracking_rig_geometry = Dict(
         required=False,
         help="""Mapping containing information about session rig geometry used

--- a/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
+++ b/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
@@ -19,7 +19,7 @@ class TestBehaviorEcephysSession:
                 input_data['session_data']['probes'][:3])
 
         cls._session_from_json = BehaviorEcephysSession.from_json(
-            session_data=input_data
+            session_data=input_data['session_data']
         )
 
     @pytest.mark.requires_bamboo


### PR DESCRIPTION
**Addresses**
 #2326

The reporter_line None correspond to the 'wt' genotype. 

The strategy writes the reporter line only for code == 'R' as shown below
```rb
    genotypes = ecephys_session.donor.genotypes
    genotypes.each do | genotype |
      code = genotype.genotype_type.code
      reporters << genotype.name if code == 'R'
```
The `wt` genotype  has a code = null and hence it is not being written to the input_json


**Solution:**
change None -> str(None)

**Note:**
PR includes additional fixes: see commit messages
