### PR TITLE
Ticket/2371/vbo/access

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -311,7 +311,8 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
 
     def get_behavior_session(
             self,
-            behavior_session_id: int
+            behavior_session_id: int,
+            skip_eye_tracking: bool = False
     ) -> BehaviorSession:
         """
         Gets `BehaviorSession` for `behavior_session_id`
@@ -319,12 +320,16 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
         ----------
         behavior_session_id: behavior session id
 
+        skip_eye_tracking: bool
+            if True, do not load eye tracking data for this session
+
         Returns
         -------
         BehaviorSession
         """
         return self.fetch_api.get_behavior_session(
-            behavior_session_id=behavior_session_id
+            behavior_session_id=behavior_session_id,
+            skip_eye_tracking=skip_eye_tracking
         )
 
 

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -52,7 +52,9 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         self._get_ophys_cells_table()
 
     def get_behavior_session(
-            self, behavior_session_id: int) -> BehaviorSession:
+            self,
+            behavior_session_id: int,
+            skip_eye_tracking: bool = False) -> BehaviorSession:
         """get a BehaviorSession by specifying behavior_session_id
 
         Parameters
@@ -92,7 +94,9 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
             row = self._ophys_experiment_table.query(f"index=={oeid}")
         file_id = str(int(row[self.cache.file_id_column]))
         data_path = self._get_data_path(file_id=file_id)
-        return BehaviorSession.from_nwb_path(str(data_path))
+        return BehaviorSession.from_nwb_path(
+                nwb_path=str(data_path),
+                skip_eye_tracking=skip_eye_tracking)
 
     def get_behavior_ophys_experiment(self, ophys_experiment_id: int
                                       ) -> BehaviorOphysExperiment:

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
@@ -406,15 +406,19 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         return table
 
     def get_behavior_session(
-            self, behavior_session_id: int) -> BehaviorSession:
+            self,
+            behavior_session_id: int,
+            skip_eye_tracking: bool = False) -> BehaviorSession:
         """Returns a BehaviorSession object that contains methods to
         analyze a single behavior session.
         :param behavior_session_id: id that corresponds to a behavior session
+        :param skip_eye_tracking: if True, do not load eye tracking data
         :type behavior_session_id: int
         :rtype: BehaviorSession
         """
         return BehaviorSession.from_lims(
-            behavior_session_id=behavior_session_id)
+            behavior_session_id=behavior_session_id,
+            skip_eye_tracking=skip_eye_tracking)
 
     def get_ophys_experiment_table(
             self,

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
@@ -14,7 +14,8 @@ from allensdk.core.authentication import DbCredentials
 from allensdk.core.auth_config import (
     MTRAIN_DB_CREDENTIAL_MAP, LIMS_DB_CREDENTIAL_MAP)
 from allensdk.internal.api.queries.utils import (
-    build_in_list_selector_query)
+    build_in_list_selector_query,
+    _sanitize_uuid_list)
 from allensdk.internal.api.queries.behavior_lims_queries import (
     foraging_id_map_from_behavior_session_id)
 from allensdk.internal.api.queries.mtrain_queries import (
@@ -456,6 +457,8 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
                 logger=self.logger)
 
         foraging_ids = list(foraging_id_map.foraging_id)
+
+        foraging_ids = _sanitize_uuid_list(foraging_ids)
 
         stimulus_names = session_stage_from_foraging_id(
                             mtrain_engine=self.mtrain_engine,

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -519,7 +519,6 @@ class BehaviorSession(DataObject, LimsReadableInterface,
     def from_nwb_path(
             cls,
             nwb_path: str,
-            skip_eye_tracking: bool = False,
             **kwargs) -> "BehaviorSession":
         """
 
@@ -527,8 +526,6 @@ class BehaviorSession(DataObject, LimsReadableInterface,
         ----------
         nwb_path
             Path to nwb file
-        skip_eye_tracking
-            if True, do not load eye tracking data
         kwargs
             Kwargs to be passed to `from_nwb`
 
@@ -541,7 +538,6 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             nwbfile = read_io.read()
             return cls.from_nwb(
                  nwbfile=nwbfile,
-                 skip_eye_tracking=skip_eye_tracking,
                  **kwargs)
 
     def to_nwb(

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_cloud_api.py
@@ -150,7 +150,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch, local):
 
     # get_behavior_session returns expected value
     # both directly and via experiment table
-    def mock_nwb(nwb_path):
+    def mock_nwb(nwb_path, skip_eye_tracking=False):
         return nwb_path
     monkeypatch.setattr(cloudapi.BehaviorSession, "from_nwb_path", mock_nwb)
     assert api.get_behavior_session(2) == "5"

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
@@ -85,7 +85,7 @@ def test_local_cache_construction(
 
     with monkeypatch.context() as ctx:
         ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
-                    lambda path: create_autospec(
+                    lambda nwb_path: create_autospec(
                         BehaviorOphysExperiment, instance=True))
         cache.get_behavior_ophys_experiment(ophys_experiment_id=5111)
     assert cache.fetch_api.cache._downloaded_data_path.is_file()
@@ -143,13 +143,14 @@ def test_load_out_of_date_manifest(
     for sess_id in (333, 444):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorSession, 'from_nwb_path',
-                        lambda path: create_autospec(
-                            BehaviorSession, instance=True))
+                        lambda nwb_path, skip_eye_tracking=False:
+                            create_autospec(
+                                BehaviorSession, instance=True))
             cache.get_behavior_session(behavior_session_id=sess_id)
     for exp_id in (5111, 5222):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
-                        lambda path: create_autospec(
+                        lambda nwb_path: create_autospec(
                             BehaviorOphysExperiment, instance=True))
             cache.get_behavior_ophys_experiment(ophys_experiment_id=exp_id)
 
@@ -218,13 +219,14 @@ def test_file_linkage(
     for sess_id in (333, 444):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorSession, 'from_nwb_path',
-                        lambda path: create_autospec(
-                            BehaviorSession, instance=True))
+                        lambda nwb_path, skip_eye_tracking=False:
+                            create_autospec(
+                                BehaviorSession, instance=True))
             cache.get_behavior_session(behavior_session_id=sess_id)
     for exp_id in (5111, 5222):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
-                        lambda path: create_autospec(
+                        lambda nwb_path: create_autospec(
                             BehaviorOphysExperiment, instance=True))
             cache.get_behavior_ophys_experiment(ophys_experiment_id=exp_id)
 
@@ -248,13 +250,14 @@ def test_file_linkage(
     for sess_id in (777, 888):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorSession, 'from_nwb_path',
-                        lambda path: create_autospec(
-                            BehaviorSession, instance=True))
+                        lambda nwb_path, skip_eye_tracking=False:
+                            create_autospec(
+                                BehaviorSession, instance=True))
             cache.get_behavior_session(behavior_session_id=sess_id)
     for exp_id in (5444, 5666, 5777):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorOphysExperiment, 'from_nwb_path',
-                        lambda path: create_autospec(
+                        lambda nwb_path: create_autospec(
                             BehaviorOphysExperiment, instance=True))
             cache.get_behavior_ophys_experiment(ophys_experiment_id=exp_id)
 


### PR DESCRIPTION
This addresses some bugs that Marina had with accessing VBO data off of rc/2.13.5

I did not add any unit tests because any testing of this code would involve instantiating a cache from_lims without specifying a data_release_date, and I didn't want our unit tests to start failing if ill-formed data got loaded into LIMS.

I am open the the idea that there is something I missed.
