### PR TITLE
Adds support for VBN trials table having different name for 'change_time'

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List, Dict, Optional
+from typing import Any, List, Dict, Optional, Type
 
 import pynwb
 import pandas as pd
@@ -492,7 +492,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                 add_is_change_to_stimulus_presentations_table)
         )
         task_parameters = TaskParameters.from_nwb(nwbfile=nwbfile)
-        trials = TrialTable.from_nwb(nwbfile=nwbfile)
+        trials = cls._trial_table_class().from_nwb(nwbfile=nwbfile)
         date_of_acquisition = DateOfAcquisition.from_nwb(nwbfile=nwbfile)
         if skip_eye_tracking:
             eye_tracking_rig_geometry = None
@@ -504,7 +504,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                 nwbfile=nwbfile, z_threshold=eye_tracking_z_threshold,
                 dilation_frames=eye_tracking_dilation_frames)
 
-        return BehaviorSession(
+        return cls(
             behavior_session_id=behavior_session_id,
             stimulus_timestamps=stimulus_timestamps,
             running_acquisition=running_acquisition,
@@ -645,7 +645,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             task calculated over a 25 trial rolling window.
         """
         return calculate_reward_rate_fix_nans(
-                self.trials,
+                self._trials,
                 self.task_parameters['response_window_sec'][0])
 
     def get_rolling_performance_df(self) -> pd.DataFrame:
@@ -685,7 +685,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
 
         """
         return construct_rolling_performance_df(
-                self.trials,
+                self._trials,
                 self.task_parameters['response_window_sec'][0],
                 self.task_parameters["session_type"])
 
@@ -1477,3 +1477,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
         # as discussed in
         # https://github.com/AllenInstitute/AllenSDK/issues/1318
         return 0.02115
+
+    @classmethod
+    def _trial_table_class(cls) -> Type[TrialTable]:
+        return TrialTable

--- a/allensdk/brain_observatory/behavior/behavior_session.py
+++ b/allensdk/brain_observatory/behavior/behavior_session.py
@@ -286,7 +286,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
             eye_tracking_rig_geometry = EyeTrackingRigGeometry.from_json(
                 dict_repr=session_data)
 
-        return BehaviorSession(
+        return cls(
             behavior_session_id=behavior_session_id,
             stimulus_timestamps=stimulus_timestamps,
             running_acquisition=running_acquisition,
@@ -1307,7 +1307,7 @@ class BehaviorSession(DataObject, LimsReadableInterface,
                 stimulus_file_lookup=stimulus_file_lookup,
                 monitor_delay=monitor_delay)
 
-        return TrialTable.from_stimulus_file(
+        return cls._trial_table_class().from_stimulus_file(
             stimulus_file=stimulus_file_lookup.behavior_stimulus_file,
             stimulus_timestamps=stimulus_timestamps,
             licks=licks,

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
@@ -45,8 +45,9 @@ class Presentations(DataObject, StimulusFileReadableInterface,
         if sort_columns:
             presentations = presentations[sorted(presentations.columns)]
         presentations = presentations.reset_index(drop=True)
-        presentations.index = pd.Int64Index(
-            range(presentations.shape[0]), name='stimulus_presentations_id')
+        presentations.index = pd.Index(
+            range(presentations.shape[0]), name='stimulus_presentations_id',
+            dtype='int')
         super().__init__(name='presentations', value=presentations)
 
     def to_nwb(self,

--- a/allensdk/brain_observatory/behavior/data_objects/trials/trial_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/trials/trial_table.py
@@ -119,7 +119,7 @@ class TrialTable(DataObject, StimulusFileReadableInterface,
         # Order/Filter columns
         trials = trials[cls.columns_to_output()]
 
-        return TrialTable(trials=trials)
+        return cls(trials=trials)
 
     @staticmethod
     def _get_trial_bounds(trial_log: List) -> List[Tuple[int, int]]:

--- a/allensdk/brain_observatory/behavior/data_objects/trials/trial_table.py
+++ b/allensdk/brain_observatory/behavior/data_objects/trials/trial_table.py
@@ -67,7 +67,7 @@ class TrialTable(DataObject, StimulusFileReadableInterface,
         if 'lick_events' in trials.columns:
             trials.drop('lick_events', inplace=True, axis=1)
         trials.index = trials.index.rename('trials_id')
-        return TrialTable(trials=trials)
+        return cls(trials=trials)
 
     @classmethod
     def columns_to_output(cls) -> List[str]:
@@ -167,3 +167,39 @@ class TrialTable(DataObject, StimulusFileReadableInterface,
 
         end_frames = [idx for idx in start_frames[1:] + [-1]]
         return list([(s, e) for s, e in zip(start_frames, end_frames)])
+
+    @property
+    def index(self) -> pd.Index:
+        return self.value.index
+
+    @property
+    def change_time(self) -> pd.Series:
+        return self.value['change_time']
+
+    @property
+    def lick_times(self) -> pd.Series:
+        return self.value['lick_times']
+
+    @property
+    def start_time(self) -> pd.Series:
+        return self.value['start_time']
+
+    @property
+    def aborted(self) -> pd.Series:
+        return self.value['aborted']
+
+    @property
+    def hit(self) -> pd.Series:
+        return self.value['hit']
+
+    @property
+    def miss(self) -> pd.Series:
+        return self.value['miss']
+
+    @property
+    def false_alarm(self) -> pd.Series:
+        return self.value['false_alarm']
+
+    @property
+    def correct_reject(self) -> pd.Series:
+        return self.value['correct_reject']

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Type
 
 import numpy as np
 import pandas as pd
@@ -248,6 +248,10 @@ class VBNBehaviorSession(BehaviorSession):
             licks=licks,
             rewards=rewards)
 
+    @classmethod
+    def _trial_table_class(cls) -> Type[VBNTrialTable]:
+        return VBNTrialTable
+
 
 class BehaviorEcephysSession(VBNBehaviorSession):
     """
@@ -264,7 +268,7 @@ class BehaviorEcephysSession(VBNBehaviorSession):
 
     def __init__(
             self,
-            behavior_session: BehaviorSession,
+            behavior_session: VBNBehaviorSession,
             metadata: BehaviorEcephysMetadata,
             probes: Probes,
             optotagging_table: OptotaggingTable

--- a/allensdk/brain_observatory/ecephys/data_objects/trials.py
+++ b/allensdk/brain_observatory/ecephys/data_objects/trials.py
@@ -119,3 +119,7 @@ class VBNTrialTable(TrialTable):
                 'hit', 'false_alarm', 'miss', 'correct_reject',
                 'aborted', 'auto_rewarded', 'change_frame',
                 'start_time', 'stop_time', 'trial_length']
+
+    @property
+    def change_time(self):
+        return self.value['change_time_no_display_delay']

--- a/allensdk/test/brain_observatory/behavior/test_trials_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_trials_processing.py
@@ -3,7 +3,9 @@ import pandas as pd
 import numpy as np
 
 from allensdk.brain_observatory.behavior import trials_processing
-
+from allensdk.brain_observatory.behavior.data_objects.trials.trial_table \
+    import \
+    TrialTable
 
 _test_response_latency_0 = np.array(
     [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan,
@@ -351,7 +353,7 @@ def trial_data_and_expectation_2():
 def test_calculate_response_latency_list(
         trials, response_window_start, expected):
     latencies = trials_processing.calculate_response_latency_list(
-            trials, response_window_start)
+            TrialTable(trials), response_window_start)
     np.testing.assert_allclose(latencies, expected)
 
 
@@ -365,6 +367,12 @@ def trials_example():
                 9: 378.0631642451044,
                 10: 386.31999971927144,
                 11: 394.57686825376004},
+            'change_time': {
+                8: 1,
+                9: 2,
+                10: 3,
+                11: 4
+            },
             'lick_times': {
                 8: np.array([]),
                 9: np.array([]),
@@ -385,7 +393,7 @@ def test_construct_rolling_performance_df(trials_example, session_type):
     rolling_dprime values with all zeros
     """
     df = trials_processing.construct_rolling_performance_df(
-            trials_example, 0.15, session_type)
+            TrialTable(trials_example), 0.15, session_type)
     if session_type.endswith("passive"):
         assert np.all(df["rolling_dprime"].values == 0.0)
     else:

--- a/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
+++ b/allensdk/test/brain_observatory/ecephys/test_behavior_ecephys_session.py
@@ -56,3 +56,13 @@ def test_session_consistency(
 
     # make sure that response_latency is not in the trials table
     assert 'response_latency' not in trials.columns
+
+
+@pytest.mark.requires_bamboo
+def test_getters_sanity(behavior_ecephys_session_fixture):
+    """Sanity check to make sure that the BehaviorEcephysSession
+    can use the BehaviorSession base class getter methods
+    """
+    behavior_ecephys_session_fixture.get_performance_metrics()
+    behavior_ecephys_session_fixture.get_rolling_performance_df()
+    behavior_ecephys_session_fixture.get_reward_rate()


### PR DESCRIPTION
Addresses #2490 

The BehaviorSession base class has methods that expect the trials table to have a column "change_time". However the VBN trials table has a column with a different name. This PR adds properties to the TrialTable class so that these properties can be accessed instead of the data frame columns so that a column with a different name can be accessed. 