### PR TITLE
Ticket/2453/bad/mouse

### DIFF
--- a/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/stimulus_file.py
@@ -210,7 +210,16 @@ class BehaviorStimulusFile(_StimulusFile):
         -------
         session duration in seconds
         """
-        delta = self.data['stop_time'] - self.data['start_time']
+        start_time = self.data['start_time']
+        stop_time = self.data['stop_time']
+
+        if not isinstance(start_time, datetime.datetime):
+            start_time = datetime.datetime.fromtimestamp(start_time)
+        if not isinstance(stop_time, datetime.datetime):
+            stop_time = datetime.datetime.fromtimestamp(stop_time)
+
+        delta = stop_time - start_time
+
         return delta.total_seconds()
 
 

--- a/allensdk/brain_observatory/vbn_2022/input_json_writer/utils.py
+++ b/allensdk/brain_observatory/vbn_2022/input_json_writer/utils.py
@@ -238,7 +238,8 @@ def session_input_from_ecephys_session_id_list(
 
     session_table = _ecephys_summary_table_from_ecephys_session_id_list(
             lims_connection=lims_connection,
-            ecephys_session_id_list=ecephys_session_id_list)
+            ecephys_session_id_list=ecephys_session_id_list,
+            failed_ecephys_session_id_list=None)
 
     # get date_of_acquisition from the pickle file by nulling out the
     # dates of acqusition from any sessions with behavior_session_ids,

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/lims_queries.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/lims_queries.py
@@ -1,5 +1,6 @@
 from typing import List, Tuple, Dict, Any, Optional
 import pandas as pd
+import numpy as np
 import logging
 
 from allensdk.api.queries.donors_queries import get_death_date_for_mouse_ids
@@ -648,8 +649,10 @@ def _filter_on_death_date(
             how='left')
 
     behavior_session_df = behavior_session_df[
-            behavior_session_df['date_of_acquisition'] <=
-            behavior_session_df['death_on']
+            np.logical_or(
+                behavior_session_df['date_of_acquisition'] <=
+                behavior_session_df['death_on'],
+                behavior_session_df['death_on'].isna())
         ]
 
     behavior_session_df.drop(

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/metadata_writer.py
@@ -146,11 +146,15 @@ class VBN2022MetadataWriterClass(argschema.ArgSchemaParser):
             df=channels_table,
             output_path=self.args['channels_path'])
 
+        failed_session_list = self.args[
+            'failed_ecephys_session_id_list']
+
         (ecephys_session_table,
          behavior_session_table) = session_tables_from_ecephys_session_id_list(
                     lims_connection=lims_connection,
                     mtrain_connection=mtrain_connection,
                     ecephys_session_id_list=session_id_list,
+                    failed_ecephys_session_id_list=failed_session_list,
                     probe_ids_to_skip=probe_ids_to_skip,
                     logger=self.logger)
 

--- a/allensdk/brain_observatory/vbn_2022/metadata_writer/schemas.py
+++ b/allensdk/brain_observatory/vbn_2022/metadata_writer/schemas.py
@@ -16,6 +16,17 @@ class VBN2022MetadataWriterInputSchema(argschema.ArgSchema):
             description=("List of ecephys_sessions.id values "
                          "of sessions to be released"))
 
+    failed_ecephys_session_id_list = argschema.fields.List(
+            argschema.fields.Int,
+            required=False,
+            default=None,
+            allow_none=True,
+            description=("List of ecephys_sessions.id values "
+                         "associated with this release that were "
+                         "failed. These are required to "
+                         "self-consistently construct the history of "
+                         "each mouse passing through the apparatus."))
+
     probes_to_skip = argschema.fields.List(
             argschema.fields.Nested(ProbeToSkip),
             required=False,

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/conftest.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/conftest.py
@@ -18,6 +18,19 @@ def smoketest_config_fixture():
 
 
 @pytest.fixture
+def smoketest_with_failed_sessions_config_fixture():
+    """
+    config parameters for on-prem metadata writer smoketest
+    """
+    config = {
+      "ecephys_session_id_list": [1051155866],
+      "failed_ecephys_session_id_list": [1050962145],
+      "probes_to_skip": [{"session": 1115077618, "probe": "probeC"}]
+    }
+    return config
+
+
+@pytest.fixture
 def patching_pickle_file_fixture(
         helper_functions,
         tmp_path_factory):

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_vbn_2022_metadata_writer_lims_queries.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_vbn_2022_metadata_writer_lims_queries.py
@@ -56,7 +56,9 @@ def test_filter_on_death_date():
         {'mouse_id': 456,
          'death_on': datetime.datetime(2020, 3, 2)},
         {'mouse_id': 789,
-         'death_on': datetime.datetime(2020, 7, 14)}]
+         'death_on': datetime.datetime(2020, 7, 14)},
+        {'mouse_id': 1011,
+         'death_on': None}]
 
     death_df = pd.DataFrame(data=death_dates)
 
@@ -85,7 +87,10 @@ def test_filter_on_death_date():
          'date_of_acquisition': datetime.datetime(2020, 2, 2)},
         {'mouse_id': 123,
          'session_id': 5,
-         'date_of_acquisition': datetime.datetime(2020, 4, 7)}]
+         'date_of_acquisition': datetime.datetime(2020, 4, 7)},
+        {'mouse_id': 1011,
+         'session_id': 6,
+         'date_of_acqusition': datetime.datetime(2021, 11, 11)}]
 
     session_df = pd.DataFrame(data=session_data)
 
@@ -97,7 +102,8 @@ def test_filter_on_death_date():
             data=[session_data[1],
                   session_data[2],
                   session_data[4],
-                  session_data[5]])
+                  session_data[5],
+                  session_data[6]])
 
     expected = expected.set_index("session_id")
     actual = actual.set_index("session_id")

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_vbn_2022_metadata_writer_lims_queries.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_vbn_2022_metadata_writer_lims_queries.py
@@ -5,7 +5,8 @@ import datetime
 from allensdk.api.queries.donors_queries import get_death_date_for_mouse_ids
 from allensdk.brain_observatory.vbn_2022.metadata_writer.lims_queries import (
     _behavior_session_table_from_ecephys_session_id_list,
-    _filter_on_death_date)
+    _filter_on_death_date,
+    _merge_ecephys_id_and_failed)
 from allensdk.test.brain_observatory.behavior.data_objects.lims_util import \
     LimsTest
 
@@ -108,3 +109,47 @@ def test_filter_on_death_date():
     expected = expected.set_index("session_id")
     actual = actual.set_index("session_id")
     pd.testing.assert_frame_equal(expected, actual)
+
+
+def test_merge_ecephys_id_and_failed():
+    """
+    Test that method merging ecephys_session_id_list
+    and failed_ecephys_session_id_list on shared donor_id
+    returns the correct result
+    """
+
+    ecephys_data = [
+        {'ecephys_session_id': 4,
+         'donor_id': '100'},
+        {'ecephys_session_id': 1,
+         'donor_id': '200'},
+        {'ecephys_session_id': 3,
+         'donor_id': '300'},
+        {'ecephys_session_id': 2,
+         'donor_id': '400'}]
+
+    failed_data = [
+        {'ecephys_session_id': 7,
+         'donor_id': '300'},
+        {'ecphys_session_id': 6,
+         'donor_id': '900'},
+        {'ecephys_session_id': 5,
+         'donor_id': '200'}]
+
+    class DummyConnection(object):
+
+        def select(self, query=None):
+            if '5' in query:
+                return pd.DataFrame(data=failed_data)
+            elif '3' in query:
+                return pd.DataFrame(data=ecephys_data)
+            else:
+                raise RuntimeError(
+                    f"cannot mock query={query}")
+
+    expected = [1, 2, 3, 4, 5, 7]
+    actual = _merge_ecephys_id_and_failed(
+                lims_connection=DummyConnection(),
+                ecephys_session_id_list=[1, 2, 3, 4],
+                failed_ecephys_session_id_list=[5, 6, 7])
+    assert expected == actual


### PR DESCRIPTION
This PR addresses

#2453 by making our `_filter_on_death_date` code treat `death_on = None` as "the mouse is still alive" (though that mouse was dead and we have updated LIMS accordingly)

#2452 by adding a `failed_ecephys_session_id_list` field to the metadata writer schema. These sessions will be used when constructing each mouse's history with our apparatus, then dropped at the moment of output.
