### PR TITLE
Csd re-referencing

### DIFF
--- a/allensdk/brain_observatory/ecephys/current_source_density/__main__.py
+++ b/allensdk/brain_observatory/ecephys/current_source_density/__main__.py
@@ -37,6 +37,9 @@ from allensdk.brain_observatory.argschema_utilities import (
     write_or_print_outputs, optional_lims_inputs
 )
 
+from allensdk.brain_observatory.ecephys.lfp_subsampling.subsampling \
+    import remove_lfp_noise
+
 
 def get_inputs_from_lims(args) -> dict:
 
@@ -123,10 +126,12 @@ def run_csd(args: dict) -> dict:
         else:
             lfp_channels = np.arange(0, probe['total_channels'])
 
+        lfp_referenced = remove_lfp_noise(lfp_raw, probe['surface_channel'], lfp_channels)
+
         logging.info('Accumulating LFP data')
         accumulated_lfp_data = accumulate_lfp_data(
             timestamps=timestamps,
-            lfp_raw=lfp_raw,
+            lfp_raw=lfp_referenced,
             lfp_channels=lfp_channels,
             trial_windows=trial_windows,
             volts_per_bit=args['volts_per_bit']

--- a/allensdk/brain_observatory/ecephys/lfp_subsampling/subsampling.py
+++ b/allensdk/brain_observatory/ecephys/lfp_subsampling/subsampling.py
@@ -203,7 +203,8 @@ def remove_lfp_offset(lfp, sampling_frequency, cutoff_frequency, filter_order):
     return lfp_filtered
 
 
-def remove_lfp_noise(lfp, surface_channel, channel_numbers, channel_max=384, channel_limit=380):
+def remove_lfp_noise(lfp, surface_channel, channel_numbers, channel_max=384, 
+                    channel_limit=380, max_out_of_brain_channels=50):
     """
     Subtract mean of channels out of brain to remove noise
 
@@ -229,7 +230,9 @@ def remove_lfp_noise(lfp, surface_channel, channel_numbers, channel_max=384, cha
     surface_channel = channel_limit if surface_channel >= channel_max else surface_channel
 
     channel_selection = np.where(channel_numbers > surface_channel)[0]
-
+    if len(channel_selection)>max_out_of_brain_channels:
+        channel_selection = channel_selection[:max_out_of_brain_channels]
+    
     median_signal_out_of_brain = np.median(lfp[:, channel_selection], 1)
 
     for ch in range(lfp.shape[1]):

--- a/allensdk/brain_observatory/ecephys/lfp_subsampling/subsampling.py
+++ b/allensdk/brain_observatory/ecephys/lfp_subsampling/subsampling.py
@@ -217,6 +217,10 @@ def remove_lfp_noise(lfp, surface_channel, channel_numbers, channel_max=384,
         Surface channel (relative to original probe)
     channel_numbers : numpy.ndarray
         Channel numbers in 'lfp' array (relative to original probe)
+    max_out_of_brain_channels: int
+        Max number of channels to take above the surface channel
+        for re-referencing
+
 
     Returns:
 


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
The ecephys CSD module is incorrectly flagging channels as 'noise' and removing them before computing the CSD. This noise actually reflects signal at the tip reference that isn't getting removed before the noise filter is applied. This PR addresses this issue by re-referencing the LFP to the agar channels before computing the CSD. 

There is also a minor fix to the re-referencing function. This function was re-referencing to all channels above the surface channel. This can sometimes fail for experiments with shallow probe insertions as the uppermost channels are in air and not agar. I have modified this function to place a limit on the number of channels to use for re-referencing.

# Type of Fix:
<!--Chose One-->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
- re-reference LFP before determining noisy channels for exclusion
- add channel limit to re-referencing function