### PR TITLE
Create VBN project cache

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_neuropixels_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_neuropixels_project_cache.py
@@ -1,0 +1,62 @@
+from allensdk.brain_observatory.behavior.behavior_project_cache.\
+    project_apis.data_io import VisualBehaviorNeuropixelsProjectCloudApi
+from allensdk.brain_observatory.behavior.behavior_project_cache.\
+    project_cache_base import ProjectCacheBase
+
+
+class VisualBehaviorNeuropixelsProjectCache(ProjectCacheBase):
+
+    PROJECT_NAME = "visual-behavior-ecephys"
+    BUCKET_NAME = "visual-behavior-ecephys-data"
+
+    def __init__(
+            self,
+            fetch_api: VisualBehaviorNeuropixelsProjectCloudApi,
+            fetch_tries: int = 2,
+            ):
+        """ Entrypoint for accessing Visual Behavior Neuropixels data.
+
+        Supports access to metadata tables:
+        get_ecephys_session_table()
+        get_behavior_session_table()
+        get_probe_table()
+        get_channel_table()
+        get_unit_table
+
+        Provides methods for instantiating session objects
+        from the nwb files:
+        get_ecephys_session() to load BehaviorEcephysSession
+        get_behavior_sesion() to load BehaviorSession
+
+        Provides tools for downloading data:
+
+        Will download data from the s3 bucket if session nwb file is not
+        in the local cache, othwerwise will use file from the cache.
+
+        """
+        super().__init__(fetch_api=fetch_api, fetch_tries=fetch_tries)
+
+    @classmethod
+    def cloud_api_class(cls):
+        return VisualBehaviorNeuropixelsProjectCloudApi
+
+    def get_ecephys_session_table(self):
+        return self.fetch_api.get_ecephys_session_table(),
+
+    def get_behavior_session_table(self):
+        return self.fetch_api.get_behavior_session_table(),
+
+    def get_probe_table(self):
+        self.fetch_api.get_probe_table(),
+
+    def get_channel_table(self):
+        return self.fetch_api.get_channel_table(),
+
+    def get_unit_table(self):
+        return self.fetch_api.get_unit_table(),
+
+    def get_ecephys_session(self, ecephys_session_id: int):
+        return self.fetch_api.get_ecephys_session(ecephys_session_id)
+
+    def get_behavior_session(self, behavior_session_id: int):
+        return self.fetch_api.get_behavior_session(behavior_session_id)

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -2,7 +2,6 @@ from functools import partial
 from typing import Optional, List, Union
 from pathlib import Path
 import pandas as pd
-import logging
 
 from allensdk.api.warehouse_cache.cache import Cache
 from allensdk.brain_observatory.behavior.behavior_project_cache.tables \
@@ -18,7 +17,8 @@ from allensdk.api.warehouse_cache.caching_utilities import \
 from allensdk.brain_observatory.behavior.behavior_project_cache.tables \
     .ophys_sessions_table import \
     BehaviorOphysSessionsTable
-from allensdk.core.authentication import DbCredentials
+from allensdk.brain_observatory.behavior.behavior_project_cache \
+    .project_cache_base import ProjectCacheBase
 
 
 class VBOLimsCache(Cache):
@@ -57,7 +57,10 @@ class VBOLimsCache(Cache):
     }
 
 
-class VisualBehaviorOphysProjectCache(object):
+class VisualBehaviorOphysProjectCache(ProjectCacheBase):
+
+    PROJECT_NAME = "visual-behavior-ophys"
+    BUCKET_NAME = "visual-behavior-ophys-data"
 
     def __init__(
             self,
@@ -75,17 +78,6 @@ class VisualBehaviorOphysProjectCache(object):
         to initialize a VisualBehaviorOphysProjectCache, rather than calling
         this directly.
 
-        --- NOTE ---
-        Because NWB files are not currently supported for this project (as of
-        11/2019), this cache will not actually save any files of session data
-        to the local machine. Only summary tables will be saved to the local
-        cache. File retrievals for specific sessions will be handled by
-        the fetch api used for the Session object, and cached in-memory
-        only to enable fast retrieval for subsequent calls.
-
-        If you are looping over session objects, be sure to clean up
-        your memory when it is not needed by calling `cache_clear` from
-        your session object.
 
         Parameters
         ==========
@@ -110,278 +102,27 @@ class VisualBehaviorOphysProjectCache(object):
         cache : bool
             Whether to write to the cache. Default=True.
         """
+
+        super().__init__(fetch_api=fetch_api, fetch_tries=fetch_tries)
+
         if cache:
             manifest_ = manifest or "behavior_project_manifest.json"
         else:
             manifest_ = None
-
-        self.fetch_api = fetch_api
-        self.cache = None
 
         if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
             if cache:
                 self.cache = VBOLimsCache(manifest=manifest_,
                                           version=version,
                                           cache=cache)
-        self.fetch_tries = fetch_tries
-        self.logger = logging.getLogger(self.__class__.__name__)
-
-    @property
-    def manifest(self):
-        if self.cache is None:
-            api_name = type(self.fetch_api).__name__
-            raise NotImplementedError(f"A {type(self).__name__} "
-                                      f"based on {api_name} "
-                                      "does not have an accessible manifest "
-                                      "property")
-        return self.cache.manifest
 
     @classmethod
-    def from_s3_cache(cls, cache_dir: Union[str, Path],
-                      bucket_name: str = "visual-behavior-ophys-data",
-                      project_name: str = "visual-behavior-ophys"
-                      ) -> "VisualBehaviorOphysProjectCache":
-        """instantiates this object with a connection to an s3 bucket and/or
-        a local cache related to that bucket.
-
-        Parameters
-        ----------
-        cache_dir: str or pathlib.Path
-            Path to the directory where data will be stored on the local system
-
-        bucket_name: str
-            for example, if bucket URI is 's3://mybucket' this value should be
-            'mybucket'
-
-        project_name: str
-            the name of the project this cache is supposed to access. This
-            project name is the first part of the prefix of the release data
-            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
-
-        Returns
-        -------
-        VisualBehaviorOphysProjectCache instance
-
-        """
-        fetch_api = BehaviorProjectCloudApi.from_s3_cache(
-                cache_dir, bucket_name, project_name,
-                ui_class_name=cls.__name__)
-        return cls(fetch_api=fetch_api)
+    def cloud_api_class(cls):
+        return BehaviorProjectCloudApi
 
     @classmethod
-    def from_local_cache(
-        cls,
-        cache_dir: Union[str, Path],
-        project_name: str = "visual-behavior-ophys",
-        use_static_cache: bool = False
-    ) -> "VisualBehaviorOphysProjectCache":
-        """instantiates this object with a local cache.
-
-        Parameters
-        ----------
-        cache_dir: str or pathlib.Path
-            Path to the directory where data will be stored on the local system
-
-        project_name: str
-            the name of the project this cache is supposed to access. This
-            project name is the first part of the prefix of the release data
-            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
-
-        Returns
-        -------
-        VisualBehaviorOphysProjectCache instance
-
-        """
-        fetch_api = BehaviorProjectCloudApi.from_local_cache(
-            cache_dir,
-            project_name,
-            ui_class_name=cls.__name__,
-            use_static_cache=use_static_cache
-        )
-        return cls(fetch_api=fetch_api)
-
-    @classmethod
-    def from_lims(cls, manifest: Optional[Union[str, Path]] = None,
-                  version: Optional[str] = None,
-                  cache: bool = False,
-                  fetch_tries: int = 2,
-                  lims_credentials: Optional[DbCredentials] = None,
-                  mtrain_credentials: Optional[DbCredentials] = None,
-                  host: Optional[str] = None,
-                  scheme: Optional[str] = None,
-                  asynchronous: bool = True,
-                  data_release_date: Optional[Union[str, List[str]]] = None
-                  ) -> "VisualBehaviorOphysProjectCache":
-        """
-        Construct a VisualBehaviorOphysProjectCache with a lims api. Use this
-        method to create a  VisualBehaviorOphysProjectCache instance rather
-        than calling VisualBehaviorOphysProjectCache directly.
-
-        Parameters
-        ==========
-        manifest : str or Path
-            full path at which manifest json will be stored
-        version : str
-            version of manifest file. If this mismatches the version
-            recorded in the file at manifest, an error will be raised.
-        cache : bool
-            Whether to write to the cache
-        fetch_tries : int
-            Maximum number of times to attempt a download before giving up and
-            raising an exception. Note that this is total tries, not retries
-        lims_credentials : DbCredentials
-            Optional credentials to access LIMS database.
-            If not set, will look for credentials in environment variables.
-        mtrain_credentials: DbCredentials
-            Optional credentials to access mtrain database.
-            If not set, will look for credentials in environment variables.
-        host : str
-            Web host for the app_engine. Currently unused. This argument is
-            included for consistency with EcephysProjectCache.from_lims.
-        scheme : str
-            URI scheme, such as "http". Currently unused. This argument is
-            included for consistency with EcephysProjectCache.from_lims.
-        asynchronous : bool
-            Whether to fetch from web asynchronously. Currently unused.
-        data_release_date: str or list of str
-            Use to filter tables to only include data released on date
-            ie 2021-03-25 or ['2021-03-25', '2021-08-12']
-        Returns
-        =======
-        VisualBehaviorOphysProjectCache
-            VisualBehaviorOphysProjectCache instance with a LIMS fetch API
-        """
-        if host and scheme:
-            app_kwargs = {"host": host, "scheme": scheme,
-                          "asynchronous": asynchronous}
-        else:
-            app_kwargs = None
-        fetch_api = BehaviorProjectLimsApi.default(
-            lims_credentials=lims_credentials,
-            mtrain_credentials=mtrain_credentials,
-            data_release_date=data_release_date,
-            app_kwargs=app_kwargs)
-        return cls(fetch_api=fetch_api, manifest=manifest, version=version,
-                   cache=cache, fetch_tries=fetch_tries)
-
-    def _cache_not_implemented(self, method_name: str) -> None:
-        """
-        Raise a NotImplementedError explaining that method_name
-        does not exist for VisualBehaviorOphysProjectCache
-        that does not have a fetch_api based on LIMS
-        """
-        msg = f"Method {method_name} does not exist for this "
-        msg += f"{type(self).__name__}, which is based on "
-        msg += f"{type(self.fetch_api).__name__}"
-        raise NotImplementedError(msg)
-
-    def construct_local_manifest(self) -> None:
-        """
-        Construct the local file used to determine if two files are
-        duplicates of each other or not. Save it into the expected
-        place in the cache. (You will see a warning if the cache
-        thinks that you need to run this method).
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('construct_local_manifest')
-        self.fetch_api.cache.construct_local_manifest()
-
-    def compare_manifests(self,
-                          manifest_0_name: str,
-                          manifest_1_name: str
-                          ) -> str:
-        """
-        Compare two manifests from this dataset. Return a dict
-        containing the list of metadata and data files that changed
-        between them
-
-        Note: this assumes that manifest_0 predates manifest_1
-
-        Parameters
-        ----------
-        manifest_0_name: str
-
-        manifest_1_name: str
-
-        Returns
-        -------
-        str
-            A string summarizing all of the changes going from
-            manifest_0 to manifest_1
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('compare_manifests')
-        return self.fetch_api.cache.compare_manifests(manifest_0_name,
-                                                      manifest_1_name)
-
-    def load_latest_manifest(self) -> None:
-        """
-        Load the manifest corresponding to the most up to date
-        version of the dataset.
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('load_latest_manifest')
-        self.fetch_api.cache.load_latest_manifest()
-
-    def latest_downloaded_manifest_file(self) -> str:
-        """
-        Return the name of the most up to date data manifest
-        available on your local system.
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('latest_downloaded_manifest_file')
-        return self.fetch_api.cache.latest_downloaded_manifest_file
-
-    def latest_manifest_file(self) -> str:
-        """
-        Return the name of the most up to date data manifest
-        corresponding to this dataset, checking in the cloud
-        if this is a cloud-backed cache.
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('latest_manifest_file')
-        return self.fetch_api.cache.latest_manifest_file
-
-    def load_manifest(self, manifest_name: str):
-        """
-        Load a specific versioned manifest for this dataset.
-
-        Parameters
-        ----------
-        manifest_name: str
-            The name of the manifest to load. Must be an element in
-            self.manifest_file_names
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('load_manifest')
-        self.fetch_api.load_manifest(manifest_name)
-
-    def list_all_downloaded_manifests(self) -> list:
-        """
-        Return a sorted list of the names of the manifest files
-        that have been downloaded to this cache.
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('list_all_downloaded_manifests')
-        return self.fetch_api.cache.list_all_downloaded_manifests()
-
-    def list_manifest_file_names(self) -> list:
-        """
-        Return a sorted list of the names of the manifest files
-        associated with this dataset.
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('list_manifest_file_names')
-        return self.fetch_api.cache.manifest_file_names
-
-    def current_manifest(self) -> Union[None, str]:
-        """
-        Return the name of the dataset manifest currently being
-        used by this cache.
-        """
-        if not isinstance(self.fetch_api, BehaviorProjectCloudApi):
-            self._cache_not_implemented('current_manifest')
-        return self.fetch_api.cache.current_manifest
+    def lims_api_class(cls):
+        return BehaviorProjectLimsApi
 
     def get_ophys_session_table(
             self,

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/__init__.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/__init__.py
@@ -1,2 +1,4 @@
 from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.data_io.behavior_project_lims_api import BehaviorProjectLimsApi  # noqa: F401, E501
 from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.data_io.behavior_project_cloud_api import BehaviorProjectCloudApi  # noqa: F401, E501
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.data_io.behavior_neuropixels_project_cloud_api import VisualBehaviorNeuropixelsProjectCloudApi  # noqa: F401, E501
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.data_io.behavior_neuropixels_project_cloud_api import ProjectCloudApiBase  # noqa: F401, E501

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_neuropixels_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_neuropixels_project_cloud_api.py
@@ -1,0 +1,149 @@
+import pandas as pd
+
+from allensdk.brain_observatory.behavior.behavior_project_cache.\
+    project_apis.data_io.project_cloud_api_base import ProjectCloudApiBase  # noqa: E501
+
+from allensdk.brain_observatory.behavior.behavior_session import (
+    BehaviorSession)
+
+from allensdk.brain_observatory.ecephys.behavior_ecephys_session \
+    import BehaviorEcephysSession
+
+
+class VisualBehaviorNeuropixelsProjectCloudApi(ProjectCloudApiBase):
+
+    MANIFEST_COMPATIBILITY = ["0.1.0", "1.0.0"]
+
+    def _load_manifest_tables(self):
+
+        self._get_ecephys_session_table()
+        self._get_behavior_session_table()
+        self._get_unit_table()
+        self._get_probe_table()
+        self._get_channel_table()
+
+    def get_behavior_session(
+            self, behavior_session_id: int) -> BehaviorSession:
+        """
+        Since we are not releasing behavior-only NWB files
+        with the VBN June 2022 release, the behavior sesion data
+        is obtained from the behavior_ecephys_session NWB file
+        based on the associated behavior_ecephys_session_id
+
+        Parameters
+        ----------
+        behavior_session_id: int
+            the id of the behavior_session
+
+        Returns
+        -------
+        BehaviorSession
+
+        Notes
+        -----
+        behavior session does not include file_id.
+        The file id is accessed via ecephys_session_id key
+        from the ecephys_session_table
+        """
+        row = self._behavior_session_table.query(
+                f"behavior_session_id=={behavior_session_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_session_table should have "
+                               "1 and only 1 entry for a given "
+                               "behavior_session_id. For "
+                               f"{behavior_session_id} "
+                               f" there are {row.shape[0]} entries.")
+        row = row.squeeze()
+        ecephys_session_id = int(row.ecephys_session_id)
+
+        row = self._ecephys_session_table.query(f"index=={ecephys_session_id}")
+
+        if len(row) == 0:
+            raise RuntimeError(f"ecephys_session: {ecephys_session_id} "
+                               f"corresponding to "
+                               f"behavior_session: {behavior_session_id} "
+                               f"does not exist in the ecephys_session_table ")
+
+        file_id = str(int(row[self.cache.file_id_column]))
+        data_path = self._get_data_path(file_id=file_id)
+
+        return BehaviorSession.from_nwb_path(str(data_path))
+
+    def get_ecephys_session(
+        self,
+        ecephys_session_id: int
+    ) -> BehaviorEcephysSession:
+
+        """get a BehaviorEcephysSession by specifying ecephys_session_id
+
+        Parameters
+        ----------
+        ecephys_session_id: int
+            the id of the ecephys session
+
+        Returns
+        -------
+        BehaviorEcephysSession
+
+        """
+        row = self._ecephys_session_table.query(
+                f"index=={ecephys_session_id}")
+        if row.shape[0] != 1:
+            raise RuntimeError("The behavior_ecephys_session_table should "
+                               "have 1 and only 1 entry for a given "
+                               f"ecephys_session_id. For "
+                               f"{ecephys_session_id} "
+                               f" there are {row.shape[0]} entries.")
+        file_id = str(int(row[self.cache.file_id_column]))
+        data_path = self._get_data_path(file_id=file_id)
+        return BehaviorEcephysSession.from_nwb_path(
+            str(data_path))
+
+    def _get_ecephys_session_table(self):
+        session_table_path = self._get_metadata_path(
+            fname="ecephys_sessions")
+        df = pd.read_csv(session_table_path)
+        self._ecephys_session_table = df.set_index("ecephys_session_id")
+
+    def get_ecephys_session_table(self) -> pd.DataFrame:
+        """Return a pd.Dataframe table summarizing ecephys_sessions
+        and associated metadata.
+
+        """
+        return self._ecephys_session_table
+
+    def _get_behavior_session_table(self):
+        session_table_path = self._get_metadata_path(
+            fname='behavior_sessions')
+        df = pd.read_csv(session_table_path)
+        self._behavior_session_table = df.set_index("behavior_session_id")
+
+    def get_behavior_session_table(self) -> pd.DataFrame:
+        return self._behavior_session_table
+
+    def _get_probe_table(self):
+        probe_table_path = self._get_metadata_path(
+            fname="probes")
+        df = pd.read_csv(probe_table_path)
+        self._probe_table = df.set_index("ecephys_probe_id")
+
+    def get_probe_table(self):
+        return self._probe_table
+
+    def _get_unit_table(self):
+        unit_table_path = self._get_metadata_path(
+            fname="units")
+        df = pd.read_csv(unit_table_path)
+        self._unit_table = df.set_index("unit_id")
+
+    def get_unit_table(self):
+        return self._unit_table
+
+    def _get_channel_table(self):
+        channel_table_path = self._get_metadata_path(
+            fname="channels")
+        df = pd.read_csv(channel_table_path)
+        self._channel_table = df.set_index("ecephys_channel_id")
+
+    def get_channel_table(self):
+        return self._channel_table

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/project_cloud_api_base.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/project_cloud_api_base.py
@@ -1,0 +1,189 @@
+from typing import Union, Optional
+from pathlib import Path
+import logging
+
+from allensdk.api.cloud_cache.cloud_cache import (
+    S3CloudCache, LocalCache, StaticLocalCache)
+
+from allensdk.brain_observatory.behavior.behavior_project_cache \
+    .utils import version_check
+
+
+class ProjectCloudApiBase(object):
+    """API for downloading data released on S3 and returning tables.
+
+    Parameters
+    ----------
+    cache: S3CloudCache
+        an instantiated S3CloudCache object, which has already run
+        `self.load_manifest()` which populates the columns:
+          - metadata_file_names
+          - file_id_column
+    skip_version_check: bool
+        whether to skip the version checking of pipeline SDK version
+        vs. running SDK version, which may raise Exceptions. (default=False)
+    local: bool
+        Whether to operate in local mode, where no data will be downloaded
+        and instead will be loaded from local
+    """
+    def __init__(
+        self,
+        cache: Union[S3CloudCache, LocalCache, StaticLocalCache],
+        skip_version_check: bool = False,
+        local: bool = False
+    ):
+
+        self.cache = cache
+        self.skip_version_check = skip_version_check
+        self._local = local
+        self.load_manifest()
+
+    def load_manifest(self, manifest_name: Optional[str] = None):
+        """
+        Load the specified manifest file into the CloudCache
+
+        Parameters
+        ----------
+        manifest_name: Optional[str]
+            Name of manifest file to load. If None, load latest
+            (default: None)
+        """
+        if manifest_name is None:
+            self.cache.load_last_manifest()
+        else:
+            self.cache.load_manifest(manifest_name)
+
+        if self.cache._manifest.metadata_file_names is None:
+            raise RuntimeError(f"{type(self.cache)} object has no metadata "
+                               f"file names. Check contents of the loaded "
+                               f"manifest file: {self.cache._manifest_name}")
+
+        if not self.skip_version_check:
+            data_sdk_version = [i for i in self.cache._manifest._data_pipeline
+                                if i['name'] == "AllenSDK"][0]["version"]
+            version_check(
+                self.cache._manifest.version,
+                data_sdk_version,
+                cmin=self.MANIFEST_COMPATIBILITY[0],
+                cmax=self.MANIFEST_COMPATIBILITY[1])
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self._load_manifest_tables()
+
+    def _load_manifest_tables(self):
+
+        raise NotImplementedError
+
+    @classmethod
+    def from_s3_cache(cls, cache_dir: Union[str, Path],
+                      bucket_name: str,
+                      project_name: str,
+                      ui_class_name: str) -> "ProjectCloudApiBase":
+        """instantiates this object with a connection to an s3 bucket and/or
+        a local cache related to that bucket.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        bucket_name: str
+            for example, if bucket URI is 's3://mybucket' this value should be
+            'mybucket'
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        ui_class_name: str
+            Name of user interface class (used to populate error messages)
+
+        Returns
+        -------
+        BehaviorProjectCloudApi instance
+
+        """
+        cache = S3CloudCache(cache_dir,
+                             bucket_name,
+                             project_name,
+                             ui_class_name=ui_class_name)
+        return cls(cache)
+
+    @classmethod
+    def from_local_cache(
+        cls,
+        cache_dir: Union[str, Path],
+        project_name: str,
+        ui_class_name: str,
+        use_static_cache: bool = False
+    ) -> "ProjectCloudApiBase":
+        """instantiates this object with a local cache.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        ui_class_name: str
+            Name of user interface class (used to populate error messages)
+
+        Returns
+        -------
+        ProjectCloudApiBase instance
+
+        """
+        if use_static_cache:
+            cache = StaticLocalCache(
+                cache_dir,
+                project_name,
+                ui_class_name=ui_class_name
+            )
+        else:
+            cache = LocalCache(
+                cache_dir,
+                project_name,
+                ui_class_name=ui_class_name
+            )
+        return cls(cache, local=True)
+
+    def _get_metadata_path(self, fname: str):
+        if self._local:
+            path = self._get_local_path(fname=fname)
+        else:
+            path = self.cache.download_metadata(fname=fname)
+        return path
+
+    def _get_data_path(self, file_id: str):
+        if self._local:
+            data_path = self._get_local_path(file_id=file_id)
+        else:
+            data_path = self.cache.download_data(file_id=file_id)
+        return data_path
+
+    def _get_local_path(self, fname: Optional[str] = None, file_id:
+                        Optional[str] = None):
+        if fname is None and file_id is None:
+            raise ValueError('Must pass either fname or file_id')
+
+        if fname is not None and file_id is not None:
+            raise ValueError('Must pass only one of fname or file_id')
+
+        if fname is not None:
+            path = self.cache.metadata_path(fname=fname)
+        else:
+            path = self.cache.data_path(file_id=file_id)
+
+        exists = path['exists']
+        local_path = path['local_path']
+        if not exists:
+            raise FileNotFoundError(f'You started a cache without a '
+                                    f'connection to s3 and {local_path} is '
+                                    'not already on your system')
+        return local_path

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_cache_base.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_cache_base.py
@@ -1,0 +1,294 @@
+from typing import Optional, Union, List
+from pathlib import Path
+import logging
+
+from allensdk.brain_observatory.behavior.behavior_project_cache.\
+    project_apis.data_io import ProjectCloudApiBase
+from allensdk.core.authentication import DbCredentials
+from allensdk.brain_observatory.behavior.behavior_project_cache.\
+    project_apis.data_io import BehaviorProjectLimsApi
+
+
+class ProjectCacheBase(object):
+
+    BUCKET_NAME: str = None
+    PROJECT_NAME: str = None
+
+    def __init__(
+            self,
+            fetch_api: Union[ProjectCloudApiBase, BehaviorProjectLimsApi],
+            fetch_tries: int = 2,
+            ):
+        """
+        Parameters
+        ==========
+        fetch_api :
+            Used to pull data from remote sources, after which it is locally
+            cached.
+        fetch_tries :
+            Maximum number of times to attempt a download before giving up and
+            raising an exception. Note that this is total tries, not retries.
+            Default=2.
+        """
+
+        self.fetch_api = fetch_api
+        self.cache = None
+
+        self.fetch_tries = fetch_tries
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    @property
+    def manifest(self):
+        if self.cache is None:
+            api_name = type(self.fetch_api).__name__
+            raise NotImplementedError(f"A {type(self).__name__} "
+                                      f"based on {api_name} "
+                                      "does not have an accessible manifest "
+                                      "property")
+        return self.cache.manifest
+
+    @classmethod
+    def from_s3_cache(cls, cache_dir: Union[str, Path]
+                      ) -> "ProjectCacheBase":
+        """instantiates this object with a connection to an s3 bucket and/or
+        a local cache related to that bucket.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        bucket_name: str
+            for example, if bucket URI is 's3://mybucket' this value should be
+            'mybucket'
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        Returns
+        -------
+        ProjectCacheBase instance
+
+        """
+
+        fetch_api = cls.cloud_api_class().from_s3_cache(
+            cache_dir,
+            bucket_name=cls.BUCKET_NAME,
+            project_name=cls.PROJECT_NAME,
+            ui_class_name=cls.__name__)
+
+        return cls(fetch_api=fetch_api)
+
+    @classmethod
+    def from_local_cache(
+        cls,
+        cache_dir: Union[str, Path],
+        use_static_cache: bool = False
+    ) -> "ProjectCacheBase":
+        """instantiates this object with a local cache.
+
+        Parameters
+        ----------
+        cache_dir: str or pathlib.Path
+            Path to the directory where data will be stored on the local system
+
+        project_name: str
+            the name of the project this cache is supposed to access. This
+            project name is the first part of the prefix of the release data
+            objects. I.e. s3://<bucket_name>/<project_name>/<object tree>
+
+        Returns
+        -------
+        ProjectCacheBase instance
+
+        """
+        fetch_api = cls.cloud_api_class().from_local_cache(
+            cache_dir,
+            project_name=cls.PROJECT_NAME,
+            ui_class_name=cls.__name__,
+            use_static_cache=use_static_cache
+        )
+        return cls(fetch_api=fetch_api)
+
+    @classmethod
+    def from_lims(cls, manifest: Optional[Union[str, Path]] = None,
+                  version: Optional[str] = None,
+                  cache: bool = False,
+                  fetch_tries: int = 2,
+                  lims_credentials: Optional[DbCredentials] = None,
+                  mtrain_credentials: Optional[DbCredentials] = None,
+                  host: Optional[str] = None,
+                  scheme: Optional[str] = None,
+                  asynchronous: bool = True,
+                  data_release_date: Optional[Union[str, List[str]]] = None
+                  ) -> "ProjectCacheBase":
+        """
+        Construct a ProjectCacheBase with a lims api.
+
+        Parameters
+        ==========
+        manifest : str or Path
+            full path at which manifest json will be stored
+        version : str
+            version of manifest file. If this mismatches the version
+            recorded in the file at manifest, an error will be raised.
+        cache : bool
+            Whether to write to the cache
+        fetch_tries : int
+            Maximum number of times to attempt a download before giving up and
+            raising an exception. Note that this is total tries, not retries
+        lims_credentials : DbCredentials
+            Optional credentials to access LIMS database.
+            If not set, will look for credentials in environment variables.
+        mtrain_credentials: DbCredentials
+            Optional credentials to access mtrain database.
+            If not set, will look for credentials in environment variables.
+        host : str
+            Web host for the app_engine. Currently unused. This argument is
+            included for consistency with EcephysProjectCache.from_lims.
+        scheme : str
+            URI scheme, such as "http". Currently unused. This argument is
+            included for consistency with EcephysProjectCache.from_lims.
+        asynchronous : bool
+            Whether to fetch from web asynchronously. Currently unused.
+        data_release_date: str or list of str
+            Use to filter tables to only include data released on date
+            ie 2021-03-25 or ['2021-03-25', '2021-08-12']
+        Returns
+        =======
+        ProjectCacheBase
+            ProjectCachBase instance with a LIMS fetch API
+        """
+        if host and scheme:
+            app_kwargs = {"host": host, "scheme": scheme,
+                          "asynchronous": asynchronous}
+        else:
+            app_kwargs = None
+        fetch_api = cls.lims_api_class().default(
+            lims_credentials=lims_credentials,
+            mtrain_credentials=mtrain_credentials,
+            data_release_date=data_release_date,
+            app_kwargs=app_kwargs)
+        return cls(fetch_api=fetch_api, manifest=manifest, version=version,
+                   cache=cache, fetch_tries=fetch_tries)
+
+    def _cache_not_implemented(self, method_name: str) -> None:
+        """
+        Raise a NotImplementedError explaining that method_name
+        does not exist for VisualBehaviorNeuropixelsProjectCache
+        that does not have a fetch_api based on LIMS
+        """
+        msg = f"Method {method_name} does not exist for this "
+        msg += f"{type(self).__name__}, which is based on "
+        msg += f"{type(self.fetch_api).__name__}"
+        raise NotImplementedError(msg)
+
+    def construct_local_manifest(self) -> None:
+        """
+        Construct the local file used to determine if two files are
+        duplicates of each other or not. Save it into the expected
+        place in the cache. (You will see a warning if the cache
+        thinks that you need to run this method).
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('construct_local_manifest')
+        self.fetch_api.cache.construct_local_manifest()
+
+    def compare_manifests(self,
+                          manifest_0_name: str,
+                          manifest_1_name: str
+                          ) -> str:
+        """
+        Compare two manifests from this dataset. Return a dict
+        containing the list of metadata and data files that changed
+        between them
+
+        Note: this assumes that manifest_0 predates manifest_1
+
+        Parameters
+        ----------
+        manifest_0_name: str
+
+        manifest_1_name: str
+
+        Returns
+        -------
+        str
+            A string summarizing all of the changes going from
+            manifest_0 to manifest_1
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('compare_manifests')
+        return self.fetch_api.cache.compare_manifests(manifest_0_name,
+                                                      manifest_1_name)
+
+    def load_latest_manifest(self) -> None:
+        """
+        Load the manifest corresponding to the most up to date
+        version of the dataset.
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('load_latest_manifest')
+        self.fetch_api.cache.load_latest_manifest()
+
+    def latest_downloaded_manifest_file(self) -> str:
+        """
+        Return the name of the most up to date data manifest
+        available on your local system.
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('latest_downloaded_manifest_file')
+        return self.fetch_api.cache.latest_downloaded_manifest_file
+
+    def latest_manifest_file(self) -> str:
+        """
+        Return the name of the most up to date data manifest
+        corresponding to this dataset, checking in the cloud
+        if this is a cloud-backed cache.
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('latest_manifest_file')
+        return self.fetch_api.cache.latest_manifest_file
+
+    def load_manifest(self, manifest_name: str):
+        """
+        Load a specific versioned manifest for this dataset.
+
+        Parameters
+        ----------
+        manifest_name: str
+            The name of the manifest to load. Must be an element in
+            self.manifest_file_names
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('load_manifest')
+        self.fetch_api.load_manifest(manifest_name)
+
+    def list_all_downloaded_manifests(self) -> list:
+        """
+        Return a sorted list of the names of the manifest files
+        that have been downloaded to this cache.
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('list_all_downloaded_manifests')
+        return self.fetch_api.cache.list_all_downloaded_manifests()
+
+    def list_manifest_file_names(self) -> list:
+        """
+        Return a sorted list of the names of the manifest files
+        associated with this dataset.
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('list_manifest_file_names')
+        return self.fetch_api.cache.manifest_file_names
+
+    def current_manifest(self) -> Union[None, str]:
+        """
+        Return the name of the dataset manifest currently being
+        used by this cache.
+        """
+        if not isinstance(self.fetch_api, self.cloud_api_class()):
+            self._cache_not_implemented('current_manifest')
+        return self.fetch_api.cache.current_manifest

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/utils.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/utils.py
@@ -1,0 +1,22 @@
+import semver
+
+
+class BehaviorCloudCacheVersionException(Exception):
+    pass
+
+
+def version_check(manifest_version: str,
+                  data_pipeline_version: str,
+                  cmin: str,
+                  cmax: str):
+    mver_parsed = semver.VersionInfo.parse(manifest_version)
+    cmin_parsed = semver.VersionInfo.parse(cmin)
+    cmax_parsed = semver.VersionInfo.parse(cmax)
+
+    if (mver_parsed < cmin_parsed) | (mver_parsed >= cmax_parsed):
+        estr = (f"the manifest has manifest_version {manifest_version} but "
+                "this version of AllenSDK is compatible only with manifest "
+                f"versions {cmin} <= X < {cmax}. \n"
+                "Consider using a version of AllenSDK closer to the version "
+                f"used to release the data: {data_pipeline_version}")
+        raise BehaviorCloudCacheVersionException(estr)

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -521,7 +521,8 @@ class BehaviorSession(DataObject, LimsReadableInterface,
         -------
         An instantiation of a `BehaviorSession`
         """
-        with pynwb.NWBHDF5IO(str(nwb_path), 'r') as read_io:
+        nwb_path = str(nwb_path)
+        with pynwb.NWBHDF5IO(nwb_path, 'r', load_namespaces=True) as read_io:
             nwbfile = read_io.read()
             return cls.from_nwb(nwbfile=nwbfile, **kwargs)
 

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/conftest.py
@@ -4,17 +4,24 @@ import io
 import semver
 
 from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.\
-        data_io.behavior_project_cloud_api import MANIFEST_COMPATIBILITY
+        data_io.behavior_project_cloud_api \
+        import BehaviorProjectCloudApi
+
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.\
+        data_io.behavior_neuropixels_project_cloud_api \
+        import VisualBehaviorNeuropixelsProjectCloudApi
 
 
 @pytest.fixture
-def s3_cloud_cache_data():
+def vbo_s3_cloud_cache_data():
 
     all_versions = {}
     all_versions['data'] = {}
     all_versions['metadata'] = {}
 
-    min_compat = semver.parse_version_info(MANIFEST_COMPATIBILITY[0])
+    cmin, cmax = BehaviorProjectCloudApi.MANIFEST_COMPATIBILITY
+
+    min_compat = semver.parse_version_info(cmin)
     versions = []
 
     version = str(min_compat)
@@ -154,6 +161,162 @@ def s3_cloud_cache_data():
     buff.seek(0)
 
     metadata['ophys_cells_table'] = bytes(buff.read(), 'utf-8')
+
+    all_versions['data'][version] = data
+    all_versions['metadata'][version] = metadata
+
+    return all_versions, versions
+
+
+@pytest.fixture
+def vbn_s3_cloud_cache_data():
+
+    all_versions = {}
+    all_versions['data'] = {}
+    all_versions['metadata'] = {}
+
+    min, max = VisualBehaviorNeuropixelsProjectCloudApi.MANIFEST_COMPATIBILITY
+
+    min_compat = semver.parse_version_info(min)
+    versions = []
+
+    version = str(min_compat)
+    versions.append(version)
+    data = {}
+    metadata = {}
+
+    data['ecephys_file_1.nwb'] = {'file_id': 1, 'data': b'abcde'}
+    data['ecephys_file_2.nwb'] = {'file_id': 2, 'data': b'fghijk'}
+
+    e_session = [{'ecephys_session_id': 5111,
+                  'file_id': 1},
+                 {'ecephys_session_id': 5112,
+                  'file_id': 2}]
+    e_session = pd.DataFrame(e_session)
+    buff = io.StringIO()
+    e_session.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['ecephys_sessions'] = bytes(buff.read(), 'utf-8')
+
+    b_session = [{'behavior_session_id': 333,
+                  'ecephys_session_id': 5111,
+                  'species': 'mouse'},
+                 {'behavior_session_id': 444,
+                  'ecephys_session_id': 5112,
+                  'species': 'mouse'}]
+    b_session = pd.DataFrame(b_session)
+    buff = io.StringIO()
+    b_session.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['behavior_sessions'] = bytes(buff.read(), 'utf-8')
+
+    probes = [
+        {'ecephys_probe_id': 5111, 'ecephys_session_id': 5111},
+        {'ecephys_probe_id': 5222, 'ecephys_session_id_id': 5112}
+    ]
+
+    probes = pd.DataFrame(probes)
+    buff = io.StringIO()
+    probes.to_csv(buff, index=False)
+    buff.seek(0)
+
+    metadata['probes'] = bytes(buff.read(), 'utf-8')
+
+    channels = {
+        'ecephys_channel_id': {0: 9080884343, 1: 1080884173, 2: 1080883843},
+        'ecephys_probe_id': {0: 1086496928, 1: 1086496914, 2: 1086496838},
+        'ecephys_session_id': {0: 775614751, 1: 775614751, 2: 775614751}}
+    channels = pd.DataFrame(channels)
+    buff = io.StringIO()
+    channels.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['channels'] = bytes(buff.read(), 'utf-8')
+
+    units = {
+        'unit_id': {0: 9080884343, 1: 1080884173, 2: 1080883843},
+        'ecephys_channel_id': {0: 1086496928, 1: 1086496914, 2: 1086496838},
+        'ecephys_probe_id': {0: 775614751, 1: 775614751, 2: 775614751},
+        'ecephys_session_id': {0: 75614751, 1: 75614751, 2: 75614751}}
+    units = pd.DataFrame(units)
+    buff = io.StringIO()
+    units.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['units'] = bytes(buff.read(), 'utf-8')
+
+    all_versions['data'][version] = data
+    all_versions['metadata'][version] = metadata
+
+# new version:
+    version = str(min_compat.bump_minor())
+    versions.append(version)
+    data = {}
+    metadata = {}
+
+    data['ecephys_file_1.nwb'] = {'file_id': 1, 'data': b'lmnopqrs'}
+    data['ecephys_file_2.nwb'] = {'file_id': 2, 'data': b'fghijk'}
+    data['ecephys_file_3.nwb'] = {'file_id': 3, 'data': b'fxxhijk'}
+
+    e_session = [
+        {'ecephys_session_id': 222, 'file_id': 1},
+        {'ecephys_session_id': 333, 'file_id': 2},
+        {'ecephys_session_id': 444, 'file_id': 3},
+    ]
+
+    e_session = pd.DataFrame(e_session)
+    buff = io.StringIO()
+    e_session.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['ecephys_sessions'] = bytes(buff.read(), 'utf-8')
+
+    b_session = [{'behavior_session_id': 777,
+                  'ecephys_session_id': 222,
+                  'species': 'mouse'},
+                 {'behavior_session_id': 888,
+                  'ecephys_session_id': 333,
+                  'species': 'mouse'},
+                 {'behavior_session_id': 999,
+                  'ecephys_session_id': 444,
+                  'species': 'mouse'}
+                 ]
+
+    b_session = pd.DataFrame(b_session)
+    buff = io.StringIO()
+    b_session.to_csv(buff, index=False)
+    buff.seek(0)
+
+    metadata['behavior_sessions'] = bytes(buff.read(), 'utf-8')
+
+    probes = [
+        {'ecephys_probe_id': 5411, 'ecephys_session_id': 222},
+        {'ecephys_probe_id': 5422, 'ecephys_session_id_id': 222}
+    ]
+
+    probes = pd.DataFrame(probes)
+    buff = io.StringIO()
+    probes.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['probes'] = bytes(buff.read(), 'utf-8')
+
+    channels = {
+        'ecephys_channel_id': {0: 9080884343, 1: 1080884173, 2: 1080883843},
+        'ecephys_probe_id': {0: 1086496928, 1: 1086496914, 2: 1086496838},
+        'ecephys_session_id': {0: 775614751, 1: 775614751, 2: 775614751}}
+    channels = pd.DataFrame(channels)
+    buff = io.StringIO()
+    channels.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['channels'] = bytes(buff.read(), 'utf-8')
+
+    units = {
+        'unit_id': {0: 9080884343, 1: 1080884173, 2: 1080883843},
+        'ecephys_channel_id': {0: 1086496928, 1: 1086496914, 2: 1086496838},
+        'ecephys_probe_id': {0: 775614751, 1: 775614751, 2: 775614751},
+        'ecephys_session_id': {0: 75614751, 1: 75614751, 2: 75614751}}
+    units = pd.DataFrame(units)
+    buff = io.StringIO()
+    units.to_csv(buff, index=False)
+    buff.seek(0)
+    metadata['units'] = bytes(buff.read(), 'utf-8')
 
     all_versions['data'][version] = data
     all_versions['metadata'][version] = metadata

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_neuropixels_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_neuropixels_project_cloud_api.py
@@ -1,0 +1,262 @@
+import pytest
+import pandas as pd
+from pathlib import Path
+from unittest.mock import MagicMock, create_autospec
+
+from allensdk.api.cloud_cache.manifest import Manifest
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.\
+    data_io import behavior_neuropixels_project_cloud_api as cloudapi  # noqa: E501
+
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.\
+    data_io import project_cloud_api_base as cloudapibase  # noqa: E501
+
+from allensdk.brain_observatory.behavior.behavior_project_cache.\
+    utils import version_check, BehaviorCloudCacheVersionException
+
+
+class MockCache():
+    def __init__(self,
+                 behavior_session_table,
+                 ecephys_session_table,
+                 probe_table,
+                 channel_table,
+                 unit_table,
+                 cachedir):
+        self.file_id_column = "file_id"
+        self.session_table_path = cachedir / "ecephys_sessions.csv"
+        self.behavior_session_table_path = cachedir / "behavior_sessions.csv"
+        self.unit_table_path = cachedir / "units.csv"
+        self.probe_table_path = cachedir / "probes.csv"
+        self.channel_table_path = cachedir / "channel.csv"
+
+        ecephys_session_table.to_csv(self.session_table_path, index=False)
+        channel_table.to_csv(self.channel_table_path, index=False)
+        probe_table.to_csv(self.probe_table_path, index=False)
+        unit_table.to_csv(self.unit_table_path, index=False)
+        behavior_session_table.to_csv(self.behavior_session_table_path,
+                                      index=False)
+
+        self._manifest = MagicMock()
+        self._manifest.metadata_file_names = ["behavior_sessions",
+                                              "ecephys_session",
+                                              "probes",
+                                              "channels",
+                                              "units"]
+        self._metadata_name_path_map = {
+                "behavior_sessions": self.behavior_session_table_path,
+                "ecephys_sessions": self.session_table_path,
+                "channels": self.channel_table_path,
+                "probes": self.probe_table_path,
+                "units": self.unit_table_path}
+
+    def download_metadata(self, fname):
+        return self._metadata_name_path_map[fname]
+
+    def download_data(self, file_id):
+        return file_id
+
+    def metadata_path(self, fname):
+        local_path = self._metadata_name_path_map[fname]
+        return {
+            'local_path': local_path,
+            'exists': Path(local_path).exists()
+        }
+
+    def data_path(self, file_id):
+        return {
+            'local_path': file_id,
+            'exists': True
+        }
+
+    def load_last_manifest(self):
+        return None
+
+
+@pytest.fixture
+def mock_cache(request, tmpdir):
+    bst = request.param.get("behavior_sessions")
+    est = request.param.get("ecephys_sessions")
+    pt = request.param.get("probes")
+    ct = request.param.get("channels")
+    ut = request.param.get("units")
+
+    # round-trip the tables through csv to pick up
+    # pandas mods to lists
+    fname = tmpdir / "my.csv"
+    bst.to_csv(fname, index=False)
+    bst = pd.read_csv(fname)
+
+    est.to_csv(fname, index=False)
+    est = pd.read_csv(fname)
+
+    pt.to_csv(fname, index=False)
+    pt = pd.read_csv(fname)
+
+    ct.to_csv(fname, index=False)
+    ct = pd.read_csv(fname)
+
+    ut.to_csv(fname, index=False)
+    ut = pd.read_csv(fname)
+
+    yield (MockCache(bst, est, pt, ct, ut, tmpdir), request.param)
+
+
+@pytest.mark.parametrize(
+        "mock_cache",
+        [
+            {
+                "behavior_sessions": pd.DataFrame({
+                    "behavior_session_id": [1, 2, 3, 4],
+                    "ecephys_session_id": [10, 11, 12, 13],
+                    "mouse_id": [4, 4, 2, 1]}),
+                "ecephys_sessions": pd.DataFrame({
+                    "ecephys_session_id": [10, 11, 12, 13],
+                    "behavior_session_id": [1, 2, 3, 4],
+                    "file_id": [10, 11, 12, 13]}),
+                "probes": pd.DataFrame({
+                    "ecephys_probe_id": [4, 5, 6, 7],
+                    "ecephys_session_id": [10, 10, 11, 11]}),
+                "channels": pd.DataFrame({
+                    "ecephys_channel_id": [14, 15, 16],
+                    "ecephys_probe_id": [4, 4, 4],
+                    "ecephys_session_id": [10, 10, 10]}),
+                "units": pd.DataFrame({
+                    "unit_id": [204, 205, 206],
+                    "ecephys_channel_id": [14, 15, 16],
+                    "ecephys_probe_id": [4, 4, 4],
+                    "ecephys_session_id": [10, 10, 10]}),
+            }
+        ],
+        indirect=["mock_cache"])
+@pytest.mark.parametrize("local", [True, False])
+def test_VisualBehaviorNeuropixelsProjectCloudApi(
+    mock_cache,
+    monkeypatch,
+    local
+):
+
+    mocked_cache, expected = mock_cache
+    api = cloudapi.VisualBehaviorNeuropixelsProjectCloudApi(
+        mocked_cache,
+        skip_version_check=True,
+        local=False)
+
+    if local:
+        api = cloudapi.VisualBehaviorNeuropixelsProjectCloudApi(
+            mocked_cache,
+            skip_version_check=True,
+            local=True)
+
+    # behavior session table as expected
+    bst = api.get_behavior_session_table()
+    assert bst.index.name == "behavior_session_id"
+    bst = bst.reset_index()
+    bst_expected = expected["behavior_sessions"]
+    for k in ["behavior_session_id", "mouse_id"]:
+        pd.testing.assert_series_equal(bst[k], bst_expected[k])
+
+    # ecephys session table as expected
+    est = api.get_ecephys_session_table()
+    assert est.index.name == "ecephys_session_id"
+    est = est.reset_index()
+    est_expected = expected["ecephys_sessions"]
+    for k in ["ecephys_session_id"]:
+        pd.testing.assert_series_equal(est[k], est_expected[k])
+
+    # probes table as expected
+    pt = api.get_probe_table()
+    assert pt.index.name == "ecephys_probe_id"
+    pt = pt.reset_index()
+    pd.testing.assert_frame_equal(pt, expected["probes"])
+
+    # channels table as expected
+    ct = api.get_channel_table()
+    assert ct.index.name == "ecephys_channel_id"
+    ct = ct.reset_index()
+    pd.testing.assert_frame_equal(ct, expected["channels"])
+
+    # units table as expected
+    ut = api.get_unit_table()
+    assert ut.index.name == "unit_id"
+    ut = ut.reset_index()
+    pd.testing.assert_frame_equal(ut, expected["units"])
+
+    def mock_nwb(nwb_path):
+        return nwb_path
+
+    monkeypatch.setattr(cloudapi.BehaviorEcephysSession,
+                        "from_nwb_path", mock_nwb)
+    assert api.get_ecephys_session(12) == "12"
+
+
+@pytest.mark.parametrize(
+        "manifest_version, data_pipeline_version, cmin, cmax, exception",
+        [
+            ("0.0.1", "2.9.0", "0.0.0", "1.0.0", False),
+            ("1.0.1", "2.9.0", "0.0.0", "1.0.0", True)
+            ])
+def test_version_check(manifest_version, data_pipeline_version,
+                       cmin, cmax, exception):
+    if exception:
+        with pytest.raises(BehaviorCloudCacheVersionException,
+                           match=f".*{data_pipeline_version}"):
+            version_check(
+                manifest_version,
+                data_pipeline_version,
+                cmin, cmax)
+    else:
+        version_check(manifest_version, data_pipeline_version, cmin, cmax)
+
+
+def test_from_local_cache(monkeypatch):
+    mock_manifest = create_autospec(Manifest)
+    mock_manifest.metadata_file_names = {
+        'ecephys_sessions',
+        'behavior_sessions',
+        'probes',
+        'units',
+        'channels'
+    }
+    mock_manifest._data_pipeline = [
+        {
+            "name": "AllenSDK",
+            "version": "2.11.0",
+            "comment": "This is a test entry. NOT REAL."
+        }
+    ]
+    mock_manifest.version = cloudapi \
+        .VisualBehaviorNeuropixelsProjectCloudApi.MANIFEST_COMPATIBILITY[0]
+
+    mock_local_cache = create_autospec(cloudapibase.LocalCache)
+    type(mock_local_cache.return_value)._manifest = mock_manifest
+    mock_static_local_cache = create_autospec(cloudapibase.StaticLocalCache)
+    type(mock_static_local_cache.return_value)._manifest = mock_manifest
+
+    with monkeypatch.context() as m:
+
+        m.setattr(cloudapibase, "LocalCache", mock_local_cache)
+        m.setattr(cloudapibase, "StaticLocalCache", mock_static_local_cache)
+
+        # Test from_local_cache with use_static_cache=False
+        try:
+            cloudapi.VisualBehaviorNeuropixelsProjectCloudApi.from_local_cache(
+                "first_cache_dir", "project_1", "ui_1", use_static_cache=False
+            )
+        except (TypeError, FileNotFoundError):
+            pass
+
+        mock_local_cache.assert_called_once_with(
+            "first_cache_dir", "project_1", "ui_1"
+        )
+
+        # Test from_local_cache with use_static_cache=True
+        try:
+            cloudapi.VisualBehaviorNeuropixelsProjectCloudApi.from_local_cache(
+                "second_cache_dir", "project_2", "ui_2", use_static_cache=True
+            )
+        except (TypeError, FileNotFoundError):
+            pass
+
+        mock_static_local_cache.assert_called_once_with(
+            "second_cache_dir", "project_2", "ui_2"
+        )

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
@@ -1,0 +1,356 @@
+from unittest.mock import create_autospec
+
+import pytest
+
+from allensdk.brain_observatory.behavior.behavior_ophys_experiment import \
+    BehaviorOphysExperiment
+from allensdk.brain_observatory.behavior.behavior_session import \
+    BehaviorSession
+from .utils import create_bucket, load_dataset
+import boto3
+from moto import mock_s3
+import pathlib
+import json
+import semver
+
+from allensdk.api.cloud_cache.cloud_cache import MissingLocalManifestWarning
+from allensdk.api.cloud_cache.cloud_cache import OutdatedManifestWarning
+from allensdk.brain_observatory.\
+    behavior.behavior_project_cache.behavior_project_cache \
+    import VisualBehaviorOphysProjectCache
+
+
+@mock_s3
+def test_manifest_methods(tmpdir, vbo_s3_cloud_cache_data):
+
+    data, versions = vbo_s3_cloud_cache_data
+
+    cache_dir = pathlib.Path(tmpdir) / "test_manifest_list"
+    bucket_name = VisualBehaviorOphysProjectCache.BUCKET_NAME
+    project_name = VisualBehaviorOphysProjectCache.PROJECT_NAME
+    create_bucket(bucket_name,
+                  project_name,
+                  data['data'],
+                  data['metadata'])
+
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    v_names = [f'{project_name}_manifest_v{i}.json' for i in versions]
+    m_list = cache.list_manifest_file_names()
+
+    assert len(m_list) == 2
+    assert all([i in m_list for i in v_names])
+    cache.load_manifest(v_names[0])
+
+    # because the BehaviorProjectCloudApi automatically
+    # loads the latest manifest, so the latest manifest
+    # will always be the latest_downloaded_manifest
+    assert cache.latest_downloaded_manifest_file() == v_names[-1]
+    assert cache.latest_manifest_file() == v_names[-1]
+
+    change_msg = cache.compare_manifests(v_names[0], v_names[-1])
+
+    for mname in ('behavior_session_table',
+                  'ophys_session_table',
+                  'ophys_experiment_table'):
+        assert f'project_metadata/{mname} changed' in change_msg
+
+    assert 'ophys_file_1.nwb changed' in change_msg
+    assert 'ophys_file_5.nwb created' in change_msg
+    assert 'ophys_file_2.nwb' not in change_msg
+    assert 'behavior_file_3.nwb' not in change_msg
+    assert 'behavior_file_4.nwb' not in change_msg
+
+
+@mock_s3
+def test_local_cache_construction(
+    tmpdir,
+    vbo_s3_cloud_cache_data,
+    monkeypatch
+):
+
+    data, versions = vbo_s3_cloud_cache_data
+    cache_dir = pathlib.Path(tmpdir) / "test_construction"
+    bucket_name = VisualBehaviorOphysProjectCache.BUCKET_NAME
+    project_name = VisualBehaviorOphysProjectCache.PROJECT_NAME
+    create_bucket(bucket_name,
+                  project_name,
+                  data['data'],
+                  data['metadata'])
+
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    v_names = [f'{project_name}_manifest_v{i}.json' for i in versions]
+    cache.load_manifest(v_names[0])
+
+    with monkeypatch.context() as ctx:
+        ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
+                    lambda path: create_autospec(
+                        BehaviorOphysExperiment, instance=True))
+        cache.get_behavior_ophys_experiment(ophys_experiment_id=5111)
+    assert cache.fetch_api.cache._downloaded_data_path.is_file()
+    cache.fetch_api.cache._downloaded_data_path.unlink()
+    assert not cache.fetch_api.cache._downloaded_data_path.is_file()
+    del cache
+
+    with pytest.warns(MissingLocalManifestWarning) as warnings:
+        cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    cmd = 'VisualBehaviorOphysProjectCache.construct_local_manifest()'
+    assert cmd in f'{warnings[0].message}'
+
+    # Because, at the point where the cache was reconstitute,
+    # the metadata files already existed at their expected local paths,
+    # the file at _downloaded_data_path file will not have been created
+    manifest_path = cache.fetch_api.cache._downloaded_data_path
+    assert not manifest_path.exists()
+
+    cache.construct_local_manifest()
+    assert cache.fetch_api.cache._downloaded_data_path.is_file()
+
+    with open(manifest_path, 'rb') as in_file:
+        local_manifest = json.load(in_file)
+    fnames = set([pathlib.Path(k).name for k in local_manifest])
+    assert 'ophys_file_1.nwb' in fnames
+    assert len(local_manifest) == 9  # 8 metadata files and 1 data file
+
+
+@mock_s3
+def test_load_out_of_date_manifest(
+    tmpdir,
+    vbo_s3_cloud_cache_data,
+    monkeypatch
+):
+    """
+    Test that VisualBehaviorOphysProjectCache can load a
+    manifest other than the latest and download files
+    from that manifest.
+    """
+    data, versions = vbo_s3_cloud_cache_data
+
+    cache_dir = pathlib.Path(tmpdir) / "test_linkage"
+    bucket_name = VisualBehaviorOphysProjectCache.BUCKET_NAME
+    project_name = VisualBehaviorOphysProjectCache.PROJECT_NAME
+    create_bucket(bucket_name,
+                  project_name,
+                  data['data'],
+                  data['metadata'])
+
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    v_names = [f'{project_name}_manifest_v{i}.json' for i in versions]
+    cache.load_manifest(v_names[0])
+    for sess_id in (333, 444):
+        with monkeypatch.context() as ctx:
+            ctx.setattr(BehaviorSession, 'from_nwb_path',
+                        lambda path: create_autospec(
+                            BehaviorSession, instance=True))
+            cache.get_behavior_session(behavior_session_id=sess_id)
+    for exp_id in (5111, 5222):
+        with monkeypatch.context() as ctx:
+            ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
+                        lambda path: create_autospec(
+                            BehaviorOphysExperiment, instance=True))
+            cache.get_behavior_ophys_experiment(ophys_experiment_id=exp_id)
+
+    v1_dir = cache_dir / f'{project_name}-{versions[0]}/data'
+
+    # Check that all expected file were downloaded
+    dir_glob = v1_dir.glob('*')
+    file_names = set()
+    file_contents = {}
+    for p in dir_glob:
+        file_names.add(p.name)
+        with open(p, 'rb') as in_file:
+            data = in_file.read()
+        file_contents[p.name] = data
+    expected = {'ophys_file_1.nwb', 'ophys_file_2.nwb',
+                'behavior_file_3.nwb', 'behavior_file_4.nwb'}
+
+    assert file_names == expected
+
+    expected = {}
+    expected['ophys_file_1.nwb'] = b'abcde'
+    expected['ophys_file_2.nwb'] = b'fghijk'
+    expected['behavior_file_3.nwb'] = b'12345'
+    expected['behavior_file_4.nwb'] = b'67890'
+
+    assert file_contents == expected
+
+
+@mock_s3
+@pytest.mark.parametrize("delete_cache", [True, False])
+def test_file_linkage(
+    tmpdir,
+    vbo_s3_cloud_cache_data,
+    delete_cache,
+    monkeypatch
+):
+    """
+    Test that symlinks are used where appropriate
+
+    if delete_cache == True, will delete the local cache
+    file between loading v1 and v2 manifests, then run
+    construct_local_cache() to make sure that the symlinks
+    are still properly constructed
+    """
+    data, versions = vbo_s3_cloud_cache_data
+    cache_dir = pathlib.Path(tmpdir) / "test_linkage"
+    bucket_name = VisualBehaviorOphysProjectCache.BUCKET_NAME
+    project_name = VisualBehaviorOphysProjectCache.PROJECT_NAME
+    create_bucket(bucket_name,
+                  project_name,
+                  data['data'],
+                  data['metadata'])
+
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    v_names = [f'{project_name}_manifest_v{i}.json' for i in versions]
+    v_dirs = [cache_dir / f'{project_name}-{i}/data' for i in versions]
+
+    assert cache.current_manifest() == v_names[-1]
+    assert cache.list_all_downloaded_manifests() == [v_names[-1]]
+
+    cache.load_manifest(v_names[0])
+    assert cache.current_manifest() == v_names[0]
+    assert cache.list_all_downloaded_manifests() == v_names
+
+    for sess_id in (333, 444):
+        with monkeypatch.context() as ctx:
+            ctx.setattr(BehaviorSession, 'from_nwb_path',
+                        lambda path: create_autospec(
+                            BehaviorSession, instance=True))
+            cache.get_behavior_session(behavior_session_id=sess_id)
+    for exp_id in (5111, 5222):
+        with monkeypatch.context() as ctx:
+            ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
+                        lambda path: create_autospec(
+                            BehaviorOphysExperiment, instance=True))
+            cache.get_behavior_ophys_experiment(ophys_experiment_id=exp_id)
+
+    v1_glob = v_dirs[0].glob('*')
+    v1_paths = {}
+    for p in v1_glob:
+        v1_paths[p.name] = p
+
+    if delete_cache:
+        local_cache = cache.fetch_api.cache._downloaded_data_path
+        assert local_cache.is_file()
+        local_cache.unlink()
+        assert not local_cache.is_file()
+        del cache
+
+        cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+        cache.construct_local_manifest()
+
+    cache.load_manifest(v_names[-1])
+    assert cache.current_manifest() == v_names[-1]
+    for sess_id in (777, 888):
+        with monkeypatch.context() as ctx:
+            ctx.setattr(BehaviorSession, 'from_nwb_path',
+                        lambda path: create_autospec(
+                            BehaviorSession, instance=True))
+            cache.get_behavior_session(behavior_session_id=sess_id)
+    for exp_id in (5444, 5666, 5777):
+        with monkeypatch.context() as ctx:
+            ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
+                        lambda path: create_autospec(
+                            BehaviorOphysExperiment, instance=True))
+            cache.get_behavior_ophys_experiment(ophys_experiment_id=exp_id)
+
+    v2_glob = v_dirs[-1].glob('*')
+    v2_paths = {}
+    for p in v2_glob:
+        v2_paths[p.name] = p
+
+    # check symlinks
+    for name in ('ophys_file_2.nwb',
+                 'behavior_file_3.nwb',
+                 'behavior_file_4.nwb'):
+
+        assert v2_paths[name].is_symlink()
+        assert v2_paths[name].resolve() == v1_paths[name].resolve()
+        assert v2_paths[name].absolute() != v1_paths[name].absolute()
+
+    name = 'ophys_file_1.nwb'
+    assert not v2_paths[name].is_symlink()
+    assert not v2_paths[name].absolute() == v1_paths[name].absolute()
+
+    assert 'ophys_file_5.nwb' in v2_paths
+
+
+@mock_s3
+def test_when_data_updated(tmpdir, vbo_s3_cloud_cache_data, data_update):
+    """
+    Test that when a cache is instantiated after an update has
+    been loaded to the dataset, the correct warning is emitted
+    """
+    data, versions = vbo_s3_cloud_cache_data
+    cache_dir = pathlib.Path(tmpdir) / "test_update"
+    bucket_name = VisualBehaviorOphysProjectCache.BUCKET_NAME
+    project_name = VisualBehaviorOphysProjectCache.PROJECT_NAME
+    create_bucket(bucket_name,
+                  project_name,
+                  data['data'],
+                  data['metadata'])
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    del cache
+
+    client = boto3.client('s3', region_name='us-east-1')
+
+    later_version = str(semver.parse_version_info(versions[-1]).bump_minor())
+    load_dataset(data_update['data'],
+                 data_update['metadata'],
+                 later_version,
+                 bucket_name,
+                 project_name,
+                 client)
+
+    name3 = f'{project_name}_manifest_v{later_version}'
+    name2 = f'{project_name}_manifest_v{versions[-1]}'
+
+    cmd = 'VisualBehaviorOphysProjectCache.load_manifest'
+    with pytest.warns(OutdatedManifestWarning, match=name3) as warnings:
+        VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    checked_msg = False
+    for w in warnings.list:
+        if w._category_name == 'OutdatedManifestWarning':
+            msg = str(w.message)
+            assert name3 in msg
+            assert name2 in msg
+            assert cmd in msg
+            checked_msg = True
+    assert checked_msg
+
+
+@mock_s3
+def test_load_last(tmpdir, vbo_s3_cloud_cache_data, data_update):
+    """
+    Test that, when a cache is instantiated over an old
+    cache_dir, it loads the most recently loaded manifest,
+    not the most up to date manifest
+    """
+    data, versions = vbo_s3_cloud_cache_data
+    cache_dir = pathlib.Path(tmpdir) / "test_update"
+    bucket_name = VisualBehaviorOphysProjectCache.BUCKET_NAME
+    project_name = VisualBehaviorOphysProjectCache.PROJECT_NAME
+    create_bucket(bucket_name,
+                  project_name,
+                  data['data'],
+                  data['metadata'])
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    v_names = [f'{project_name}_manifest_v{i}.json' for i in versions]
+
+    assert cache.current_manifest() == v_names[-1]
+    cache.load_manifest(v_names[0])
+    assert cache.current_manifest() == v_names[0]
+    del cache
+
+    msg = 'VisualBehaviorOphysProjectCache.compare_manifests'
+    with pytest.warns(OutdatedManifestWarning, match=msg):
+        cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
+
+    assert cache.current_manifest() == v_names[0]


### PR DESCRIPTION
**Problem:**
Addressing issue [#30](https://github.com/AllenInstitute/ecephys_etl_pipelines/issues/30)

**Solution:**
Create  `VisualBehaviorEcephysProjectCache` project class and corresponding `BehaviorEcephysProjectCloudApi `
Unlike for the VBO, we do not provide a LIMS api, only cloud api. 

**Validation:**
This works for me:
```python
    cache_dir='/home/sergeyg/Projects/visbeh/mycache'

    VisualBehaviorNeuropixelsProjectCache.BUCKET_NAME = 'sfd-cloudcache-test-bucket'
    VisualBehaviorNeuropixelsProjectCache.PROJECT_NAME = 'visual-behavior-neuropixels-2022'

    cache = VisualBehaviorNeuropixelsProjectCache.from_s3_cache(
        cache_dir,
        )
    manifest_list = cache.list_all_downloaded_manifests()

    behavior_session_table = cache.get_behavior_session_table()
    ecephys_session_table = cache.get_ecephys_session_table()
    vbn_session = cache.get_ecephys_session(ecephys_session_id=1056495334)
    behavior_session = cache.get_behavior_session(behavior_session_id=1038268488)

```

**Note:**
there is some code duplication in `BehaviorEcephysProjectCloudApi` relative to `BehaviorProjectCloudApi(BehaviorProjectBase)`
We may think about how to refactor some of it to eliminate duplicate code