### PR TITLE
Ticket/2433/vbo/bug

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
@@ -136,6 +136,9 @@ class Presentations(DataObject, StimulusFileReadableInterface,
             {c: 'int64' for c in table.select_dtypes(include='int')})
         table = table.sort_values(by=["start_time"])
 
+        table = table.reset_index(drop=True)
+        table.index = table.index.astype('int64')
+
         if add_is_change:
             table['is_change'] = is_change_event(stimulus_presentations=table)
         return Presentations(presentations=table, column_list=column_list)

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_cache.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_cache.py
@@ -1,0 +1,29 @@
+import pytest
+import pandas as pd
+from allensdk.brain_observatory.behavior.behavior_project_cache\
+    .behavior_project_cache import \
+        VisualBehaviorOphysProjectCache
+
+
+@pytest.mark.requires_bamboo
+def test_session_from_vbo_cache():
+    """
+    Test that a behavior-only session and a behavior-ophys experiment
+    can be loaded from a small VBO cache that was saved on-prem.
+
+    This test will catch any changes we make to the code that break
+    backwards compatibility with the VBO data release
+
+    This is really just a smoke test
+    """
+    cache_dir = '/allen/aibs/informatics/module_test_data/vbo_cache'
+
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir=cache_dir)
+    session = cache.get_behavior_session(behavior_session_id=870987812)
+    experiment = cache.get_behavior_ophys_experiment(
+                    ophys_experiment_id=951980471)
+
+    assert isinstance(cache.get_behavior_session_table(), pd.DataFrame)
+    assert isinstance(cache.get_ophys_session_table(), pd.DataFrame)
+    assert isinstance(cache.get_ophys_experiment_table(), pd.DataFrame)
+    assert isinstance(cache.get_ophys_cells_table(), pd.DataFrame)

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_cache.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_cache.py
@@ -1,8 +1,14 @@
 import pytest
-import pandas as pd
-from allensdk.brain_observatory.behavior.behavior_project_cache\
-    .behavior_project_cache import \
-        VisualBehaviorOphysProjectCache
+import pathlib
+
+from allensdk.brain_observatory.behavior.behavior_project_cache \
+    .behavior_project_cache import (
+        VisualBehaviorOphysProjectCache)
+
+from allensdk.brain_observatory.behavior.behavior_session import (
+    BehaviorSession)
+from allensdk.brain_observatory.behavior.behavior_ophys_experiment import (
+    BehaviorOphysExperiment)
 
 
 @pytest.mark.requires_bamboo
@@ -16,14 +22,21 @@ def test_session_from_vbo_cache():
 
     This is really just a smoke test
     """
-    cache_dir = '/allen/aibs/informatics/module_test_data/vbo_cache'
+    cache_dir = pathlib.Path('/allen/aibs/informatics/'
+                             'module_test_data/vbo_cache/'
+                             'visual-behavior-ophys-1.0.1')
 
-    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir=cache_dir)
-    session = cache.get_behavior_session(behavior_session_id=870987812)
-    experiment = cache.get_behavior_ophys_experiment(
-                    ophys_experiment_id=951980471)
+    ophys_dir = cache_dir / 'behavior_ophys_experiments'
+    beh_dir = cache_dir / 'behavior_sessions'
 
-    assert isinstance(cache.get_behavior_session_table(), pd.DataFrame)
-    assert isinstance(cache.get_ophys_session_table(), pd.DataFrame)
-    assert isinstance(cache.get_ophys_experiment_table(), pd.DataFrame)
-    assert isinstance(cache.get_ophys_cells_table(), pd.DataFrame)
+    BehaviorSession.from_nwb_path(
+            nwb_path=beh_dir / 'behavior_session_870987812.nwb')
+    BehaviorOphysExperiment.from_nwb_path(
+            nwb_path=ophys_dir / 'behavior_ophys_experiment_948507789.nwb')
+
+    # these values are baked-in by the choice we made when releasing the
+    # VBO 2021 dataset
+    assert (VisualBehaviorOphysProjectCache.BUCKET_NAME
+            == 'visual-behavior-ophys-data')
+    assert (VisualBehaviorOphysProjectCache.PROJECT_NAME
+            == 'visual-behavior-ophys')

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
@@ -77,8 +77,9 @@ class TestPresentations:
         ts.to_nwb(nwbfile=self._nwbfile)
 
     @pytest.mark.requires_bamboo
-    @pytest.mark.parametrize('roundtrip', [True, False])
-    def test_read_write_nwb(self, roundtrip,
+    @pytest.mark.parametrize('roundtrip, add_is_change',
+                             ([True, False], [True, False]))
+    def test_read_write_nwb(self, roundtrip, add_is_change,
                             data_object_roundtrip_fixture):
         self._table_from_json.to_nwb(nwbfile=self._nwbfile)
 
@@ -86,11 +87,11 @@ class TestPresentations:
             obt = data_object_roundtrip_fixture(
                 nwbfile=self._nwbfile,
                 data_object_cls=Presentations,
-                add_is_change=False
+                add_is_change=add_is_change
             )
         else:
             obt = Presentations.from_nwb(nwbfile=self._nwbfile,
-                                         add_is_change=False)
+                                         add_is_change=add_is_change)
 
         assert obt == self._table_from_json
 


### PR DESCRIPTION
Some of the work we did in support of VBN broke the code to load a VBO behavior session. This PR fixes that bug and adds a smoke test which loads some data from a VBO cache that I saved on-prem so that we can detect failures like this in the future.
