### PR TITLE
Modify write nwb methods to instantiate objects using from_lims

### DIFF
--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
@@ -11,6 +11,7 @@ from allensdk.brain_observatory.behavior.write_behavior_nwb.schemas import (
     BehaviorInputSchema, OutputSchema)
 from allensdk.brain_observatory.argschema_utilities import (
     write_or_print_outputs)
+from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 
 def write_behavior_nwb(session_data, nwb_filepath):
@@ -31,6 +32,10 @@ def write_behavior_nwb(session_data, nwb_filepath):
         nwbfile = lims_session.to_nwb()
         with NWBHDF5IO(nwb_filepath_inprogress, 'w') as nwb_file_writer:
             nwb_file_writer.write(nwbfile)
+        logging.info("Comparing a BehaviorSession created from LIMS "
+                     "with a BehaviorSession created from NWB")
+        nwb_session = BehaviorSession.from_nwb_path(nwb_filepath_inprogress)
+        assert sessions_are_equal(lims_session, nwb_session, reraise=True)
         os.rename(nwb_filepath_inprogress, nwb_filepath)
         return {'output_path': nwb_filepath}
     except Exception as e:

--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
@@ -11,7 +11,6 @@ from allensdk.brain_observatory.behavior.write_behavior_nwb.schemas import (
     BehaviorInputSchema, OutputSchema)
 from allensdk.brain_observatory.argschema_utilities import (
     write_or_print_outputs)
-from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 
 def write_behavior_nwb(session_data, nwb_filepath):

--- a/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_behavior_nwb/__main__.py
@@ -27,33 +27,11 @@ def write_behavior_nwb(session_data, nwb_filepath):
             os.remove(filename)
 
     try:
-        json_session = BehaviorSession.from_json(
-            session_data,
-            stimulus_presentation_columns=[
-                    'start_time', 'stop_time',
-                    'duration',
-                    'image_name', 'image_index',
-                    'is_change', 'omitted',
-                    'start_frame', 'end_frame',
-                    'image_set']
-        )
-
         behavior_session_id = session_data['behavior_session_id']
         lims_session = BehaviorSession.from_lims(behavior_session_id)
-
-        logging.info("Comparing a BehaviorSession created from JSON "
-                     "with a BehaviorSession created from LIMS")
-        assert sessions_are_equal(json_session, lims_session, reraise=True)
-
         nwbfile = lims_session.to_nwb()
         with NWBHDF5IO(nwb_filepath_inprogress, 'w') as nwb_file_writer:
             nwb_file_writer.write(nwbfile)
-
-        logging.info("Comparing a BehaviorSession created from JSON "
-                     "with a BehaviorSession created from NWB")
-        nwb_session = BehaviorSession.from_nwb_path(nwb_filepath_inprogress)
-        assert sessions_are_equal(json_session, nwb_session, reraise=True)
-
         os.rename(nwb_filepath_inprogress, nwb_filepath)
         return {'output_path': nwb_filepath}
     except Exception as e:

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -11,7 +11,6 @@ from allensdk.brain_observatory.behavior.write_nwb._schemas import (
     InputSchema, OutputSchema)
 from allensdk.brain_observatory.argschema_utilities import (
     write_or_print_outputs)
-from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 
 def write_behavior_ophys_nwb(session_data: dict,

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -28,25 +28,11 @@ def write_behavior_ophys_nwb(session_data: dict,
             os.remove(filename)
 
     try:
-        json_session = BehaviorOphysExperiment.from_json(
-            session_data=session_data)
         lims_session = BehaviorOphysExperiment.from_lims(
             ophys_experiment_id=session_data['ophys_experiment_id'])
-
-        logging.info("Comparing a BehaviorOphysExperiment created from JSON "
-                     "with a BehaviorOphysExperiment created from LIMS")
-        assert sessions_are_equal(json_session, lims_session, reraise=True,
-                                  ignore_keys={'metadata': {'project_code'}})
-
-        nwbfile = json_session.to_nwb()
+        nwbfile = lims_session.to_nwb()
         with NWBHDF5IO(nwb_filepath_inprogress, 'w') as nwb_file_writer:
             nwb_file_writer.write(nwbfile)
-
-        logging.info("Comparing a BehaviorOphysExperiment created from JSON "
-                     "with a BehaviorOphysExperiment created from NWB")
-        nwb_session = BehaviorOphysExperiment.from_nwb(nwbfile=nwbfile)
-        assert sessions_are_equal(json_session, nwb_session, reraise=True)
-
         os.rename(nwb_filepath_inprogress, nwb_filepath)
         return {'output_path': nwb_filepath}
     except Exception as e:

--- a/allensdk/brain_observatory/behavior/write_nwb/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/__main__.py
@@ -11,6 +11,7 @@ from allensdk.brain_observatory.behavior.write_nwb._schemas import (
     InputSchema, OutputSchema)
 from allensdk.brain_observatory.argschema_utilities import (
     write_or_print_outputs)
+from allensdk.brain_observatory.session_api_utils import sessions_are_equal
 
 
 def write_behavior_ophys_nwb(session_data: dict,
@@ -32,6 +33,11 @@ def write_behavior_ophys_nwb(session_data: dict,
         nwbfile = lims_session.to_nwb()
         with NWBHDF5IO(nwb_filepath_inprogress, 'w') as nwb_file_writer:
             nwb_file_writer.write(nwbfile)
+        logging.info("Comparing a BehaviorSession created from LIMS "
+                     "with a BehaviorSession created from NWB")
+        nwb_session = BehaviorOphysExperiment.from_nwb_path(
+            nwb_filepath_inprogress)
+        assert sessions_are_equal(lims_session, nwb_session, reraise=True)
         os.rename(nwb_filepath_inprogress, nwb_filepath)
         return {'output_path': nwb_filepath}
     except Exception as e:

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -144,19 +144,19 @@ class NWBWriter:
 
         Parameters
         ----------
-        kwargs: kwargs sent to `from_json`, `from_nwb`, `to_nwb`
+        kwargs: kwargs sent to `from_nwb`, `to_nwb`
 
         """
-        from_json_kwargs = {
+        from_lims_kwargs = {
             k: v for k, v in kwargs.items()
-            if k in inspect.signature(self._serializer.from_json).parameters}
-        json_session = self._serializer.from_json(
-            session_data=self._session_data, **from_json_kwargs)
+            if k in inspect.signature(self._serializer.from_lims).parameters}
+        lims_session = self._serializer.from_lims(
+            session_data=self._session_data, **from_lims_kwargs)
 
         try:
             nwbfile = self._write_nwb(
-                session=json_session, **kwargs)
-            self._compare_sessions(nwbfile=nwbfile, json_session=json_session,
+                session=lims_session, **kwargs)
+            self._compare_sessions(nwbfile=nwbfile, lims_session=lims_session,
                                    **kwargs)
             os.rename(self.nwb_filepath_inprogress, self._nwb_filepath)
         except Exception as e:
@@ -174,7 +174,7 @@ class NWBWriter:
         Parameters
         ----------
         session_data
-        kwargs: kwargs to pass to `from_json` and `to_nwb`
+        kwargs: kwargs to pass to `to_nwb`
 
         Returns
         -------
@@ -189,10 +189,10 @@ class NWBWriter:
             nwb_file_writer.write(nwbfile)
         return nwbfile
 
-    def _compare_sessions(self, nwbfile: NWBFile, json_session: DataObject,
+    def _compare_sessions(self, nwbfile: NWBFile, lims_session: DataObject,
                           **kwargs):
         kwargs = {
             k: v for k, v in kwargs.items()
             if k in inspect.signature(self._serializer.from_nwb).parameters}
         nwb_session = self._serializer.from_nwb(nwbfile, **kwargs)
-        assert sessions_are_equal(json_session, nwb_session, reraise=True)
+        assert sessions_are_equal(lims_session, nwb_session, reraise=True)

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -151,7 +151,8 @@ class NWBWriter:
             k: v for k, v in kwargs.items()
             if k in inspect.signature(self._serializer.from_lims).parameters}
         lims_session = self._serializer.from_lims(
-            behavior_session_id=self._session_data['behavior_session_id'], **from_lims_kwargs)
+            behavior_session_id=self._session_data['behavior_session_id'],
+            **from_lims_kwargs)
 
         try:
             nwbfile = self._write_nwb(

--- a/allensdk/brain_observatory/nwb/nwb_utils.py
+++ b/allensdk/brain_observatory/nwb/nwb_utils.py
@@ -151,7 +151,7 @@ class NWBWriter:
             k: v for k, v in kwargs.items()
             if k in inspect.signature(self._serializer.from_lims).parameters}
         lims_session = self._serializer.from_lims(
-            session_data=self._session_data, **from_lims_kwargs)
+            behavior_session_id=self._session_data['behavior_session_id'], **from_lims_kwargs)
 
         try:
             nwbfile = self._write_nwb(


### PR DESCRIPTION
* Modified write_nwb methods to instantiate objects using from_lims instead of from_json
* Removed json validation in NWB writers. 