### PR TITLE
BehaviorSession.from_lims now supports checking if eye tracking metad…

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -10,6 +10,8 @@ import pathlib
 from pynwb import NWBFile
 
 from allensdk import OneResultExpectedError
+from allensdk.brain_observatory.behavior.data_files.eye_tracking_video import \
+    EyeTrackingVideo
 from allensdk.brain_observatory.sync_dataset import Dataset as SyncDataset
 from allensdk.brain_observatory import sync_utilities
 
@@ -411,11 +413,15 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                     db=lims_db,
                     behavior_session_id=behavior_session_id.value)
 
+            eye_tracking_video = EyeTrackingVideo.from_lims(
+                db=lims_db, behavior_session_id=behavior_session_id.value)
+
             eye_tracking_metadata_file = None
 
             eye_tracking_table = cls._read_eye_tracking_table(
                 eye_tracking_file=eye_tracking_file,
                 eye_tracking_metadata_file=eye_tracking_metadata_file,
+                eye_tracking_video=eye_tracking_video,
                 sync_file=sync_file,
                 z_threshold=eye_tracking_z_threshold,
                 dilation_frames=eye_tracking_dilation_frames)
@@ -1400,10 +1406,13 @@ class BehaviorSession(DataObject, LimsReadableInterface,
     def _read_eye_tracking_table(
             cls,
             eye_tracking_file: EyeTrackingFile,
-            eye_tracking_metadata_file: EyeTrackingMetadataFile,
             sync_file: SyncFile,
             z_threshold: float,
-            dilation_frames: int) -> EyeTrackingTable:
+            dilation_frames: int,
+            eye_tracking_metadata_file: Optional[
+                EyeTrackingMetadataFile] = None,
+            eye_tracking_video: Optional[EyeTrackingVideo] = None
+    ) -> EyeTrackingTable:
 
         # this is possible if instantiating from_lims
         if sync_file is None:
@@ -1426,6 +1435,8 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
         return EyeTrackingTable.from_data_file(
                     data_file=eye_tracking_file,
+                    metadata_file=eye_tracking_metadata_file,
+                    video=eye_tracking_video,
                     stimulus_timestamps=stimulus_timestamps,
                     z_threshold=z_threshold,
                     dilation_frames=dilation_frames,

--- a/allensdk/brain_observatory/behavior/data_files/eye_tracking_video.py
+++ b/allensdk/brain_observatory/behavior/data_files/eye_tracking_video.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from typing import Union, Any
+
+from allensdk.internal.api import PostgresQueryMixin
+
+from allensdk.internal.core import DataFile
+
+
+class EyeTrackingVideo(DataFile):
+    """Eye tracking video"""
+    def to_json(self) -> dict:
+        raise NotImplementedError
+
+    @classmethod
+    def from_lims(
+            cls,
+            db: PostgresQueryMixin,
+            behavior_session_id: Union[int, str],
+            session_type: str = 'OphysSession'
+    ) -> "EyeTrackingVideo":
+        """
+
+        Parameters
+        ----------
+        db: PostgresQueryMixin
+        behavior_session_id: behavior session id
+        session_type: session type the eye tracking video is associated with.
+            Either 'OphysSession' or 'EcephysSession'
+
+        Returns
+        -------
+        `EyeTrackingVideo` instance
+        """
+        valid_session_types = ('OphysSession', 'EcephysSession')
+        if session_type not in valid_session_types:
+            raise ValueError(f'Session type must be one of '
+                             f'{valid_session_types}')
+        query = f"""
+                SELECT wkf.storage_directory || wkf.filename AS eye_tracking_file
+                FROM behavior_sessions bs
+                JOIN ophys_sessions os ON os.id = bs.ophys_session_id
+                LEFT JOIN well_known_files wkf ON wkf.attachable_id = os.id
+                JOIN well_known_file_types wkft ON wkf.well_known_file_type_id = wkft.id
+                WHERE wkf.attachable_type = '{session_type}'
+                    AND wkft.name = 'RawEyeTrackingVideo'
+                    AND bs.id = {behavior_session_id};
+                """  # noqa E501
+        filepath = db.fetchone(query, strict=True)
+        return cls(filepath=filepath)
+
+    @staticmethod
+    def load_data(filepath: Union[str, Path], **kwargs) -> Any:
+        return None
+
+    @classmethod
+    def from_json(cls, dict_repr: dict) -> "DataFile":
+        raise NotImplementedError

--- a/allensdk/test/brain_observatory/behavior/test_behavior_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_session.py
@@ -5,6 +5,9 @@ from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 import pytest
 
+from allensdk.test.brain_observatory.behavior.data_objects.lims_util import \
+    LimsTest
+
 
 @pytest.fixture
 def session_data_fixture():
@@ -78,3 +81,14 @@ def test_behavior_session_equivalent_json_lims(session_data_fixture):
                                              skip_eye_tracking=True)
 
     assert sessions_are_equal(json_session, lims_session, reraise=True)
+
+
+class TestBehaviorSession(LimsTest):
+    @pytest.mark.requires_bamboo
+    def test_eye_tracking_loaded_with_metadata_frame(self):
+        # This session uses MVR to record the eye tracking video
+        sess_id = 1154034257
+
+        sess = BehaviorSession.from_lims(behavior_session_id=sess_id,
+                                         lims_db=self.dbconn)
+        assert not sess.eye_tracking.empty


### PR DESCRIPTION
Addresses #2473 

We need to know the eye tracking video filepath to know whether MVR was used (inserts a metadata frame as the first frame).
Currently, we use the eye tracking metadata file for this, which includes a path to the eye tracking video. However, the eye tracking metadata file is not tracked for ophys sessions so it cannot be used for ophys sessions. So I used the eye tracking video instead to detect if the filepath is from MVR or not to remove the metadata frame. 