### PR TITLE
ticket/2383/lick/timestamps

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -1212,9 +1212,13 @@ class BehaviorSession(DataObject, LimsReadableInterface,
     def _read_licks(
             cls,
             stimulus_file_lookup: StimulusFileLookup,
-            sync_file: Optional[SyncFile]) -> Licks:
+            sync_file: Optional[SyncFile],
+            monitor_delay: float) -> Licks:
         """
         Construct the Licks data object for this session
+
+        Note: monitor_delay is a part of the call signature so that
+        it can be used in sub-class implementations of this method.
         """
 
         stimulus_timestamps = cls._read_behavior_stimulus_timestamps(
@@ -1338,7 +1342,8 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
         licks = cls._read_licks(
             stimulus_file_lookup=stimulus_file_lookup,
-            sync_file=sync_file)
+            sync_file=sync_file,
+            monitor_delay=monitor_delay)
 
         rewards = cls._read_rewards(
             stimulus_file_lookup=stimulus_file_lookup,

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
@@ -47,3 +47,59 @@ def get_ophys_stimulus_timestamps(sync_path: Union[str, Path]) -> np.ndarray:
     aligner = OphysTimeAligner(sync_file=sync_path)
     stimulus_timestamps, _ = aligner.clipped_stim_timestamps
     return stimulus_timestamps
+
+
+def get_frame_indices(
+        frame_timestamps: np.ndarray,
+        event_timestamps: np.ndarray) -> np.ndarray:
+    """
+    Given an array of timestamps corresponding to stimulus frames
+    and an array of timestamps corresponding to some event (i.e.
+    licks), return an array of indexes indicating which frame
+    each event occured on. Indexes will be chosen to be the
+    smallest index satisfying
+
+    frame_timestamps[event_indices] >= event_timestamps
+
+    Parameters
+    ----------
+    frame_timestamps: np.ndarray
+        must be in ascending order
+
+    event_timetamps: np.ndarray
+
+    Returns
+    -------
+    event_indices: np.ndarray
+        integers that are all >= 0 and < len(frame_timestamps)
+
+    Note
+    ----
+    If a value is repeated in frame_timestamps, the first suitable
+    frame index is returned for a given event_timestamp
+    """
+
+    delta_t = np.diff(frame_timestamps)
+    if delta_t.min() < -1.0e-10:
+        raise ValueError("frame_timestamps are not in ascending order")
+
+    n_frames = len(frame_timestamps)
+
+    event_indices = np.searchsorted(
+                        frame_timestamps,
+                        event_timestamps,
+                        side='left')
+
+    event_indices = np.clip(event_indices, None, n_frames-1)
+
+    # correct for fact that searchsorted will select as
+    # frame index the first frame time that is larger
+    # than lick_times; we want the lick_times associated
+    # with the last frame that is smaller than the lick_time
+    event_frame_times = frame_timestamps[event_indices]
+    delta = event_timestamps-event_frame_times
+    to_decrement = (delta < -1.0e-6)
+    event_indices[to_decrement] -= 1
+    event_indices = np.clip(event_indices, 0, n_frames-1)
+
+    return event_indices

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
@@ -57,9 +57,10 @@ def get_frame_indices(
     and an array of timestamps corresponding to some event (i.e.
     licks), return an array of indexes indicating which frame
     each event occured on. Indexes will be chosen to be the
-    smallest index satisfying
+    first index satisfying
 
-    frame_timestamps[event_indices] >= event_timestamps
+    frame_timestamps[event_indices] <= event_timestamps
+    event_timestamps < frame_timestamps[event_indices+1]
 
     Parameters
     ----------

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/timestamps_processing.py
@@ -80,8 +80,7 @@ def get_frame_indices(
     frame index is returned for a given event_timestamp
     """
 
-    delta_t = np.diff(frame_timestamps)
-    if delta_t.min() < -1.0e-10:
+    if np.any(np.diff(frame_timestamps) < -1.0e-10):
         raise ValueError("frame_timestamps are not in ascending order")
 
     n_frames = len(frame_timestamps)

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -28,6 +28,10 @@ from allensdk.brain_observatory.behavior.\
 from allensdk.brain_observatory.behavior.data_objects.eye_tracking \
     .eye_tracking_table import EyeTrackingTable, get_lost_frames
 
+from allensdk.brain_observatory.behavior.data_objects.timestamps \
+    .stimulus_timestamps.timestamps_processing import (
+        get_frame_indices)
+
 
 class VBNBehaviorSession(BehaviorSession):
     """
@@ -113,6 +117,12 @@ class VBNBehaviorSession(BehaviorSession):
         accepting only those licks that occur during the time
         of the behavior stimulus block
         """
+
+        if sync_file is None:
+            msg = (f"{cls}._read_licks requires a sync_file; "
+                   "you passed in sync_file=None")
+            raise ValueError(msg)
+
         lick_times = StimulusTimestamps(
                        timestamps=sync_file.data['lick_times'],
                        monitor_delay=0.0)
@@ -134,10 +144,9 @@ class VBNBehaviorSession(BehaviorSession):
 
         lick_times = lick_times.value[valid]
 
-        behavior_stim = stimulus_file_lookup.behavior_stimulus_file
-        behavior_data = behavior_stim.data
-        lick_sensor = behavior_data['items']['behavior']['lick_sensors'][0]
-        lick_frames = lick_sensor['lick_events']
+        lick_frames = get_frame_indices(
+                        frame_timestamps=behavior_stim_times.value,
+                        event_timestamps=lick_times)
 
         if len(lick_frames) != len(lick_times):
             msg = (f"{len(lick_frames)} lick frames; "

--- a/allensdk/test/brain_observatory/behavior/data_objects/stimulus_timestamps/test_timestamps_processing.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/stimulus_timestamps/test_timestamps_processing.py
@@ -5,7 +5,10 @@ import pytest
 
 from allensdk.brain_observatory.behavior.data_objects.timestamps \
     .stimulus_timestamps.timestamps_processing import (
-        get_behavior_stimulus_timestamps, get_ophys_stimulus_timestamps)
+        get_behavior_stimulus_timestamps,
+        get_ophys_stimulus_timestamps,
+        get_frame_indices)
+
 from allensdk.internal.brain_observatory.time_sync import OphysTimeAligner
 
 
@@ -78,3 +81,44 @@ def test_get_ophys_stimulus_timestamps(
     mock_ophys_time_aligner.assert_called_with(sync_file=sync_path)
     property_mock.assert_called_once()
     assert np.allclose(obt, expected_timestamps)
+
+
+@pytest.mark.parametrize(
+    "frame_timestamps, event_timestamps, expected_indices",
+    [(np.arange(0, 1, 0.11),
+      np.array([0.22, 0.13, 0.32, 0.77]),
+      np.array([2, 1, 2, 7])),
+     (np.arange(0, 1, 0.11),
+      np.array([-0.1, 2.1, 0.55, 0.42]),
+      np.array([0, 9, 5, 3])),
+     (np.array([0.11, 0.11, 0.33, 0.33, 0.44]),
+      np.array([0.05, 0.12, 0.22, 0.33, 0.77]),
+      np.array([0, 1, 1, 2, 4]))])
+def test_get_frame_indices(
+        frame_timestamps,
+        event_timestamps,
+        expected_indices):
+    """
+    Test that get_frame_indices correctly associates events
+    with frames
+    """
+    actual = get_frame_indices(
+                frame_timestamps=frame_timestamps,
+                event_timestamps=event_timestamps)
+
+    np.testing.assert_array_equal(actual, expected_indices)
+
+
+def test_get_frame_indices_error():
+    """
+    Test that a ValueError is raised when unsorted
+    frame_timestamps are passed into get_frame_indices
+    """
+
+    frame_timestamps = np.array([0.1, 0.4, 0.3])
+    event_timestamps = np.array([0.11, 0.22])
+    with pytest.raises(ValueError,
+                       match="frame_timestamps are not in ascending order"):
+        get_frame_indices(
+            frame_timestamps=frame_timestamps,
+            event_timestamps=event_timestamps)


### PR DESCRIPTION
This PR should address the problem we have been having with len(lick_timestamps) != len(lick_frames). It does so by reading both the frame times and the lick times from the sync file and then assigning a frame number to each lick by selecting the largest frame index that is at a time <= the lick time.

I am currently running this branch on some of the sessions which failed due to lick alignment. It seems to be passing. I'll post here when my test is done.
