### PR TITLE
Ticket/2450/supplemental/columns

### DIFF
--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
@@ -167,10 +167,10 @@ class VBN2022MetadataWriterClass(argschema.ArgSchemaParser):
 
         # add supplemental columns to the ecephys_sessions
         # column
-        if self.args['supplemental_columns'] is not None:
-            self.logger.info("Adding supplemental columns")
+        if self.args['supplemental_data'] is not None:
+            self.logger.info("Adding supplemental data")
             supplemental_df = pd.DataFrame(
-                    data=self.args['supplemental_columns'])
+                    data=self.args['supplemental_data'])
 
             columns_to_patch = []
             for column_name in supplemental_df.columns:

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
@@ -5,6 +5,9 @@ import pandas as pd
 
 import allensdk
 
+from allensdk.core.dataframe_utils import (
+    patch_df_from_other)
+
 from allensdk.brain_observatory.vbn_2022.metadata_writer.schemas import (
     VBN2022MetadataWriterInputSchema,
     DataReleaseToolsInputSchema)
@@ -143,7 +146,7 @@ class VBN2022MetadataWriterClass(argschema.ArgSchemaParser):
             df=channels_table,
             output_path=self.args['channels_path'])
 
-        (session_table,
+        (ecephys_session_table,
          behavior_session_table) = session_tables_from_ecephys_session_id_list(
                     lims_connection=lims_connection,
                     mtrain_connection=mtrain_connection,
@@ -154,16 +157,35 @@ class VBN2022MetadataWriterClass(argschema.ArgSchemaParser):
         ecephys_nwb_dir = pathlib.Path(
                                 self.args['ecephys_nwb_dir'])
 
-        session_table = add_file_paths_to_metadata_table(
-                    metadata_table=session_table,
+        ecephys_session_table = add_file_paths_to_metadata_table(
+                    metadata_table=ecephys_session_table,
                     id_generator=file_id_generator,
                     file_dir=ecephys_nwb_dir,
                     file_prefix=self.args['ecephys_nwb_prefix'],
                     index_col='ecephys_session_id',
                     on_missing_file=self.args['on_missing_file'])
 
+        # add supplemental columns to the ecephys_sessions
+        # column
+        if self.args['supplemental_columns'] is not None:
+            self.logger.info("Adding supplemental columns")
+            supplemental_df = pd.DataFrame(
+                    data=self.args['supplemental_columns'])
+
+            columns_to_patch = []
+            for column_name in supplemental_df.columns:
+                if column_name == 'ecephys_session_id':
+                    continue
+                columns_to_patch.append(column_name)
+
+            ecephys_session_table = patch_df_from_other(
+                    target_df=ecephys_session_table,
+                    source_df=supplemental_df,
+                    columns_to_patch=columns_to_patch,
+                    index_column='ecephys_session_id')
+
         self.write_df(
-            df=session_table,
+            df=ecephys_session_table,
             output_path=self.args['ecephys_sessions_path'])
 
         self.write_df(

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/schemas.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/schemas.py
@@ -47,6 +47,18 @@ class VBN2022MetadataWriterInputSchema(argschema.ArgSchema):
           "{ecephys_nwb_dir}/{ecephys_nwb_prefix}_{ecephys_session_id}.nwb")
     )
 
+    supplemental_columns = argschema.fields.List(
+            argschema.fields.Dict,
+            default=None,
+            allow_none=True,
+            description=(
+                "List of dicts definining any supplemental columns "
+                "that need to be added to the ecephys_sessions.csv "
+                "table. Each dict should represent a row in a dataframe "
+                "that will get merged on ecephys_session_id with "
+                "the ecephys_sessions table (row must therefore contain "
+                "ecephys_session_id)"))
+
     on_missing_file = argschema.fields.Str(
             default='error',
             required=False,

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/schemas.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/schemas.py
@@ -47,7 +47,7 @@ class VBN2022MetadataWriterInputSchema(argschema.ArgSchema):
           "{ecephys_nwb_dir}/{ecephys_nwb_prefix}_{ecephys_session_id}.nwb")
     )
 
-    supplemental_columns = argschema.fields.List(
+    supplemental_data = argschema.fields.List(
             argschema.fields.Dict,
             default=None,
             allow_none=True,

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/conftest.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/conftest.py
@@ -11,8 +11,8 @@ def smoketest_config_fixture():
     config parameters for on-prem metadata writer smoketest
     """
     config = {
-      "ecephys_session_id_list": [1115077618, 1081429294, 1123100019],
-      "probes_to_skip": [{"session": 1123100019, "probe": "probeC"}]
+      "ecephys_session_id_list": [1115077618, 1081429294],
+      "probes_to_skip": [{"session": 1115077618, "probe": "probeC"}]
     }
     return config
 

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_cli.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_cli.py
@@ -23,7 +23,7 @@ def test_metadata_writer_smoketest(
     smoke test for VBN 2022 metadata writer. Requires LIMS
     and mtrain connections.
 
-    If with_supplement is True, add supplemental columns
+    If with_supplement is True, add supplemental data
     to the ecephys_sessions.csv file and test for their existence
     """
 
@@ -51,7 +51,7 @@ def test_metadata_writer_smoketest(
                        'supplementA': None,
                        'supplementB': None}]
 
-        config['supplemental_columns'] = supplement
+        config['supplemental_data'] = supplement
 
     expected_paths = []
     for name in output_names:
@@ -92,7 +92,7 @@ def test_metadata_writer_smoketest(
     if with_supplement:
         df = pd.read_csv(output_dir / 'ecephys_sessions.csv')
         # make sure that no extra rows were added when adding
-        # the supplemental columns
+        # the supplemental data
         assert len(df) == 2
 
         for expected in supplement[:2]:

--- a/allensdk/test/core/test_datafame_utils.py
+++ b/allensdk/test/core/test_datafame_utils.py
@@ -174,3 +174,27 @@ def test_patch_with_duplicates(
                 columns_to_patch=['b', 'd'])
 
     pd.testing.assert_frame_equal(actual, expected_df)
+
+
+def test_patch_new_column(
+        target_df_fixture,
+        source_df_fixture):
+    """
+    Test case where we use patch_df_from_other in the case where we are
+    adding a column to target_df
+    """
+    expected_data = [
+        {'a': 1, 'b': 3.4, 'c': 'apple', 'd': None, 'e': 'frog'},
+        {'a': 9, 'b': 4.5, 'c': 'banana', 'd': 4.6, 'e': None},
+        {'a': 12, 'b': 7.8, 'c': 'pineapple', 'd': 'purple', 'e': 'dog'},
+        {'a': 17, 'b': None, 'c': 'papaya', 'd': 11, 'e': 'cat'}
+    ]
+    expected_df = pd.DataFrame(data=expected_data)
+
+    actual = patch_df_from_other(
+                source_df=source_df_fixture.copy(deep=True),
+                target_df=target_df_fixture,
+                index_column='a',
+                columns_to_patch=['e'])
+
+    pd.testing.assert_frame_equal(actual, expected_df)


### PR DESCRIPTION
As part of the 2022 VBN release, we are adding some hand annotations not currently represented in the LIMS database to the ecephys_sessions table. Rather than update the schema of the LIMS database (a change that would have implications for all previously-collected ecephys data), we are adding functionality to the VBN metadata_writer that allows us to add columns to the ecephys_sessions table by hand. This PR encompasses that functionality. The new `supplemental_columns` entry in the metadata_writer schema should look something like this

```
  "supplemental_columns": [
    {
      "abnormal_activity": false,
      "ecephys_session_id": 1051155866
    },
    {
      "abnormal_activity": false,
      "ecephys_session_id": 1044385384
    },
    {
      "abnormal_activity": false,
      "ecephys_session_id": 1044594870
    },
    {
      "abnormal_activity": false,
      "abnormal_histology": [
        "Hippocampus"
      ],
      "ecephys_session_id": 1056495334
    }]
```
