### PR TITLE
Ticket/2416/date/of/acq

### DIFF
--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/dataframe_manipulations.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/dataframe_manipulations.py
@@ -281,8 +281,6 @@ def _patch_date_and_stage_from_pickle_file(
                     behavior_df.session_type.isna()))
     ].behavior_session_id.values
 
-    assert len(invalid_beh) == len(np.unique(invalid_beh))
-
     if len(invalid_beh) > 0:
         pickle_path_df = stimulus_pickle_paths_from_behavior_session_ids(
                             lims_connection=lims_connection,

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/lims_queries.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/lims_queries.py
@@ -702,7 +702,10 @@ def _behavior_session_table_from_ecephys_session_id_list(
 
     behavior_session_df = _patch_date_and_stage_from_pickle_file(
                              lims_connection=lims_connection,
-                             behavior_df=behavior_session_df)
+                             behavior_df=behavior_session_df,
+                             flag_columns=['date_of_acquisition',
+                                           'foraging_id',
+                                           'session_type'])
 
     if exclude_sessions_after_death_date:
         # filter out any sessions which were mistakenly entered that fall

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/conftest.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/conftest.py
@@ -57,6 +57,19 @@ def patching_pickle_file_fixture(
                     'date_of_acquisition': this_date,
                     'session_type': this_stage}
 
+    this_date = datetime.datetime(year=1974, month=7, day=22)
+    this_stage = 'third_stage'
+    pkl_data = {'start_time': this_date,
+                'items':
+                {'behavior':
+                 {'params': {'stage': this_stage}}}}
+    pkl_path = pathlib.Path(
+                    tempfile.mkstemp(dir=tmp_dir, suffix='.pkl')[1])
+    pd.to_pickle(pkl_data, pkl_path)
+    output[2134] = {'pkl_path': pkl_path,
+                    'date_of_acquisition': this_date,
+                    'session_type': this_stage}
+
     yield output
 
     helper_functions.windows_safe_cleanup_dir(

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_dataframe_manipulations.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_dataframe_manipulations.py
@@ -277,7 +277,6 @@ def test_patch_date_and_stage_from_pickle_file(
                                   expected)
 
 
-
 def test_patch_date_and_stage_from_pickle_file_error():
     """
     Make sure that an error gets raised when you give

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_dataframe_manipulations.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_dataframe_manipulations.py
@@ -265,12 +265,13 @@ def test_patch_date_and_stage_from_pickle_file(
         cols_to_fix = ['date_of_acquisition', 'session_type']
 
     expected_data = copy.deepcopy(input_data)
-    for idx, bid in enumerate((1123, 5813, 2134)):
+    for element in expected_data:
+        bid = element['behavior_session_id']
         if bid not in ids_to_fix:
             continue
         for col in cols_to_fix:
             this_s = patching_pickle_file_fixture[bid][col]
-            expected_data[idx+1][col] = this_s
+            element[col] = this_s
 
     expected = pd.DataFrame(data=expected_data)
     pd.testing.assert_frame_equal(actual,


### PR DESCRIPTION
This PR fixes the input JSON generation code for VBN to get date_of_acquisition from the pickle file, rather than from the LIMs database. With this change, we should not need to change the VBN NWB generation code, since we will be writing the correct date_of_acquisition to the input JSON. Below is some data showing the result of this PR. For each session

`csv` points to the date_of_acquisition recorded in the metadata table (which we already were reading from the pickle file)
 
`old` points to the date_of_acquisition recorded in input JSONs generated before this PR

`new` points to the date_of_acquisition recorded in input JSONs generated by the code in this PR

The fact that `csv` and `new` are identical and differ from `old` indicates that we are getting the right date (or, at least, a self-consistent date).

```
session 1055221968 -- csv 2020-10-07 14:01:41.373 -- old 2020-10-07 21:01:14 -- new 2020-10-07 14:01:41.373000
session 1055240613 -- csv 2020-10-07 14:53:34.486 -- old 2020-10-07 21:53:05 -- new 2020-10-07 14:53:34.486000
session 1120251466 -- csv 2021-08-05 13:50:07.381 -- old 2021-08-05 20:49:41 -- new 2021-08-05 13:50:07.381000
session 1122903357 -- csv 2021-08-18 13:33:50.720 -- old 2021-08-18 20:33:23 -- new 2021-08-18 13:33:50.720000
```
