### PR TITLE
bugfix: use mask instead of image to set nan pixels

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -87,7 +87,7 @@ jobs:
                   /bin/bash -c "pip install -r requirements.txt; \
                                 pip install -r test_requirements.txt; \
                                 python -m pytest \
-                                    --log-level=WARNING \
+                                    --log-level=INFO \
                                     --capture=no \
                                     --cov=allensdk \
                                     --cov-config coveragerc \

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -87,6 +87,7 @@ jobs:
                   /bin/bash -c "pip install -r requirements.txt; \
                                 pip install -r test_requirements.txt; \
                                 python -m pytest \
+                                    --log-level=WARNING \
                                     --capture=no \
                                     --cov=allensdk \
                                     --cov-config coveragerc \

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -93,5 +93,5 @@ jobs:
                                     --cov-report html \
                                     --junitxml=test-reports/test.xml \
                                     --boxed \
-                                    --numprocesses 4 \
+                                    --numprocesses auto \
                                     --durations=0"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
                                 pip install -r test_requirements.txt; \
                                 pip install -e .; \
                                 python -m pytest \
-                                    --log-level=WARNING \
+                                    --log-level=INFO \
                                     --capture=no \
                                     --cov=allensdk \
                                     --cov-config coveragerc \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,11 +29,12 @@ jobs:
                                 pip install -r test_requirements.txt; \
                                 pip install -e .; \
                                 python -m pytest \
+                                    --log-level=WARNING \
                                     --capture=no \
                                     --cov=allensdk \
                                     --cov-config coveragerc \
                                     --cov-report html \
                                     --junitxml=test-reports/test.xml \
                                     --boxed \
-                                    --numprocesses 4 \
+                                    --numprocesses auto \
                                     --durations=0"

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/stimulus_templates.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/stimulus_templates.py
@@ -75,7 +75,7 @@ class StimulusImageFactory:
         mask = self._monitor.get_mask()
         arr = arr.astype(np.float)
         arr *= mask
-        arr[arr == 0] = np.nan
+        arr[mask == 0] = np.nan
         return arr
 
     def _warp(self, arr: np.ndarray) -> np.ndarray:

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_lims_api.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_lims_api.py
@@ -241,6 +241,10 @@ class TestLimsCloudConsistency:
 
         from_s3 = self.cloud_cache.get_behavior_session_table()
         from_s3 = from_s3.drop(columns=['file_id', 'isilon_filepath'])
+
+        from_lims = from_lims.sort_index()
+        from_s3 = from_s3.sort_index()
+
         pd.testing.assert_frame_equal(from_lims, from_s3)
 
     @pytest.mark.requires_bamboo
@@ -253,6 +257,10 @@ class TestLimsCloudConsistency:
         from_lims = from_lims.drop(columns=list(SESSION_SUPPRESS))
 
         from_s3 = self.cloud_cache.get_ophys_session_table()
+
+        from_lims = from_lims.sort_index()
+        from_s3 = from_s3.sort_index()
+
         pd.testing.assert_frame_equal(from_lims, from_s3)
 
     @pytest.mark.requires_bamboo
@@ -268,4 +276,7 @@ class TestLimsCloudConsistency:
 
         from_s3 = self.cloud_cache.get_ophys_experiment_table()
         from_s3 = from_s3.drop(columns=['file_id', 'isilon_filepath'])
+
+        from_lims = from_lims.sort_index()
+        from_s3 = from_s3.sort_index()
         pd.testing.assert_frame_equal(from_lims, from_s3)

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_metadata_writer.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_metadata_writer.py
@@ -93,10 +93,10 @@ class TestVBO:
             self.project_table_writer._write_ophys_sessions()
             obtained = pd.read_csv(Path(self.test_dir.name) /
                                    'ophys_session_table.csv')
-            obtained = obtained.sort_values('behavior_session_id')\
+            obtained = obtained.sort_values('ophys_session_id')\
                 .reset_index(drop=True)
-            expected = self.expected_behavior_sessions_table\
-                .sort_values('behavior_session_id')\
+            expected = self.expected_ophys_sessions_table\
+                .sort_values('ophys_session_id')\
                 .reset_index(drop=True)
             pd.testing.assert_frame_equal(
                 obtained, expected)
@@ -109,10 +109,10 @@ class TestVBO:
             self.project_table_writer._write_ophys_experiments()
             obtained = pd.read_csv(Path(self.test_dir.name) /
                                    'ophys_experiment_table.csv')
-            obtained = obtained.sort_values('behavior_session_id')\
+            obtained = obtained.sort_values('ophys_experiment_id')\
                 .reset_index(drop=True)
-            expected = self.expected_behavior_sessions_table\
-                .sort_values('behavior_session_id')\
+            expected = self.expected_ophys_experiments_table\
+                .sort_values('ophys_experiment_id')\
                 .reset_index(drop=True)
             pd.testing.assert_frame_equal(
                 obtained, expected)

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_metadata_writer.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_metadata_writer.py
@@ -77,8 +77,13 @@ class TestVBO:
             self.project_table_writer._write_behavior_sessions()
             obtained = pd.read_csv(Path(self.test_dir.name) /
                                    'behavior_session_table.csv')
+            obtained = obtained.sort_values('behavior_session_id')\
+                .reset_index(drop=True)
+            expected = self.expected_behavior_sessions_table\
+                .sort_values('behavior_session_id')\
+                .reset_index(drop=True)
             pd.testing.assert_frame_equal(
-                obtained, self.expected_behavior_sessions_table)
+                obtained, expected)
 
     @pytest.mark.requires_bamboo
     def test_get_ophys_sessions_table(self):
@@ -88,8 +93,13 @@ class TestVBO:
             self.project_table_writer._write_ophys_sessions()
             obtained = pd.read_csv(Path(self.test_dir.name) /
                                    'ophys_session_table.csv')
+            obtained = obtained.sort_values('behavior_session_id')\
+                .reset_index(drop=True)
+            expected = self.expected_behavior_sessions_table\
+                .sort_values('behavior_session_id')\
+                .reset_index(drop=True)
             pd.testing.assert_frame_equal(
-                obtained, self.expected_ophys_sessions_table)
+                obtained, expected)
 
     @pytest.mark.requires_bamboo
     def test_get_ophys_experiments_table(self):
@@ -99,8 +109,13 @@ class TestVBO:
             self.project_table_writer._write_ophys_experiments()
             obtained = pd.read_csv(Path(self.test_dir.name) /
                                    'ophys_experiment_table.csv')
+            obtained = obtained.sort_values('behavior_session_id')\
+                .reset_index(drop=True)
+            expected = self.expected_behavior_sessions_table\
+                .sort_values('behavior_session_id')\
+                .reset_index(drop=True)
             pd.testing.assert_frame_equal(
-                obtained, self.expected_ophys_experiments_table)
+                obtained, expected)
 
     @pytest.mark.requires_bamboo
     def test_get_ophys_cells_table(self):

--- a/allensdk/test/brain_observatory/behavior/data_objects/metadata/behavior_metadata/test_behavior_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/metadata/behavior_metadata/test_behavior_metadata.py
@@ -301,7 +301,8 @@ class TestNWB(BehaviorMetaTestCase):
         self.nwbfile = pynwb.NWBFile(
             session_description='asession',
             identifier='afile',
-            session_start_time=datetime.datetime(2022, 8, 24, 12, 35)
+            session_start_time=datetime.datetime(2022, 8, 24, 12, 35,
+                                                 tzinfo=pytz.UTC)
         )
 
     @pytest.mark.parametrize('roundtrip', [True, False])

--- a/allensdk/test/brain_observatory/behavior/data_objects/metadata/test_behavior_ophys_metadata.py
+++ b/allensdk/test/brain_observatory/behavior/data_objects/metadata/test_behavior_ophys_metadata.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import pynwb
 import pytest
+import pytz
 
 from allensdk.brain_observatory.behavior.data_objects.metadata\
     .behavior_metadata.equipment import \
@@ -175,7 +176,8 @@ class TestNWB(TestBOM):
         self.nwbfile = pynwb.NWBFile(
             session_description='asession',
             identifier=str(self.meta.ophys_metadata.ophys_experiment_id),
-            session_start_time=datetime.datetime(2022, 8, 24, 12, 35)
+            session_start_time=datetime.datetime(2022, 8, 24, 12, 35,
+                                                 tzinfo=pytz.UTC)
         )
 
     @pytest.mark.parametrize('meso', [True, False])


### PR DESCRIPTION
#2516 

The issue was that the image was being used to set nan pixels, but if the image contains pixels exactly equal to 0, then they will be set to nan as well. So use the mask instead.

In addition:
- update tests which started failing
- change pytest settings to use all available cores (didn't actually speed up tests) and using info log level rather than debug