### PR TITLE
Ticket-2566

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py
+++ b/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py
@@ -100,8 +100,7 @@ class BehaviorOphysExperiment(BehaviorSession):
                   eye_tracking_dilation_frames: int = 2,
                   events_filter_scale_seconds: float = 2.0/31.0,
                   events_filter_n_time_steps: int = 20,
-                  exclude_invalid_rois=True,
-                  skip_eye_tracking=False) -> \
+                  exclude_invalid_rois=True) -> \
             "BehaviorOphysExperiment":
         """
         Parameters
@@ -117,8 +116,6 @@ class BehaviorOphysExperiment(BehaviorSession):
             See `BehaviorOphysExperiment.from_nwb`
         exclude_invalid_rois
             Whether to exclude invalid rois
-        skip_eye_tracking
-            Used to skip returning eye tracking data
         """
         def _is_multi_plane_session():
             imaging_plane_group_meta = ImagingPlaneGroup.from_lims(
@@ -162,7 +159,6 @@ class BehaviorOphysExperiment(BehaviorSession):
             sync_file=sync_file,
             monitor_delay=monitor_delay,
             date_of_acquisition=date_of_acquisition,
-            skip_eye_tracking=skip_eye_tracking,
             eye_tracking_z_threshold=eye_tracking_z_threshold,
             eye_tracking_dilation_frames=eye_tracking_dilation_frames
         )
@@ -275,8 +271,7 @@ class BehaviorOphysExperiment(BehaviorSession):
                   eye_tracking_dilation_frames: int = 2,
                   events_filter_scale_seconds: float = 2.0/31.0,
                   events_filter_n_time_steps: int = 20,
-                  exclude_invalid_rois=True,
-                  skip_eye_tracking=False) -> \
+                  exclude_invalid_rois=True) -> \
             "BehaviorOphysExperiment":
         """
 
@@ -293,8 +288,6 @@ class BehaviorOphysExperiment(BehaviorSession):
             See `BehaviorOphysExperiment.from_nwb`
         exclude_invalid_rois
             Whether to exclude invalid rois
-        skip_eye_tracking
-            Used to skip returning eye tracking data
 
         """
         def _is_multi_plane_session():

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/behavior_project_cache.py
@@ -312,8 +312,7 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
 
     def get_behavior_session(
             self,
-            behavior_session_id: int,
-            skip_eye_tracking: bool = False
+            behavior_session_id: int
     ) -> BehaviorSession:
         """
         Gets `BehaviorSession` for `behavior_session_id`
@@ -321,16 +320,12 @@ class VisualBehaviorOphysProjectCache(ProjectCacheBase):
         ----------
         behavior_session_id: behavior session id
 
-        skip_eye_tracking: bool
-            if True, do not load eye tracking data for this session
-
         Returns
         -------
         BehaviorSession
         """
         return self.fetch_api.get_behavior_session(
-            behavior_session_id=behavior_session_id,
-            skip_eye_tracking=skip_eye_tracking
+            behavior_session_id=behavior_session_id
         )
 
 

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -53,8 +53,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
     def get_behavior_session(
             self,
-            behavior_session_id: int,
-            skip_eye_tracking: bool = False) -> BehaviorSession:
+            behavior_session_id: int) -> BehaviorSession:
         """get a BehaviorSession by specifying behavior_session_id
 
         Parameters
@@ -95,8 +94,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         file_id = str(int(row[self.cache.file_id_column]))
         data_path = self._get_data_path(file_id=file_id)
         return BehaviorSession.from_nwb_path(
-                nwb_path=str(data_path),
-                skip_eye_tracking=skip_eye_tracking)
+                nwb_path=str(data_path))
 
     def get_behavior_ophys_experiment(self, ophys_experiment_id: int
                                       ) -> BehaviorOphysExperiment:

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
@@ -473,18 +473,15 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
 
     def get_behavior_session(
             self,
-            behavior_session_id: int,
-            skip_eye_tracking: bool = False) -> BehaviorSession:
+            behavior_session_id: int) -> BehaviorSession:
         """Returns a BehaviorSession object that contains methods to
         analyze a single behavior session.
         :param behavior_session_id: id that corresponds to a behavior session
-        :param skip_eye_tracking: if True, do not load eye tracking data
         :type behavior_session_id: int
         :rtype: BehaviorSession
         """
         return BehaviorSession.from_lims(
-            behavior_session_id=behavior_session_id,
-            skip_eye_tracking=skip_eye_tracking)
+            behavior_session_id=behavior_session_id)
 
     def get_ophys_experiment_table(
             self

--- a/allensdk/brain_observatory/behavior/data_files/eye_tracking_file.py
+++ b/allensdk/brain_observatory/behavior/data_files/eye_tracking_file.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from allensdk.brain_observatory.behavior.eye_tracking_processing import \
     load_eye_tracking_hdf
-from allensdk.internal.api import PostgresQueryMixin
+from allensdk.internal.api import PostgresQueryMixin, OneResultExpectedError
 from allensdk.internal.core.lims_utilities import safe_system_path
 from allensdk.internal.core import DataFile
 
@@ -41,7 +41,10 @@ class EyeTrackingFile(DataFile):
                     AND wkft.name = 'EyeTracking Ellipses'
                     AND bs.id = {behavior_session_id};
                 """  # noqa E501
-        filepath = db.fetchone(query, strict=True)
+        try:
+            filepath = db.fetchone(query, strict=True)
+        except OneResultExpectedError:
+            return None
         return cls(filepath=filepath)
 
     @staticmethod

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -15,8 +15,7 @@ from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 
 def write_behavior_ophys_nwb(session_data: dict,
-                             nwb_filepath: str,
-                             skip_eye_tracking: bool):
+                             nwb_filepath: str):
 
     nwb_filepath_inprogress = nwb_filepath+'.inprogress'
     nwb_filepath_error = nwb_filepath+'.error'
@@ -30,10 +29,9 @@ def write_behavior_ophys_nwb(session_data: dict,
 
     try:
         json_session = BehaviorOphysExperiment.from_json(
-            session_data=session_data, skip_eye_tracking=skip_eye_tracking)
+            session_data=session_data)
         lims_session = BehaviorOphysExperiment.from_lims(
-            ophys_experiment_id=session_data['ophys_experiment_id'],
-            skip_eye_tracking=skip_eye_tracking)
+            ophys_experiment_id=session_data['ophys_experiment_id'])
 
         logging.info("Comparing a BehaviorOphysExperiment created from JSON "
                      "with a BehaviorOphysExperiment created from LIMS")
@@ -76,10 +74,8 @@ def main():
         raise err
 
     try:
-        skip_eye_tracking = parser.args['skip_eye_tracking']
         output = write_behavior_ophys_nwb(parser.args['session_data'],
-                                          parser.args['output_path'],
-                                          skip_eye_tracking)
+                                          parser.args['output_path'])
         logging.info('File successfully created')
     except Exception as err:
         logging.error('NWB write failure')

--- a/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/_schemas.py
@@ -133,10 +133,6 @@ class InputSchema(ArgSchema):
                                       'used for this experiment')
     output_path = String(required=True, validate=check_write_access_overwrite,
                          description='write outputs to here')
-    skip_eye_tracking = Boolean(
-        required=True, default=False,
-        description="Whether or not to skip processing eye tracking data. "
-                    "If True, no eye tracking data will be written to NWB")
 
 
 class OutputSchema(RaisingSchema):

--- a/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/behavior_ecephys_session.py
@@ -56,7 +56,6 @@ class VBNBehaviorSession(BehaviorSession):
                   sync_file: Optional[Any] = None,
                   monitor_delay: Optional[float] = None,
                   date_of_acquisition: Optional[Any] = None,
-                  skip_eye_tracking=False,
                   eye_tracking_z_threshold: float = 3.0,
                   eye_tracking_dilation_frames: int = 2) \
             -> "VBNBehaviorSession":

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_cloud_api.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_behavior_project_cloud_api.py
@@ -156,7 +156,7 @@ def test_BehaviorProjectCloudApi(mock_cache, monkeypatch, local):
 
     # get_behavior_session returns expected value
     # both directly and via experiment table
-    def mock_nwb(nwb_path, skip_eye_tracking=False):
+    def mock_nwb(nwb_path):
         return nwb_path
     monkeypatch.setattr(cloudapi.BehaviorSession, "from_nwb_path", mock_nwb)
     assert api.get_behavior_session(2) == "5"

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
@@ -143,7 +143,7 @@ def test_load_out_of_date_manifest(
     for sess_id in (333, 444):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorSession, 'from_nwb_path',
-                        lambda nwb_path, skip_eye_tracking=False:
+                        lambda nwb_path:
                             create_autospec(
                                 BehaviorSession, instance=True))
             cache.get_behavior_session(behavior_session_id=sess_id)
@@ -219,7 +219,7 @@ def test_file_linkage(
     for sess_id in (333, 444):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorSession, 'from_nwb_path',
-                        lambda nwb_path, skip_eye_tracking=False:
+                        lambda nwb_path:
                             create_autospec(
                                 BehaviorSession, instance=True))
             cache.get_behavior_session(behavior_session_id=sess_id)
@@ -250,7 +250,7 @@ def test_file_linkage(
     for sess_id in (777, 888):
         with monkeypatch.context() as ctx:
             ctx.setattr(BehaviorSession, 'from_nwb_path',
-                        lambda nwb_path, skip_eye_tracking=False:
+                        lambda nwb_path:
                             create_autospec(
                                 BehaviorSession, instance=True))
             cache.get_behavior_session(behavior_session_id=sess_id)

--- a/allensdk/test/brain_observatory/behavior/test_behavior_session.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_session.py
@@ -20,8 +20,7 @@ def test_nwb_end_to_end_session(
     tmpdir = pathlib.Path(tmpdir)
     nwb_path = tmpdir / f'session_{session_id}.nwb'
     session = BehaviorSession.from_lims(
-            behavior_session_id=session_id,
-            skip_eye_tracking=True)
+            behavior_session_id=session_id)
     nwb_file = session.to_nwb()
     with NWBHDF5IO(nwb_path, 'w') as nwb_file_writer:
         nwb_file_writer.write(nwb_file)
@@ -101,12 +100,10 @@ def test_behavior_session_list_data_attributes_and_methods(monkeypatch):
 @pytest.mark.nightly
 def test_behavior_session_equivalent_json_lims(session_data_fixture):
 
-    json_session = BehaviorSession.from_json(session_data_fixture,
-                                             skip_eye_tracking=True)
+    json_session = BehaviorSession.from_json(session_data_fixture)
 
     behavior_session_id = session_data_fixture['behavior_session_id']
-    lims_session = BehaviorSession.from_lims(behavior_session_id,
-                                             skip_eye_tracking=True)
+    lims_session = BehaviorSession.from_lims(behavior_session_id)
 
     assert sessions_are_equal(json_session, lims_session, reraise=True)
 

--- a/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
+++ b/allensdk/test/brain_observatory/behavior/test_write_nwb_behavior_ophys.py
@@ -32,7 +32,6 @@ def test_write_behavior_ophys_nwb_no_file():
         write_behavior_ophys_nwb(
             session_data=None,
             nwb_filepath='',
-            skip_eye_tracking=True
         )
 
 
@@ -74,7 +73,6 @@ def test_write_behavior_ophys_nwb_with_file(tmpdir):
             write_behavior_ophys_nwb(
                 session_data=None,
                 nwb_filepath=str(fake_nwb_fp),
-                skip_eye_tracking=True
             )
 
             # Check that the new .error file exists, and that we


### PR DESCRIPTION
Allow behavior only data to be processed without having to set `skip_eye_tracking`. Remove `skip_eye_tracking` variable as it is now superfluous.