### PR TITLE
Ophys cells table now supports passed_only filter

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -72,7 +72,8 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
             fetch_tries: int = 2,
             manifest: Optional[Union[str, Path]] = None,
             version: Optional[str] = None,
-            cache: bool = True):
+            cache: bool = True
+    ):
         """ Entrypoint for accessing visual behavior data. Supports
         access to summaries of session data and provides tools for
         downloading detailed session data (such as dff traces).
@@ -133,7 +134,6 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
             index_column: str = "ophys_session_id",
             as_df=True,
             include_behavior_data=True,
-            passed_only=True,
             n_workers: int = 1
     ) -> Union[pd.DataFrame, BehaviorOphysSessionsTable]:
         """
@@ -181,14 +181,6 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
         sessions = BehaviorOphysSessionsTable(df=ophys_sessions,
                                               suppress=suppress,
                                               index_column=index_column)
-        if passed_only:
-            oet = self.get_ophys_experiment_table(passed_only=True,
-                                                  n_workers=n_workers)
-            for i in sessions.table.index:
-                sub_df = oet.query(f"ophys_session_id=={i}")
-                values = list(set(sub_df["ophys_container_id"].values))
-                values.sort()
-                sessions.table.at[i, "ophys_container_id"] = values
 
         return sessions.table if as_df else sessions
 
@@ -196,7 +188,6 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
             self,
             suppress: Optional[List[str]] = None,
             as_df=True,
-            passed_only=True,
             n_workers: int = 1
     ) -> Union[pd.DataFrame, SessionsTable]:
         """
@@ -205,9 +196,6 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
             dataframe.
         :type suppress: list of str
         :param as_df: whether to return as df or as SessionsTable
-        :param passed_only: if True, return only experiments flagged as
-                            'passed' and containers flagged as 'published'
-                            (default=True)
         :param n_workers
             Number of parallel processes to use for i.e reading from pkl files
         :rtype: pd.DataFrame
@@ -234,8 +222,7 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
             experiments, left_index=True, right_on='behavior_session_id',
             suffixes=('_behavior', '_ophys'))
         experiments = ExperimentsTable(df=experiments,
-                                       suppress=suppress,
-                                       passed_only=passed_only)
+                                       suppress=suppress)
         return experiments.table if as_df else experiments
 
     def get_ophys_cells_table(self) -> pd.DataFrame:
@@ -264,7 +251,6 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
             suppress: Optional[List[str]] = None,
             as_df=True,
             include_ophys_data=True,
-            passed_only=True,
             n_workers: int = 1
     ) -> Union[pd.DataFrame, SessionsTable]:
         """
@@ -299,7 +285,6 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
                 suppress=suppress,
                 as_df=False,
                 include_behavior_data=False,
-                passed_only=passed_only,
                 n_workers=n_workers)
         else:
             ophys_session_table = None

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_cache_base.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_cache_base.py
@@ -122,7 +122,8 @@ class ProjectCacheBase(object):
                   host: Optional[str] = None,
                   scheme: Optional[str] = None,
                   asynchronous: bool = True,
-                  data_release_date: Optional[Union[str, List[str]]] = None
+                  data_release_date: Optional[Union[str, List[str]]] = None,
+                  passed_only: bool = True
                   ) -> "ProjectCacheBase":
         """
         Construct a ProjectCacheBase with a lims api.
@@ -156,10 +157,13 @@ class ProjectCacheBase(object):
         data_release_date: str or list of str
             Use to filter tables to only include data released on date
             ie 2021-03-25 or ['2021-03-25', '2021-08-12']
+        passed_only
+            Whether to limit to data with `workflow_state` set to 'passed'
+            and 'published'
         Returns
         =======
         ProjectCacheBase
-            ProjectCachBase instance with a LIMS fetch API
+            ProjectCacheBase instance with a LIMS fetch API
         """
         if host and scheme:
             app_kwargs = {"host": host, "scheme": scheme,
@@ -170,7 +174,9 @@ class ProjectCacheBase(object):
             lims_credentials=lims_credentials,
             mtrain_credentials=mtrain_credentials,
             data_release_date=data_release_date,
-            app_kwargs=app_kwargs)
+            app_kwargs=app_kwargs,
+            passed_only=passed_only
+        )
         return cls(fetch_api=fetch_api, manifest=manifest, version=version,
                    cache=cache, fetch_tries=fetch_tries)
 

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/tables/experiments_table.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/tables/experiments_table.py
@@ -64,7 +64,3 @@ class ExperimentsTable(ProjectTable, OphysMixin):
         self._df = add_experience_level_to_experiment_table(self._df)
         self._df = add_passive_flag_to_ophys_experiment_table(self._df)
         self._df = add_image_set_to_experiment_table(self._df)
-
-        if self._passed_only:
-            self._df = self._df.query("experiment_workflow_state=='passed'")
-            self._df = self._df.query("container_workflow_state=='published'")

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/tables/ophys_mixin.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/tables/ophys_mixin.py
@@ -11,9 +11,3 @@ class OphysMixin:
             self._df = self._df.drop(
                 ['date_of_acquisition_behavior',
                  'date_of_acquisition_ophys'], axis=1)
-
-            self._df['session_type'] = \
-                self._df['session_type_ophys']
-            self._df = self._df.drop(
-                ['session_type_behavior',
-                 'session_type_ophys'], axis=1)

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/tables/sessions_table.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/tables/sessions_table.py
@@ -82,14 +82,6 @@ class SessionsTable(ProjectTable):
             self._df = self._df.drop(['date_of_acquisition_behavior',
                                       'date_of_acquisition_ophys'], axis=1)
 
-            # Session_type appears 2 times in dataframe. Select
-            # session_type_behavior and delete the duplicates
-            self._df['session_type'] = \
-                self._df['session_type_behavior']
-            self._df = self._df.drop(
-                ['session_type_behavior',
-                 'session_type_ophys'], axis=1)
-
     def __add_session_number(self):
         """Parses session number from session type and and adds to dataframe"""
 

--- a/allensdk/internal/api/queries/utils.py
+++ b/allensdk/internal/api/queries/utils.py
@@ -56,6 +56,15 @@ def build_in_list_selector_query(
     return session_query
 
 
+def build_where_clause(clauses: List[str]):
+    if not clauses:
+        return ''
+    where_clause = ' AND '.join(clauses)
+    if not where_clause[:5].lower() == 'where':
+        where_clause = f'WHERE {where_clause}'
+    return where_clause
+
+
 def _sanitize_uuid_list(uuid_list: List[str]) -> List[str]:
     """
     Loop over a list of strings, removing any that cannot be cast

--- a/allensdk/test/test_lims_queries.py
+++ b/allensdk/test/test_lims_queries.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from allensdk.internal.api.queries.utils import (
     build_in_list_selector_query,
-    _sanitize_uuid_list)
+    _sanitize_uuid_list, build_where_clause)
 
 from allensdk.internal.api.queries.behavior_lims_queries import (
     foraging_id_map_from_behavior_session_id)
@@ -50,6 +50,19 @@ def test_build_in_selector_error():
             valid_list=[1, 2, 3],
             operator='above',
             valid=True)
+
+
+@pytest.mark.parametrize('clauses, expected', [
+    (['foo=b', 'baz=a'], 'WHERE foo=b AND baz=a'),
+    (['WHERE foo=b and baz=c'], 'WHERE foo=b and baz=c'),
+    (['foo=b', 'baz=a', 'bar=c'], 'WHERE foo=b AND baz=a AND bar=c'),
+    (['WHERE foo=b', 'baz=a'], 'WHERE foo=b AND baz=a'),
+    (['where foo=b', 'baz=a'], 'where foo=b AND baz=a'),
+    ([], ''),
+    (['foo=b'], 'WHERE foo=b')
+])
+def test_build_where_clause(clauses, expected):
+    assert build_where_clause(clauses=clauses) == expected
 
 
 class MockQueryEngine:


### PR DESCRIPTION
Addresses #2242 

The issue was that ophys cells table did not filter by passed only, so it was returning more experiments than in the ophys experiments table. 

- Adds passed_only arg to class constructor rather than in instance methods since `passed_only` applies to all table the class returns
- ophys_cells_table now supports passed_only flag
- cleans up logic to filter by passed only in sql rather than in python
- only pulls session type from pkl file, not from DB, in order to cleanup logic