### PR TITLE
Fixes issue with nan manual_structure_acronym

### DIFF
--- a/allensdk/brain_observatory/ecephys/_channel.py
+++ b/allensdk/brain_observatory/ecephys/_channel.py
@@ -74,9 +74,11 @@ class Channel(DataObject):
 
     @property
     def manual_structure_acronym(self) -> str:
-        return self._manual_structure_acronym.split('-')[0] \
-            if self._strip_structure_subregion \
-            else self._manual_structure_acronym
+        acronym = self._manual_structure_acronym
+        if type(self._manual_structure_acronym) is str and \
+                self._strip_structure_subregion:
+            acronym = self._manual_structure_acronym.split('-')[0]
+        return acronym
 
     @property
     def anterior_posterior_ccf_coordinate(self) -> Optional[float]:

--- a/allensdk/test/brain_observatory/ecephys/test_probes.py
+++ b/allensdk/test/brain_observatory/ecephys/test_probes.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+import numpy as np
 import pytest
 from pynwb import NWBFile
 
@@ -76,7 +77,7 @@ class TestProbes:
         assert expected_n_units == obtained_n_units
 
 
-@pytest.mark.parametrize('manual_structure_acronym', ('LGd-sh', 'LGd'))
+@pytest.mark.parametrize('manual_structure_acronym', ('LGd-sh', 'LGd', np.nan))
 @pytest.mark.parametrize('strip_structure_subregion', (True, False))
 def test_probe_channels_strip_subregion(
         manual_structure_acronym, strip_structure_subregion):
@@ -91,9 +92,12 @@ def test_probe_channels_strip_subregion(
         manual_structure_acronym=manual_structure_acronym,
         strip_structure_subregion=strip_structure_subregion
     )
-    if strip_structure_subregion:
-        expected = 'LGd'
+    if type(manual_structure_acronym) is str:
+        if strip_structure_subregion:
+            expected = 'LGd'
+        else:
+            expected = 'LGd-sh' if manual_structure_acronym == 'LGd-sh' \
+                else 'LGd'
+        assert c.manual_structure_acronym == expected
     else:
-        expected = 'LGd-sh' if manual_structure_acronym == 'LGd-sh' else 'LGd'
-
-    assert c.manual_structure_acronym == expected
+        assert np.isnan(c.manual_structure_acronym)


### PR DESCRIPTION
Addresses #2403

It is possible for manual_structure_acronym to be coerced to nan in VCN code. It was failing when it tried to parse a string. The fix is to check whether it actually is a string before trying to parse it. 

The following code which didn't work before now works
```
from allensdk.brain_observatory.ecephys.ecephys_project_cache import (
    EcephysProjectCache)
import os


def main():
    manifest_path = '/allen/aibs/informatics/danielsf/scratch/ecephys_manifest.json'
    if os.path.exists(manifest_path):
        os.unlink(manifest_path)

    cache = EcephysProjectCache.from_warehouse(manifest=manifest_path)
    session = cache.get_session_data(session_id=719161530)
    session.units


if __name__ == '__main__':
    main()
```