### PR TITLE
tolist() can be expensive; use list comprehension instead which is fas…

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/cell_specimens/traces/corrected_fluorescence_traces.py
+++ b/allensdk/brain_observatory/behavior/data_objects/cell_specimens/traces/corrected_fluorescence_traces.py
@@ -42,7 +42,7 @@ class CorrectedFluorescenceTraces(DataObject, RoisMixin,
         # We want rois x timepoints, hence the transpose
         f_traces = corr_fluorescence_nwb.data[:].T.copy()
         roi_ids = corr_fluorescence_nwb.rois.table.id[:].copy()
-        df = pd.DataFrame({'corrected_fluorescence': f_traces.tolist()},
+        df = pd.DataFrame({'corrected_fluorescence': [x for x in f_traces]},
                           index=pd.Index(
                               data=roi_ids,
                               name='cell_roi_id'))

--- a/allensdk/brain_observatory/behavior/data_objects/cell_specimens/traces/dff_traces.py
+++ b/allensdk/brain_observatory/behavior/data_objects/cell_specimens/traces/dff_traces.py
@@ -71,7 +71,7 @@ class DFFTraces(DataObject, RoisMixin,
         # We want rois x timepoints, hence the transpose
         dff_traces = dff_nwb.data[:].T
 
-        df = pd.DataFrame({'dff': dff_traces.tolist()},
+        df = pd.DataFrame({'dff': [x for x in dff_traces]},
                           index=pd.Index(data=dff_nwb.rois.table.id[:],
                                          name='cell_roi_id'))
         return DFFTraces(traces=df)


### PR DESCRIPTION
#2306 
Addresses low hanging fruit in "slowness" in `from_nwb` calls
`tolist()` can take 1 minute+ here. List comprehension is much faster since it doesn't recursively convert all values to python types. We can't remove conversion to list here (which would be ideal, since conversion to list here is just not a good idea), since Marina doesn't want to change her code to support that change, but this is a middle ground

It converts to list of numpy array, which is what `from_lims` currently returns