### PR TITLE
increase lower bound on jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ h5py
 matplotlib>=1.4.3,<3.4.3
 numpy
 pandas>=1.1.5
-jinja2>=2.7.3,<2.12.0
+jinja2>=3.0.0
 scipy>=1.4.0,<2.0.0
 six>=1.9.0,<2.0.0
 pynrrd>=0.2.1,<1.0.0


### PR DESCRIPTION
Addresses #2478 

Jinja2 is a dependency of allensdk. It has a dependency called Markupsafe, and only specifies a lower bound of 0.2.3 even though it really requires < 2.1.1. Markupsafe 2.1.1 was getting installed.

Apparently they didn't fix it because jinja2 2.x is not supported. 

Increase lower bound to 3.x.