### PR TITLE
Changes to support python 3.10

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "windows-latest", "ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,6 @@ name: ci/nightly
 on:
   schedule:
     - cron: '05 6 * * *'
-  workflow_dispatch:
-
 
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ["self-hosted"]
     strategy:
       matrix:
-        image: ["allensdk_local_py37:latest"]
+        image: ["allensdk_local_py38:latest"]
         branch: ["master", "rc/**"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,8 @@ name: ci/nightly
 on:
   schedule:
     - cron: '05 6 * * *'
+  workflow_dispatch:
+
 
 
 jobs:

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbn_from_s3.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbn_from_s3.py
@@ -157,7 +157,10 @@ def test_local_cache_construction(
         cache = VisualBehaviorNeuropixelsProjectCache.from_s3_cache(cache_dir)
 
     cmd = 'VisualBehaviorNeuropixelsProjectCache.construct_local_manifest()'
-    assert cmd in f'{warnings[0].message}'
+    warning_msgs = [
+        f'{warnings[i].message}' for i in range(len(warnings))
+        if type(warnings[i].message) is MissingLocalManifestWarning]
+    assert any([cmd in msg for msg in warning_msgs])
 
     # Because, at the point where the cache was reconstitute,
     # the metadata files already existed at their expected local paths,

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_vbo_from_s3.py
@@ -97,7 +97,10 @@ def test_local_cache_construction(
         cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir)
 
     cmd = 'VisualBehaviorOphysProjectCache.construct_local_manifest()'
-    assert cmd in f'{warnings[0].message}'
+    warning_msgs = [
+        f'{warnings[i].message}' for i in range(len(warnings))
+        if type(warnings[i].message) is MissingLocalManifestWarning]
+    assert any([cmd in msg for msg in warning_msgs])
 
     # Because, at the point where the cache was reconstitute,
     # the metadata files already existed at their expected local paths,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 psycopg2-binary
 hdmf<=3.4.7
 h5py
-matplotlib>=1.4.3,<3.4.3
+matplotlib>=1.4.3
 numpy
 pandas>=1.1.5
 jinja2>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 from setuptools import find_packages, setup
 
@@ -87,9 +86,9 @@ setup(
         "License :: Other/Proprietary License", # Allen Institute License
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-pytest>=4.4.0,<6.0.0
+pytest>=4.4.0
 pytest-cov>=2.6.1,<3.0.0
 pytest-cover>=3.0.0,<4.0.0
 pytest-pep8>=1.0.6,<2.0.0


### PR DESCRIPTION
- Update python versions that github actions tests to 3.8 - 3.10
- Update setup.py to list supported python versions to 3.8 - 3.10
- Remove upper bound on matplotlib install which failed on windows/py310
- Remove upper bound on pytest which failed on py310