### PR TITLE
Makes sure timestamps and eye tracking frames are aligned

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/eye_tracking/eye_tracking_table.py
@@ -233,6 +233,10 @@ class EyeTrackingTable(DataObject, DataFileReadableInterface,
             )
             eye_data = data_file.data.loc[frames]
 
+            if is_metadata_frame_present:
+                # Reset index to start at 0 if metadata frame was dropped
+                eye_data.index -= 1
+
             eye_tracking_data = process_eye_tracking_data(
                                      eye_data,
                                      stimulus_timestamps.value,

--- a/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
+++ b/allensdk/brain_observatory/behavior/data_objects/timestamps/stimulus_timestamps/stimulus_timestamps.py
@@ -55,6 +55,28 @@ class StimulusTimestamps(DataObject,
         self._sync_file = sync_file
         self._monitor_delay = monitor_delay
 
+    def update_timestamps(
+            self,
+            timestamps: np.ndarray
+    ) -> "StimulusTimestamps":
+        """
+        Returns newly instantiated `StimulusTimestamps` with `timestamps`
+
+        Parameters
+        ----------
+        timestamps
+
+        Returns
+        -------
+        `StimulusTimestamps` with `timestamps`
+        """
+        return StimulusTimestamps(
+            timestamps=timestamps,
+            monitor_delay=self._monitor_delay,
+            stimulus_file=self._stimulus_file,
+            sync_file=self._sync_file
+        )
+
     def subtract_monitor_delay(self) -> "StimulusTimestamps":
         """
         Return a version of this StimulusTimestamps object with
@@ -265,3 +287,6 @@ class StimulusTimestamps(DataObject,
         nwbfile.add_processing_module(stim_mod)
 
         return nwbfile
+
+    def __len__(self):
+        return len(self.value)

--- a/allensdk/brain_observatory/behavior/eye_tracking_processing.py
+++ b/allensdk/brain_observatory/behavior/eye_tracking_processing.py
@@ -152,7 +152,7 @@ def determine_likely_blinks(eye_areas: pd.Series,
                                                 iterations=dilation_frames)
     else:
         likely_blinks = blinks
-    return pd.Series(likely_blinks)
+    return pd.Series(likely_blinks, index=eye_areas.index)
 
 
 def process_eye_tracking_data(eye_data: pd.DataFrame,
@@ -200,7 +200,7 @@ def process_eye_tracking_data(eye_data: pd.DataFrame,
     # This solution was discussed in
     # https://github.com/AllenInstitute/AllenSDK/issues/1545
 
-    if n_sync > n_eye_frames and n_sync <= n_eye_frames+15:
+    if n_eye_frames < n_sync <= n_eye_frames + 15:
         frame_times = frame_times[:n_eye_frames]
         n_sync = len(frame_times)
 

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -200,7 +200,7 @@ class VBNBehaviorSession(BehaviorSession):
             trim_after_spike=False)
 
         stimulus_timestamps = StimulusTimestamps(
-                                timestamps=frame_times,
+                                timestamps=frame_times.values,
                                 monitor_delay=0.0)
 
         return EyeTrackingTable.from_data_file(
@@ -208,6 +208,7 @@ class VBNBehaviorSession(BehaviorSession):
                     stimulus_timestamps=stimulus_timestamps,
                     z_threshold=z_threshold,
                     dilation_frames=dilation_frames,
+                    metadata_file=eye_tracking_metadata_file,
                     empty_on_fail=False)
 
 


### PR DESCRIPTION
Addresses #2376

Addresses 2 issues with eye tracking timestamps/frame alignment:

1. Removes metadata frame if present
2. Truncates timestamps if the number of timestamps is greater than number of frames. Discussion of why this is valid to do is in #2376 
