### PR TITLE
Ticket/2594/dev

### DIFF
--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -1,20 +1,22 @@
 import pandas as pd
 from typing import Iterable
 
-from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.abcs import BehaviorProjectBase  # noqa: E501
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.abcs import (  # noqa: E501
+    BehaviorProjectBase,
+)
 from allensdk.brain_observatory.behavior.behavior_session import (
-    BehaviorSession)
+    BehaviorSession,
+)
 from allensdk.brain_observatory.behavior.behavior_ophys_experiment import (
-    BehaviorOphysExperiment)
-from allensdk.brain_observatory.behavior.swdb.utilities import literal_col_eval
-from allensdk.brain_observatory.behavior.behavior_project_cache.\
-    project_apis.data_io.project_cloud_api_base import ProjectCloudApiBase  # noqa: E501
+    BehaviorOphysExperiment,
+)
+from allensdk.core.utilities import literal_col_eval
+from allensdk.brain_observatory.behavior.behavior_project_cache.project_apis.data_io.project_cloud_api_base import (  # noqa: E501
+    ProjectCloudApiBase,
+)
 
+COL_EVAL_LIST = ["ophys_experiment_id", "ophys_container_id", "driver_line"]
 
-
-COL_EVAL_LIST = ["ophys_experiment_id",
-                    "ophys_container_id",
-                    "driver_line"]
 
 class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
@@ -22,17 +24,23 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
     def _load_manifest_tables(self):
 
-        expected_metadata = set(["behavior_session_table",
-                                 "ophys_session_table",
-                                 "ophys_experiment_table",
-                                 "ophys_cells_table"])
+        expected_metadata = set(
+            [
+                "behavior_session_table",
+                "ophys_session_table",
+                "ophys_experiment_table",
+                "ophys_cells_table",
+            ]
+        )
 
         cache_metadata = set(self.cache._manifest.metadata_file_names)
 
         if cache_metadata != expected_metadata:
-            raise RuntimeError("expected S3CloudCache object to have "
-                               f"metadata file names: {expected_metadata} "
-                               f"but it has {cache_metadata}")
+            raise RuntimeError(
+                "expected S3CloudCache object to have "
+                f"metadata file names: {expected_metadata} "
+                f"but it has {cache_metadata}"
+            )
 
         self._get_ophys_session_table()
         self._get_behavior_session_table()
@@ -40,8 +48,8 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         self._get_ophys_cells_table()
 
     def get_behavior_session(
-            self,
-            behavior_session_id: int) -> BehaviorSession:
+        self, behavior_session_id: int
+    ) -> BehaviorSession:
         """get a BehaviorSession by specifying behavior_session_id
 
         Parameters
@@ -67,13 +75,16 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
         """
         row = self._behavior_session_table.query(
-                f"behavior_session_id=={behavior_session_id}")
+            f"behavior_session_id=={behavior_session_id}"
+        )
         if row.shape[0] != 1:
-            raise RuntimeError("The behavior_session_table should have "
-                               "1 and only 1 entry for a given "
-                               "behavior_session_id. For "
-                               f"{behavior_session_id} "
-                               f" there are {row.shape[0]} entries.")
+            raise RuntimeError(
+                "The behavior_session_table should have "
+                "1 and only 1 entry for a given "
+                "behavior_session_id. For "
+                f"{behavior_session_id} "
+                f" there are {row.shape[0]} entries."
+            )
         row = row.squeeze()
         has_file_id = not pd.isna(row[self.cache.file_id_column])
         if not has_file_id:
@@ -81,11 +92,11 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
             row = self._ophys_experiment_table.query(f"index=={oeid}")
         file_id = str(int(row[self.cache.file_id_column]))
         data_path = self._get_data_path(file_id=file_id)
-        return BehaviorSession.from_nwb_path(
-                nwb_path=str(data_path))
+        return BehaviorSession.from_nwb_path(nwb_path=str(data_path))
 
-    def get_behavior_ophys_experiment(self, ophys_experiment_id: int
-                                      ) -> BehaviorOphysExperiment:
+    def get_behavior_ophys_experiment(
+        self, ophys_experiment_id: int
+    ) -> BehaviorOphysExperiment:
         """get a BehaviorOphysExperiment by specifying ophys_experiment_id
 
         Parameters
@@ -99,25 +110,29 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
         """
         row = self._ophys_experiment_table.query(
-                f"index=={ophys_experiment_id}")
+            f"index=={ophys_experiment_id}"
+        )
         if row.shape[0] != 1:
-            raise RuntimeError("The behavior_ophys_experiment_table should "
-                               "have 1 and only 1 entry for a given "
-                               f"ophys_experiment_id. For "
-                               f"{ophys_experiment_id} "
-                               f" there are {row.shape[0]} entries.")
+            raise RuntimeError(
+                "The behavior_ophys_experiment_table should "
+                "have 1 and only 1 entry for a given "
+                f"ophys_experiment_id. For "
+                f"{ophys_experiment_id} "
+                f" there are {row.shape[0]} entries."
+            )
         file_id = str(int(row[self.cache.file_id_column]))
         data_path = self._get_data_path(file_id=file_id)
-        return BehaviorOphysExperiment.from_nwb_path(
-            str(data_path))
+        return BehaviorOphysExperiment.from_nwb_path(str(data_path))
 
     def _get_ophys_session_table(self):
         session_table_path = self._get_metadata_path(
-            fname="ophys_session_table")
-        df = literal_col_eval(pd.read_csv(session_table_path,
-                                          dtype={'mouse_id': str}),
-                                          columns=COL_EVAL_LIST)
-        df['date_of_acquisition'] = pd.to_datetime(df['date_of_acquisition'])
+            fname="ophys_session_table"
+        )
+        df = literal_col_eval(
+            pd.read_csv(session_table_path, dtype={"mouse_id": str}),
+            columns=COL_EVAL_LIST,
+        )
+        df["date_of_acquisition"] = pd.to_datetime(df["date_of_acquisition"])
         self._ophys_session_table = df.set_index("ophys_session_id")
 
     def get_ophys_session_table(self) -> pd.DataFrame:
@@ -135,11 +150,13 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
     def _get_behavior_session_table(self):
         session_table_path = self._get_metadata_path(
-            fname='behavior_session_table')
-        df = literal_col_eval(pd.read_csv(session_table_path,
-                                          dtype={'mouse_id': str}),
-                                          columns=COL_EVAL_LIST)
-        df['date_of_acquisition'] = pd.to_datetime(df['date_of_acquisition'])
+            fname="behavior_session_table"
+        )
+        df = literal_col_eval(
+            pd.read_csv(session_table_path, dtype={"mouse_id": str}),
+            columns=COL_EVAL_LIST,
+        )
+        df["date_of_acquisition"] = pd.to_datetime(df["date_of_acquisition"])
 
         self._behavior_session_table = df.set_index("behavior_session_id")
 
@@ -162,22 +179,27 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
 
     def _get_ophys_experiment_table(self):
         experiment_table_path = self._get_metadata_path(
-            fname="ophys_experiment_table")
-        df = literal_col_eval(pd.read_csv(experiment_table_path,
-                                          dtype={'mouse_id': str}),
-                                          columns=COL_EVAL_LIST)
-        df['date_of_acquisition'] = pd.to_datetime(df['date_of_acquisition'])
+            fname="ophys_experiment_table"
+        )
+        df = literal_col_eval(
+            pd.read_csv(experiment_table_path, dtype={"mouse_id": str}),
+            columns=COL_EVAL_LIST,
+        )
+        df["date_of_acquisition"] = pd.to_datetime(df["date_of_acquisition"])
 
         self._ophys_experiment_table = df.set_index("ophys_experiment_id")
 
     def _get_ophys_cells_table(self):
         ophys_cells_table_path = self._get_metadata_path(
-            fname="ophys_cells_table")
-        df = literal_col_eval(pd.read_csv(ophys_cells_table_path),
-                                columns=COL_EVAL_LIST)
+            fname="ophys_cells_table"
+        )
+        df = literal_col_eval(
+            pd.read_csv(ophys_cells_table_path), columns=COL_EVAL_LIST
+        )
         # NaN's for invalid cells force this to float, push to int
-        df['cell_specimen_id'] = pd.array(df['cell_specimen_id'],
-                                          dtype="Int64")
+        df["cell_specimen_id"] = pd.array(
+            df["cell_specimen_id"], dtype="Int64"
+        )
         self._ophys_cells_table = df.set_index("cell_roi_id")
 
     def get_ophys_cells_table(self):
@@ -197,7 +219,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         return self._ophys_experiment_table
 
     def get_natural_movie_template(self, number: int) -> Iterable[bytes]:
-        """ Download a template for the natural movie stimulus. This is the
+        """Download a template for the natural movie stimulus. This is the
         actual movie that was shown during the recording session.
         :param number: identifier for this scene
         :type number: int

--- a/allensdk/brain_observatory/behavior/swdb/utilities.py
+++ b/allensdk/brain_observatory/behavior/swdb/utilities.py
@@ -3,8 +3,6 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 import matplotlib as mpl
-from typing import List
-import ast
 
 '''
     This file contains a set of functions that are useful in analyzing visual behavior data
@@ -19,11 +17,9 @@ def save_figure(fig, figsize, save_dir, folder, filename, formats=['.png']):
         fig: a figure object
         figsize: tuple of desired figure size
         save_dir: string, the directory to save the figure
-        folder: string, the sub-folder to save the figure in. if the
-        folder does not exist, it will be created
+        folder: string, the sub-folder to save the figure in. if the folder does not exist, it will be created
         filename: string, the desired name of the saved figure
-        formats: a list of file formats as strings to save the figure
-        as, ex: ['.png','.pdf']
+        formats: a list of file formats as strings to save the figure as, ex: ['.png','.pdf']
     '''
     fig_dir = os.path.join(save_dir, folder)
     if not os.path.exists(fig_dir):
@@ -31,10 +27,7 @@ def save_figure(fig, figsize, save_dir, folder, filename, formats=['.png']):
     mpl.rcParams['pdf.fonttype'] = 42
     fig.set_size_inches(figsize)
     for f in formats:
-        fig.savefig(
-            os.path.join(fig_dir, fig_title + f),
-            transparent=True,
-            orientation='landscape')
+        fig.savefig(os.path.join(fig_dir, fig_title + f), transparent=True, orientation='landscape')
 
 
 def get_dff_matrix(session):
@@ -53,15 +46,11 @@ def get_dff_matrix(session):
 
 def get_mean_df(response_df, conditions=['cell_specimen_id', 'image_name']):
     '''
-        Computes an analysis on a selection of responses (either flashes
-        or trials). Computes mean_response, sem_response, the pref_stim,
-        fraction_active_responses.
+        Computes an analysis on a selection of responses (either flashes or trials). Computes mean_response, sem_response, the pref_stim, fraction_active_responses.
 
         INPUTS
         response_df: the dataframe to group
-        conditions: the conditions to group by, the first entry should be
-        'cell_specimen_id', the second could be 'image_name' or
-        'change_image_name'
+        conditions: the conditions to group by, the first entry should be 'cell_specimen_id', the second could be 'image_name' or 'change_image_name'
 
         OUTPUTS:
         mdf: a dataframe with the following columns:
@@ -69,22 +58,15 @@ def get_mean_df(response_df, conditions=['cell_specimen_id', 'image_name']):
             sem_response: the sem of the mean_response
             mean_trace: the average dff trace for each condition
             sem_trace: the sem of the mean_trace
-            mean_responses: the list of mean_responses for each element
-                of each group
-            pref_stim: if conditions includes image_name or
-                change_image_name, sets a boolean column for whether
-                that was the cell's preferred stimulus
-            fraction_significant_responses: the fraction of
-                individual image presentations or trials that were
-                significant (p_value > 0.05)
+            mean_responses: the list of mean_responses for each element of each group
+            pref_stim: if conditions includes image_name or change_image_name, sets a boolean column for whether that was the cell's preferred stimulus
+            fraction_significant_responses: the fraction of individual image presentations or trials that were significant (p_value > 0.05)
     '''
 
     # Group by conditions
     rdf = response_df.copy()
     mdf = rdf.groupby(conditions).apply(get_mean_sem_trace)
-    mdf = mdf[
-        ['mean_response', 'sem_response', 'mean_trace', 
-            'sem_trace', 'mean_responses']]
+    mdf = mdf[['mean_response', 'sem_response', 'mean_trace', 'sem_trace', 'mean_responses']]
     mdf = mdf.reset_index()
 
     # Add preferred stimulus if we can
@@ -109,8 +91,7 @@ def get_mean_sem_trace(group):
         group: a pandas groupby object
         
         OUTPUT:
-        a pandas series with the mean_response, sem_response,
-        mean_trace, sem_trace, and mean_responses computed for the group. 
+        a pandas series with the mean_response, sem_response, mean_trace, sem_trace, and mean_responses computed for the group. 
     '''
     mean_response = np.mean(group['mean_response'])
     mean_responses = group['mean_response'].values
@@ -124,18 +105,13 @@ def get_mean_sem_trace(group):
 
 def annotate_mean_df_with_pref_stim(mean_df):
     '''
-        Computes the preferred stimulus for each cell/trial or
-        cell/flash combination. Preferred image is computed by seeing
-        which image evoked the largest average mean_response across
-        all images. 
+        Computes the preferred stimulus for each cell/trial or cell/flash combination. Preferred image is computed by seeing which image evoked the largest average mean_response across all images. 
 
         INPUTS:
         mean_df: the mean_df to be annotated
 
         OUTPUTS:
-        mean_df with a new column appended 'pref_stim' which is a
-        boolean TRUE/FALSE for whether that image was that cell's
-        preferred image.
+        mean_df with a new column appended 'pref_stim' which is a boolean TRUE/FALSE for whether that image was that cell's preferred image.
        
         ASSERTS:
         Each cell has one unique preferred stimulus 
@@ -155,13 +131,10 @@ def annotate_mean_df_with_pref_stim(mean_df):
     for cell in mdf['cell_specimen_id'].unique():
         mc = mdf[(mdf['cell_specimen_id'] == cell)]
         mc = mc[mc[image_name] != 'omitted']
-        temp = mc[
-            (mc.mean_response == np.max(mc.mean_response.values))
-            ][image_name].values
+        temp = mc[(mc.mean_response == np.max(mc.mean_response.values))][image_name].values
         if len(temp) > 0:  # need this test if the mean_response was nan
             pref_image = temp[0]
-            # PROBLEM, this is slow, and sets on slice,
-            # better to use mdf.at[test, 'pref_stim']
+            # PROBLEM, this is slow, and sets on slice, better to use mdf.at[test, 'pref_stim']
             row = mdf[(mdf['cell_specimen_id'] == cell) & (mdf[image_name] == pref_image)].index
             mdf.loc[row, 'pref_stim'] = True
 
@@ -382,41 +355,11 @@ def get_active_cell_indices(dff_traces):
 
 
 def compute_lifetime_sparseness(image_responses):
-    # image responses should be an array of the trial averaged responses
-    # to each image
-    # sparseness = 1-(sum of trial averaged responses to images / N)squared /
-    # (sum of (squared mean responses / n)) / (1-(1/N))
+    # image responses should be an array of the trial averaged responses to each image
+    # sparseness = 1-(sum of trial averaged responses to images / N)squared / (sum of (squared mean responses / n)) / (1-(1/N))
     # N = number of images
     # after Vinje & Gallant, 2000; Froudarakis et al., 2014
     N = float(len(image_responses))
-    ls = ((1 - (1 / N) * ((np.power(image_responses.sum(axis=0), 2)) /
-     (np.power(image_responses, 2).sum(axis=0)))) / (
+    ls = ((1 - (1 / N) * ((np.power(image_responses.sum(axis=0), 2)) / (np.power(image_responses, 2).sum(axis=0)))) / (
         1 - (1 / N)))
     return ls
-
-def literal_col_eval(df: pd.DataFrame,
-                     columns: List[str]) -> pd.DataFrame:
-    ''' Eval string entries of specified columns 
-    '''
-
-    for column in columns:
-        if column in df.columns:
-            df.loc[df[column].notnull(), column] = \
-                df[column][df[column].notnull()].apply(
-                    lambda x: ast.literal_eval(x) if isinstance(x, str) else x
-                )
-    return df
-
-
-def df_list_to_tuple(df: pd.DataFrame,
-                     columns: List[str]) -> pd.DataFrame:
-    ''' convert list to tuple 
-    '''
-
-    for column in columns:
-        if column in df.columns:
-            df.loc[df[column].notnull(), column] = \
-                df[column][df[column].notnull()].apply(
-                    lambda x: tuple(x) if isinstance(x, list) else x
-                )
-    return df

--- a/allensdk/brain_observatory/behavior/swdb/utilities.py
+++ b/allensdk/brain_observatory/behavior/swdb/utilities.py
@@ -3,6 +3,8 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 import matplotlib as mpl
+from typing import List
+import ast
 
 '''
     This file contains a set of functions that are useful in analyzing visual behavior data
@@ -17,9 +19,11 @@ def save_figure(fig, figsize, save_dir, folder, filename, formats=['.png']):
         fig: a figure object
         figsize: tuple of desired figure size
         save_dir: string, the directory to save the figure
-        folder: string, the sub-folder to save the figure in. if the folder does not exist, it will be created
+        folder: string, the sub-folder to save the figure in. if the
+        folder does not exist, it will be created
         filename: string, the desired name of the saved figure
-        formats: a list of file formats as strings to save the figure as, ex: ['.png','.pdf']
+        formats: a list of file formats as strings to save the figure
+        as, ex: ['.png','.pdf']
     '''
     fig_dir = os.path.join(save_dir, folder)
     if not os.path.exists(fig_dir):
@@ -27,7 +31,10 @@ def save_figure(fig, figsize, save_dir, folder, filename, formats=['.png']):
     mpl.rcParams['pdf.fonttype'] = 42
     fig.set_size_inches(figsize)
     for f in formats:
-        fig.savefig(os.path.join(fig_dir, fig_title + f), transparent=True, orientation='landscape')
+        fig.savefig(
+            os.path.join(fig_dir, fig_title + f),
+            transparent=True,
+            orientation='landscape')
 
 
 def get_dff_matrix(session):
@@ -46,11 +53,15 @@ def get_dff_matrix(session):
 
 def get_mean_df(response_df, conditions=['cell_specimen_id', 'image_name']):
     '''
-        Computes an analysis on a selection of responses (either flashes or trials). Computes mean_response, sem_response, the pref_stim, fraction_active_responses.
+        Computes an analysis on a selection of responses (either flashes
+        or trials). Computes mean_response, sem_response, the pref_stim,
+        fraction_active_responses.
 
         INPUTS
         response_df: the dataframe to group
-        conditions: the conditions to group by, the first entry should be 'cell_specimen_id', the second could be 'image_name' or 'change_image_name'
+        conditions: the conditions to group by, the first entry should be
+        'cell_specimen_id', the second could be 'image_name' or
+        'change_image_name'
 
         OUTPUTS:
         mdf: a dataframe with the following columns:
@@ -58,15 +69,22 @@ def get_mean_df(response_df, conditions=['cell_specimen_id', 'image_name']):
             sem_response: the sem of the mean_response
             mean_trace: the average dff trace for each condition
             sem_trace: the sem of the mean_trace
-            mean_responses: the list of mean_responses for each element of each group
-            pref_stim: if conditions includes image_name or change_image_name, sets a boolean column for whether that was the cell's preferred stimulus
-            fraction_significant_responses: the fraction of individual image presentations or trials that were significant (p_value > 0.05)
+            mean_responses: the list of mean_responses for each element
+                of each group
+            pref_stim: if conditions includes image_name or
+                change_image_name, sets a boolean column for whether
+                that was the cell's preferred stimulus
+            fraction_significant_responses: the fraction of
+                individual image presentations or trials that were
+                significant (p_value > 0.05)
     '''
 
     # Group by conditions
     rdf = response_df.copy()
     mdf = rdf.groupby(conditions).apply(get_mean_sem_trace)
-    mdf = mdf[['mean_response', 'sem_response', 'mean_trace', 'sem_trace', 'mean_responses']]
+    mdf = mdf[
+        ['mean_response', 'sem_response', 'mean_trace', 
+            'sem_trace', 'mean_responses']]
     mdf = mdf.reset_index()
 
     # Add preferred stimulus if we can
@@ -91,7 +109,8 @@ def get_mean_sem_trace(group):
         group: a pandas groupby object
         
         OUTPUT:
-        a pandas series with the mean_response, sem_response, mean_trace, sem_trace, and mean_responses computed for the group. 
+        a pandas series with the mean_response, sem_response,
+        mean_trace, sem_trace, and mean_responses computed for the group. 
     '''
     mean_response = np.mean(group['mean_response'])
     mean_responses = group['mean_response'].values
@@ -105,13 +124,18 @@ def get_mean_sem_trace(group):
 
 def annotate_mean_df_with_pref_stim(mean_df):
     '''
-        Computes the preferred stimulus for each cell/trial or cell/flash combination. Preferred image is computed by seeing which image evoked the largest average mean_response across all images. 
+        Computes the preferred stimulus for each cell/trial or
+        cell/flash combination. Preferred image is computed by seeing
+        which image evoked the largest average mean_response across
+        all images. 
 
         INPUTS:
         mean_df: the mean_df to be annotated
 
         OUTPUTS:
-        mean_df with a new column appended 'pref_stim' which is a boolean TRUE/FALSE for whether that image was that cell's preferred image.
+        mean_df with a new column appended 'pref_stim' which is a
+        boolean TRUE/FALSE for whether that image was that cell's
+        preferred image.
        
         ASSERTS:
         Each cell has one unique preferred stimulus 
@@ -131,10 +155,13 @@ def annotate_mean_df_with_pref_stim(mean_df):
     for cell in mdf['cell_specimen_id'].unique():
         mc = mdf[(mdf['cell_specimen_id'] == cell)]
         mc = mc[mc[image_name] != 'omitted']
-        temp = mc[(mc.mean_response == np.max(mc.mean_response.values))][image_name].values
+        temp = mc[
+            (mc.mean_response == np.max(mc.mean_response.values))
+            ][image_name].values
         if len(temp) > 0:  # need this test if the mean_response was nan
             pref_image = temp[0]
-            # PROBLEM, this is slow, and sets on slice, better to use mdf.at[test, 'pref_stim']
+            # PROBLEM, this is slow, and sets on slice,
+            # better to use mdf.at[test, 'pref_stim']
             row = mdf[(mdf['cell_specimen_id'] == cell) & (mdf[image_name] == pref_image)].index
             mdf.loc[row, 'pref_stim'] = True
 
@@ -355,11 +382,41 @@ def get_active_cell_indices(dff_traces):
 
 
 def compute_lifetime_sparseness(image_responses):
-    # image responses should be an array of the trial averaged responses to each image
-    # sparseness = 1-(sum of trial averaged responses to images / N)squared / (sum of (squared mean responses / n)) / (1-(1/N))
+    # image responses should be an array of the trial averaged responses
+    # to each image
+    # sparseness = 1-(sum of trial averaged responses to images / N)squared /
+    # (sum of (squared mean responses / n)) / (1-(1/N))
     # N = number of images
     # after Vinje & Gallant, 2000; Froudarakis et al., 2014
     N = float(len(image_responses))
-    ls = ((1 - (1 / N) * ((np.power(image_responses.sum(axis=0), 2)) / (np.power(image_responses, 2).sum(axis=0)))) / (
+    ls = ((1 - (1 / N) * ((np.power(image_responses.sum(axis=0), 2)) /
+     (np.power(image_responses, 2).sum(axis=0)))) / (
         1 - (1 / N)))
     return ls
+
+def literal_col_eval(df: pd.DataFrame,
+                     columns: List[str]) -> pd.DataFrame:
+    ''' Eval string entries of specified columns 
+    '''
+
+    for column in columns:
+        if column in df.columns:
+            df.loc[df[column].notnull(), column] = \
+                df[column][df[column].notnull()].apply(
+                    lambda x: ast.literal_eval(x) if isinstance(x, str) else x
+                )
+    return df
+
+
+def df_list_to_tuple(df: pd.DataFrame,
+                     columns: List[str]) -> pd.DataFrame:
+    ''' convert list to tuple 
+    '''
+
+    for column in columns:
+        if column in df.columns:
+            df.loc[df[column].notnull(), column] = \
+                df[column][df[column].notnull()].apply(
+                    lambda x: tuple(x) if isinstance(x, list) else x
+                )
+    return df

--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -1141,7 +1141,8 @@ class EcephysSession(LazyPropertyMixin):
         for colname in stimulus_presentations.columns:
             if colname not in exclude_columns:
                 stimulus_presentations[colname] = \
-                    stimulus_presentations[colname].apply(naming_utilities.eval_str) 
+                    stimulus_presentations[colname].apply(
+                        naming_utilities.eval_str)
 
         stimulus_presentations['duration'] = \
             stimulus_presentations['stop_time'] - \

--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -1039,7 +1039,6 @@ class EcephysSession(LazyPropertyMixin):
 
             non_null = np.array(uniques[uniques != "null"])
             non_null = non_null
-            # non_null = np.sort(non_null)
 
             if not drop_nulls and "null" in uniques:
                 non_null = np.concatenate([non_null, ["null"]])

--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -8,6 +8,7 @@ import pandas as pd
 import scipy.stats
 import xarray as xr
 
+from allensdk.brain_observatory.behavior.swdb.utilities import literal_col_eval, df_list_to_tuple
 from allensdk.brain_observatory.ecephys.ecephys_session_api import (
     EcephysNwb1Api,
     EcephysNwbSessionApi,

--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -1124,7 +1124,7 @@ class EcephysSession(LazyPropertyMixin):
         # pandas groupby ops ignore nans, so we need a new "nonapplicable"
         # value that pandas does not recognize as null ...
         stimulus_presentations.replace("", nonapplicable, inplace=True)
-        stimulus_presentations.fillna(nonapplicable, inplace=True)
+        stimulus_presentations = stimulus_presentations.astype("object").fillna(nonapplicable)
 
         stimulus_presentations['duration'] = \
             stimulus_presentations['stop_time'] - \

--- a/allensdk/brain_observatory/ecephys/ecephys_session.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session.py
@@ -1039,7 +1039,7 @@ class EcephysSession(LazyPropertyMixin):
 
             non_null = np.array(uniques[uniques != "null"])
             non_null = non_null
-            non_null = np.sort(non_null)
+            # non_null = np.sort(non_null)
 
             if not drop_nulls and "null" in uniques:
                 non_null = np.concatenate([non_null, ["null"]])
@@ -1135,9 +1135,13 @@ class EcephysSession(LazyPropertyMixin):
         stimulus_presentations = stimulus_presentations.astype(
             col_type_map).fillna(nonapplicable)
 
-        # Values in 'spatial_frequency' is expected to be str
-        stimulus_presentations.spatial_frequency = \
-            stimulus_presentations.spatial_frequency.astype(str)
+        # eval str(numeric) and str(lists), convert lists to tuple for
+        # dict key compatibility
+        exclude_columns = ['stimulus_name']
+        for colname in stimulus_presentations.columns:
+            if colname not in exclude_columns:
+                stimulus_presentations[colname] = \
+                    stimulus_presentations[colname].apply(naming_utilities.eval_str) 
 
         stimulus_presentations['duration'] = \
             stimulus_presentations['stop_time'] - \

--- a/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
@@ -196,13 +196,14 @@ def map_column_names(table, name_map=None, ignore_case=True):
 
     return output
 
+
 def eval_str(val):
     if isinstance(val, str):
         try:
             val = eval(val)
             if isinstance(val, list):
                 val = tuple(val)
-        except:
+        except: # noqa E722
             pass
     return val
 #

--- a/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
@@ -195,15 +195,3 @@ def map_column_names(table, name_map=None, ignore_case=True):
     output = table.rename(columns=name_map)
 
     return output
-
-
-def eval_str(val):
-    """Evaluates str(numeric) and str(list)
-    """
-
-    if isinstance(val, str):
-        if val.replace('.', '').isdigit():
-            val = eval(val)
-        elif val[0] == "[" and val[-1] == "]":
-            val = tuple(eval(val))
-    return val

--- a/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
@@ -198,12 +198,12 @@ def map_column_names(table, name_map=None, ignore_case=True):
 
 
 def eval_str(val):
+    """Evaluates str(numeric) and str(list)
+    """
+
     if isinstance(val, str):
-        try:
+        if val.replace('.', '').isdigit():
             val = eval(val)
-            if isinstance(val, list):
-                val = tuple(val)
-        except: # noqa E722
-            pass
+        elif val[0] == "[" and val[-1] == "]":
+            val = tuple(eval(val))
     return val
-#

--- a/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_table/naming_utilities.py
@@ -195,4 +195,14 @@ def map_column_names(table, name_map=None, ignore_case=True):
     output = table.rename(columns=name_map)
 
     return output
+
+def eval_str(val):
+    if isinstance(val, str):
+        try:
+            val = eval(val)
+            if isinstance(val, list):
+                val = tuple(val)
+        except:
+            pass
+    return val
 #

--- a/allensdk/core/utilities.py
+++ b/allensdk/core/utilities.py
@@ -1,0 +1,27 @@
+import ast
+import pandas as pd
+from typing import List
+
+# Utils for processing dataframes
+
+
+def literal_col_eval(df: pd.DataFrame, columns: List[str]) -> pd.DataFrame:
+    """Eval string entries of specified columns"""
+
+    for column in columns:
+        if column in df.columns:
+            df.loc[df[column].notnull(), column] = df[column][
+                df[column].notnull()
+            ].apply(lambda x: ast.literal_eval(x) if isinstance(x, str) else x)
+    return df
+
+
+def df_list_to_tuple(df: pd.DataFrame, columns: List[str]) -> pd.DataFrame:
+    """convert list to tuple so that it can be hashable"""
+
+    for column in columns:
+        if column in df.columns:
+            df.loc[df[column].notnull(), column] = df[column][
+                df[column].notnull()
+            ].apply(lambda x: tuple(x) if isinstance(x, list) else x)
+    return df

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_session.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_session.py
@@ -66,7 +66,7 @@ def raw_mean_waveforms():
 @pytest.fixture
 def raw_channels():
     return pd.DataFrame({
-        'local_index': [0, 1, 2],
+        'probe_channel_number': [0, 1, 2],
         'probe_horizontal_position': [5, 10, 15],
         'probe_id': [0, 0, 0],
         'probe_vertical_position': [10, 22, 33],
@@ -79,7 +79,7 @@ def raw_units():
     return pd.DataFrame({
         'firing_rate': np.linspace(1, 3, 3),
         'isi_violations': [40, 0.5, 0.1],
-        'local_index': [0, 0, 1],
+        'probe_channel_number': [0, 0, 1],
         'peak_channel_id': [2, 1, 0],
         'quality': ['good', 'good', 'noise'],
         'snr': [0.1, 1.4, 10.0],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ hdmf>=2.5.8
 h5py
 matplotlib>=1.4.3,<3.4.3
 numpy
-pandas>=1.4.0
+pandas>=1.1.5
 jinja2>=3.0.0
 scipy>=1.4.0,<2.0.0
 six>=1.9.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ hdmf>=2.5.8
 h5py
 matplotlib>=1.4.3,<3.4.3
 numpy
-pandas>=1.1.5
+pandas>=1.4.0
 jinja2>=3.0.0
 scipy>=1.4.0,<2.0.0
 six>=1.9.0,<2.0.0


### PR DESCRIPTION
This PR address three issues

1. `_build_stimulus_presentations` method has pandas operations that trigger errors.
    * [stimulus_presentations.replace triggering error with pandas 1.1.5](https://github.com/AllenInstitute/AllenSDK/blob/f69f0649428346a11461472f374205916756ff4c/allensdk/brain_observatory/ecephys/ecephys_session.py#L1126)
      * [Error reported in ticket on pandas repo, fixed on Nov 20 2021](https://github.com/pandas-dev/pandas/issues/44499) This coincides to the pandas 1.4 release
    * `stimulus_presentations.fillna` triggering an error when replacing pd.NA values with a string in a boolean type column (opacity).
      * solution: first convert all "boolean" type columns to the "object" type.
2. `stimulus_presentations['spatial_frequency']` contains numeric values of mixed str and float types, along with str(list)
    * Unique values from spatial_frequency column - current
`['0.08', '[0.0, 0.0]', '0.04', 0.08, 0.04, 0.32, 0.02, 0.16]`
    * Unique values from spatial_frequency column - 2020 pre-release:
`['0.02' '0.04' '0.08' '0.16' '0.32' '[0.0, 0.0]']`
    * [Test in static_gratings expects float vals for spatial_frequency (sfvals)](https://github.com/AllenInstitute/AllenSDK/blob/f69f0649428346a11461472f374205916756ff4c/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_static_gratings.py#L53)
    * [Stimulus table fixture expects string values](https://github.com/AllenInstitute/AllenSDK/blob/f69f0649428346a11461472f374205916756ff4c/allensdk/test/brain_observatory/ecephys/stimulus_table/test_stimulus_table_module.py#L205)
      * However, no tests fail when eval all numeric/list strings in the stimulus_presentation tables.
3. Replace instance of `local_index` to `probe_channel_number` as reported in ticket #2573