### PR TITLE
Ticket/2432/rename/local index

### DIFF
--- a/allensdk/brain_observatory/ecephys/_channel.py
+++ b/allensdk/brain_observatory/ecephys/_channel.py
@@ -11,7 +11,7 @@ class Channel(DataObject):
             id: int,
             probe_id: int,
             valid_data: bool,
-            local_index: int,
+            probe_channel_number: int,
             probe_vertical_position: int,
             probe_horizontal_position: int,
             manual_structure_acronym: str = '',
@@ -36,7 +36,7 @@ class Channel(DataObject):
         self._id = id
         self._probe_id = probe_id
         self._valid_data = valid_data
-        self._local_index = local_index
+        self._probe_channel_number = probe_channel_number
         self._probe_vertical_position = probe_vertical_position
         self._probe_horizontal_position = probe_horizontal_position
         self._manual_structure_acronym = manual_structure_acronym
@@ -61,8 +61,8 @@ class Channel(DataObject):
         return self._valid_data
 
     @property
-    def local_index(self) -> int:
-        return self._local_index
+    def probe_channel_number(self) -> int:
+        return self._probe_channel_number
 
     @property
     def probe_vertical_position(self) -> int:

--- a/allensdk/brain_observatory/ecephys/_channels.py
+++ b/allensdk/brain_observatory/ecephys/_channels.py
@@ -30,7 +30,7 @@ class Channels(DataObject, NwbReadableInterface, JsonReadableInterface):
             id=channel['id'],
             probe_id=channel['probe_id'],
             valid_data=channel['valid_data'],
-            local_index=channel['local_index'],
+            probe_channel_number=channel['probe_channel_number'],
             probe_vertical_position=channel['probe_vertical_position'],
             probe_horizontal_position=channel['probe_horizontal_position'],
             manual_structure_acronym=channel['manual_structure_acronym'],
@@ -91,11 +91,28 @@ class Channels(DataObject, NwbReadableInterface, JsonReadableInterface):
             if probe_id is not None:
                 if row['probe_id'] != probe_id:
                     continue
+
+            has_local_index = ('local_index' in row.keys())
+            has_channel_number = ('probe_channel_number' in row.keys())
+            if has_local_index and has_channel_number:
+                raise RuntimeError("Unclear how to read channel; "
+                                   "has both 'local_index' and "
+                                   "'probe_channel_number'")
+            elif has_local_index:
+                idx_col = 'local_index'
+            elif has_channel_number:
+                idx_col = 'probe_channel_number'
+            else:
+                raise RuntimeError("Unclear how to read channel; "
+                                   "has neither 'local_index' nor "
+                                   "'probe_channel_number'.\n"
+                                   f"Columns are {row.keys()}")
+
             manual_structure_acronym = \
                 np.nan if row['location'] in ['None', ''] else row['location']
             channels.append(Channel(
                 id=channel_id,
-                local_index=row['local_index'],
+                probe_channel_number=row[idx_col],
                 probe_horizontal_position=row['probe_horizontal_position'],
                 probe_vertical_position=row['probe_vertical_position'],
                 probe_id=row['probe_id'],

--- a/allensdk/brain_observatory/ecephys/_channels.py
+++ b/allensdk/brain_observatory/ecephys/_channels.py
@@ -92,6 +92,10 @@ class Channels(DataObject, NwbReadableInterface, JsonReadableInterface):
                 if row['probe_id'] != probe_id:
                     continue
 
+            # this block of code is necessary to maintain
+            # backwards compatibility with Visual Coding Neuropixels
+            # NWB files, which used 'local_index' to mean what we
+            # now mean by 'probe_channel_number'
             has_local_index = ('local_index' in row.keys())
             has_channel_number = ('probe_channel_number' in row.keys())
             if has_local_index and has_channel_number:

--- a/allensdk/brain_observatory/ecephys/nwb_util.py
+++ b/allensdk/brain_observatory/ecephys/nwb_util.py
@@ -103,10 +103,11 @@ def add_probe_to_nwbfile(nwbfile, probe_id, sampling_rate, lfp_sampling_rate,
     return nwbfile, probe_nwb_device, probe_nwb_electrode_group
 
 
-def add_ecephys_electrodes(nwbfile: pynwb.NWBFile,
-                           channels: List[dict],
-                           electrode_group: EcephysElectrodeGroup,
-                           local_index_whitelist: Optional[np.ndarray] = None):
+def add_ecephys_electrodes(
+       nwbfile: pynwb.NWBFile,
+       channels: List[dict],
+       electrode_group: EcephysElectrodeGroup,
+       channel_number_whitelist: Optional[np.ndarray] = None):
     """Add electrode information to an ecephys nwbfile electrode table.
 
     Parameters
@@ -139,7 +140,7 @@ def add_ecephys_electrodes(nwbfile: pynwb.NWBFile,
 
     electrode_group : EcephysElectrodeGroup
         The pynwb electrode group that electrodes should be associated with
-    local_index_whitelist : Optional[np.ndarray], optional
+    channel_number_whitelist : Optional[np.ndarray], optional
         If provided, only add electrodes (a.k.a. channels) specified by the
         whitelist (and in order specified), by default None
     """
@@ -147,9 +148,9 @@ def add_ecephys_electrodes(nwbfile: pynwb.NWBFile,
 
     channel_table = pd.DataFrame(channels)
 
-    if local_index_whitelist is not None:
-        channel_table.set_index("local_index", inplace=True)
-        channel_table = channel_table.loc[local_index_whitelist, :]
+    if channel_number_whitelist is not None:
+        channel_table.set_index("probe_channel_number", inplace=True)
+        channel_table = channel_table.loc[channel_number_whitelist, :]
         channel_table.reset_index(inplace=True)
 
     for _, row in channel_table.iterrows():
@@ -164,7 +165,7 @@ def add_ecephys_electrodes(nwbfile: pynwb.NWBFile,
             z=(np.nan if z is None else z),
             probe_vertical_position=row["probe_vertical_position"],
             probe_horizontal_position=row["probe_horizontal_position"],
-            local_index=row["local_index"],
+            probe_channel_number=row["probe_channel_number"],
             valid_data=row["valid_data"],
             probe_id=row["probe_id"],
             group=electrode_group,
@@ -194,7 +195,8 @@ def _add_ecephys_electrode_columns(nwbfile: pynwb.NWBFile,
         ("probe_horizontal_position",
          "Width-wise position of electrode/channel on device (microns)"),
         ("probe_id", "The unique id of this electrode's/channel's device"),
-        ("local_index", "The local index of electrode/channel on device"),
+        ("probe_channel_number",
+         "The local index of electrode/channel on device"),
         ("valid_data", "Whether data from this electrode/channel is usable")
     ]
 

--- a/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/__main__.py
@@ -289,7 +289,7 @@ def write_probe_lfp_file(session_id, session_metadata, session_start_time,
 
     add_ecephys_electrodes(nwbfile, probe["channels"],
                            probe_nwb_electrode_group,
-                           local_index_whitelist=lfp_channels)
+                           channel_number_whitelist=lfp_channels)
 
     electrode_table_region = nwbfile.create_electrode_table_region(
         region=np.arange(len(nwbfile.electrodes)).tolist(),  # use raw inds

--- a/allensdk/brain_observatory/ecephys/write_nwb/schemas.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/schemas.py
@@ -35,7 +35,7 @@ class Channel(RaisingSchema):
     id = Int(required=True)
     probe_id = Int(required=True)
     valid_data = Boolean(required=True)
-    local_index = Int(required=True)
+    probe_channel_number = Int(required=True)
     probe_vertical_position = Int(required=True)
     probe_horizontal_position = Int(required=True)
     manual_structure_id = Int(required=True, allow_none=True)

--- a/allensdk/brain_observatory/vbn_2022/input_json_writer/utils.py
+++ b/allensdk/brain_observatory/vbn_2022/input_json_writer/utils.py
@@ -556,7 +556,7 @@ def channel_input_from_ecephys_session_id(
     raw_channels_table = raw_channels_table[[
                               'id',
                               'probe_id',
-                              'local_index',
+                              'probe_channel_number',
                               'manual_structure_id',
                               'manual_structure_acronym',
                               'anterior_posterior_ccf_coordinate',

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/lims_queries.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/lims_queries.py
@@ -333,7 +333,7 @@ def channels_table_from_ecephys_session_id_list(
         ecephys_channel_id -- int64
         ecephys_probe_id -- int64
         ecephys_session_id -- int64
-        local_index -- int64
+        probe_channel_number -- int64
         probe_vertical_position -- float64
         probe_horizontal_position -- float64
         anterior_posterior_ccf_coordinate -- float64
@@ -350,7 +350,7 @@ def channels_table_from_ecephys_session_id_list(
        ecephys_channels.id as ecephys_channel_id
       ,ecephys_channels.ecephys_probe_id
       ,ecephys_sessions.id AS ecephys_session_id
-      ,ecephys_channels.local_index
+      ,ecephys_channels.local_index as probe_channel_number
       ,ecephys_channels.probe_vertical_position
       ,ecephys_channels.probe_horizontal_position
       ,ecephys_channels.anterior_posterior_ccf_coordinate

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
@@ -114,6 +114,10 @@ class VBN2022MetadataWriterClass(argschema.ArgSchemaParser):
                     axis='columns',
                     inplace=True)
 
+        channels_table.rename(
+            columns={'local_index': 'probe_channel_number'},
+            inplace=True)
+
         channels_table.to_csv(self.args['channels_path'], index=False)
 
         (session_table,

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
@@ -114,10 +114,6 @@ class VBN2022MetadataWriterClass(argschema.ArgSchemaParser):
                     axis='columns',
                     inplace=True)
 
-        channels_table.rename(
-            columns={'local_index': 'probe_channel_number'},
-            inplace=True)
-
         channels_table.to_csv(self.args['channels_path'], index=False)
 
         (session_table,

--- a/allensdk/test/brain_observatory/behavior/data_objects/stimulus_timestamps/test_stimulus_timestamps.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/stimulus_timestamps/test_stimulus_timestamps.py
@@ -262,7 +262,7 @@ class TestStimulusTimestampsFromMultipleStimulusBlocks:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
         input_data = input_data['session_data']

--- a/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/test_stimuli.py
@@ -56,7 +56,7 @@ class TestPresentations:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             cls.input_data = json.load(f)['session_data']
         cls._table_from_json = Presentations.from_path(
@@ -177,7 +177,7 @@ class TestTemplates:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             cls.input_data = json.load(f)['session_data']
         sf = BehaviorStimulusFile.from_json(

--- a/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_metadata.py
+++ b/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_metadata.py
@@ -12,7 +12,7 @@ class TestBehaviorEcephysMetadata:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
         input_data = input_data['session_data']

--- a/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
+++ b/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
@@ -10,7 +10,7 @@ class TestBehaviorEcephysSession:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
 

--- a/allensdk/test/brain_observatory/ecephys/test_optotagging_table.py
+++ b/allensdk/test/brain_observatory/ecephys/test_optotagging_table.py
@@ -11,7 +11,7 @@ class TestOptotaggingTable:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
         cls._table_from_json = OptotaggingTable.from_json(

--- a/allensdk/test/brain_observatory/ecephys/test_probes.py
+++ b/allensdk/test/brain_observatory/ecephys/test_probes.py
@@ -84,7 +84,7 @@ def test_probe_channels_strip_subregion(
     """Tests that subregion is stripped from manual structure acronym"""
     c = Channel(
         id=1,
-        local_index=1,
+        probe_channel_number=1,
         probe_vertical_position=1,
         probe_horizontal_position=1,
         probe_id=1,

--- a/allensdk/test/brain_observatory/ecephys/test_probes.py
+++ b/allensdk/test/brain_observatory/ecephys/test_probes.py
@@ -14,7 +14,7 @@ class TestProbes:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
 

--- a/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
+++ b/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
@@ -284,7 +284,8 @@ def test_add_probe_to_nwbfile(
     (None,
 
      {"probe_vertical_position", "probe_horizontal_position",
-      "probe_id", "local_index", "valid_data", "x", "y", "z", "group",
+      "probe_id", "probe_channel_number", "valid_data",
+      "x", "y", "z", "group",
       "group_name", "imp", "location", "filtering"}),
 
     ([("test_column_a", "description_a"),
@@ -301,12 +302,12 @@ def test_add_ecephys_electrode_columns(nwbfile, columns_to_add,
     assert set(nwbfile.electrodes.colnames) == expected_columns
 
 
-@pytest.mark.parametrize(("channels, local_index_whitelist, "
+@pytest.mark.parametrize(("channels, channel_number_whitelist, "
                           "expected_electrode_table"), [
                              ([{"id": 1,
                                 "probe_id": 1234,
                                 "valid_data": True,
-                                "local_index": 23,
+                                "probe_channel_number": 23,
                                 "probe_vertical_position": 10,
                                 "probe_horizontal_position": 10,
                                 "anterior_posterior_ccf_coordinate": 15.0,
@@ -319,7 +320,7 @@ def test_add_ecephys_electrode_columns(nwbfile, columns_to_add,
                                {"id": 2,
                                 "probe_id": 1234,
                                 "valid_data": True,
-                                "local_index": 15,
+                                "probe_channel_number": 15,
                                 "probe_vertical_position": 20,
                                 "probe_horizontal_position": 20,
                                 "anterior_posterior_ccf_coordinate": 25.0,
@@ -335,7 +336,7 @@ def test_add_ecephys_electrode_columns(nwbfile, columns_to_add,
                                   "id": [2, 1],
                                   "probe_id": [1234, 1234],
                                   "valid_data": [True, True],
-                                  "local_index": [15, 23],
+                                  "probe_channel_number": [15, 23],
                                   "probe_vertical_position": [20, 10],
                                   "probe_horizontal_position": [20, 10],
                                   "x": [25.0, 15.0],
@@ -349,7 +350,7 @@ def test_add_ecephys_electrode_columns(nwbfile, columns_to_add,
                               }).set_index("id"))
 
                          ])
-def test_add_ecephys_electrodes(nwbfile, channels, local_index_whitelist,
+def test_add_ecephys_electrodes(nwbfile, channels, channel_number_whitelist,
                                 expected_electrode_table):
     mock_device = pynwb.device.Device(name="mock_device")
     mock_electrode_group = pynwb.ecephys.ElectrodeGroup(name="mock_group",
@@ -361,7 +362,7 @@ def test_add_ecephys_electrodes(nwbfile, channels, local_index_whitelist,
         nwbfile,
         channels,
         mock_electrode_group,
-        local_index_whitelist)
+        channel_number_whitelist)
 
     obt_electrode_table = \
         nwbfile.electrodes.to_dataframe().drop(columns=["group", "group_name"])
@@ -591,7 +592,7 @@ def probe_data():
             {
                 "id": 0,
                 "probe_id": 12,
-                "local_index": 1,
+                "probe_channel_number": 1,
                 "probe_vertical_position": 21,
                 "probe_horizontal_position": 33,
                 "valid_data": True,
@@ -605,7 +606,7 @@ def probe_data():
             {
                 "id": 1,
                 "probe_id": 12,
-                "local_index": 2,
+                "probe_channel_number": 2,
                 "probe_vertical_position": 21,
                 "probe_horizontal_position": 32,
                 "valid_data": True,
@@ -619,7 +620,7 @@ def probe_data():
             {
                 "id": 2,
                 "probe_id": 12,
-                "local_index": 3,
+                "probe_channel_number": 3,
                 "probe_vertical_position": 21,
                 "probe_horizontal_position": 31,
                 "valid_data": True,
@@ -725,7 +726,8 @@ def test_write_probe_lfp_file(tmpdir_factory, lfp_data, probe_data, csd_data):
         obt_electrodes_df = obt_f.electrodes.to_dataframe()
 
         obt_electrodes = obt_electrodes_df.loc[
-                         :, ["local_index", "probe_horizontal_position",
+                         :, ["probe_channel_number",
+                             "probe_horizontal_position",
                              "probe_id", "probe_vertical_position",
                              "valid_data", "x", "y", "z", "location", "imp",
                              "filtering"]
@@ -1077,7 +1079,7 @@ def test_filter_and_sort_spikes(
        "channels": [{"id": 1,
                      "probe_id": 1234,
                      "valid_data": True,
-                     "local_index": 0,
+                     "probe_channel_number": 0,
                      "probe_vertical_position": 10,
                      "probe_horizontal_position": 10,
                      "anterior_posterior_ccf_coordinate": 15.0,
@@ -1089,7 +1091,7 @@ def test_filter_and_sort_spikes(
                     {"id": 2,
                      "probe_id": 1234,
                      "valid_data": True,
-                     "local_index": 1,
+                     "probe_channel_number": 1,
                      "probe_vertical_position": 20,
                      "probe_horizontal_position": 20,
                      "anterior_posterior_ccf_coordinate": 25.0,

--- a/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
+++ b/allensdk/test/brain_observatory/nwb/test_nwb_utils.py
@@ -42,7 +42,7 @@ class TestNwbWriter:
     @classmethod
     def setup_class(cls):
         with open('/allen/aibs/informatics/module_test_data/ecephys/'
-                  'BEHAVIOR_ECEPHYS_WRITE_NWB_QUEUE_1111216934_input.json') \
+                  'ecephys_session_1111216934_input.json') \
                 as f:
             input_data = json.load(f)
         cls.session_data = input_data['session_data']

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/resources/column_lookup.json
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/resources/column_lookup.json
@@ -71,7 +71,7 @@
     "ecephys_session_id",
     "ecephys_structure_acronym",
     "left_right_ccf_coordinate",
-    "local_index",
+    "probe_channel_number",
     "probe_horizontal_position",
     "probe_vertical_position",
     "unit_count",


### PR DESCRIPTION
This PR renames channel.local_index -> channel.probe_channel_number as requested.

I went ahead and made the name change every where that channel.local_index occurs in the code. This required adding an if/else block to check if an NWB file was published with channel.local_index (as in the case of the Visual Coding Neuropixels release), in which case local_index is mapped to the column probe_channel_number in the channels dataframe


I ran this code to verify that we can still download and open NWB files from the Visual Coding Neuropixels release

```
from allensdk.brain_observatory.ecephys.ecephys_project_cache import (
    EcephysProjectCache)
import os
import hashlib
manifest_path = '/allen/aibs/informatics/danielsf/scratch/warehouse/ecephys_manifest.json'
if os.path.exists(manifest_path):
    os.unlink(manifest_path)

cache = EcephysProjectCache.from_warehouse(manifest=manifest_path)

session_table = cache.get_session_table()
print('got session csv')

probes = cache.get_probes()
print('got probes csv')

channels = cache.get_channels()
print('got channels csv')

units = cache.get_units()
print('got units csv')

session = cache.get_session_data(session_id=719161530)
print('units')
print(session.units)

print('channels')
print(session.channels)
print(session.channels.columns)
```

The final line of the output, listing the columns in the channels dataframe, looks like

```
Index(['filtering', 'manual_structure_acronym', 'probe_channel_number',
       'probe_horizontal_position', 'probe_id', 'probe_vertical_position',
       'ecephys_structure_id', 'ecephys_structure_acronym',
       'anterior_posterior_ccf_coordinate', 'dorsal_ventral_ccf_coordinate',
       'left_right_ccf_coordinate'],
      dtype='object')
```

Note that probe_channel_number is present; local_index is not.