### PR TITLE
Fix gaussian_function_2d flipped axes

### DIFF
--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
@@ -343,7 +343,7 @@ def _gaussian_function_2d(peak_height, center_y, center_x, width_y, width_x):
     
     """
     
-    return lambda x,y: peak_height \
+    return lambda y, x: peak_height \
                        * np.exp( \
                        -( \
                          ((center_y - y) / width_y)**2 \

--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
@@ -1,14 +1,15 @@
+import logging
+import warnings
+
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy.ndimage as ndi
-from scipy.optimize import curve_fit, leastsq
-import logging
-import matplotlib.pyplot as plt
+from scipy.optimize import leastsq
 
 from ...chisquare_categorical import chisq_from_stim_table
 from .stimulus_analysis import StimulusAnalysis
 
-import warnings
-warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 class ReceptiveFieldMapping(StimulusAnalysis):
     """
-    A class for computing single-unit metrics from the receptive field mapping stimulus of an ecephys session NWB file.
+    A class for computing single-unit metrics from the receptive
+    field mapping stimulus of an ecephys session NWB file.
 
     To use, pass in a EcephysSession object::
         session = EcephysSession.from_nwb_path('/path/to/my.nwb')
@@ -25,17 +27,36 @@ class ReceptiveFieldMapping(StimulusAnalysis):
     or, alternatively, pass in the file path::
         rf_analysis = ReceptiveFieldMapping('/path/to/my.nwb')
 
-    You can also pass in a unit filter dictionary which will only select units with certain properties. For example
-    to get only those units which are on probe C and found in the VISp area::
-        rf_analysis = ReceptiveFieldMapping(session, filter={'location': 'probeC', 'ecephys_structure_acronym': 'VISp'})
+    You can also pass in a unit filter dictionary which will only
+    select units with certain properties. For example
+    to get only those units which are on probe C and found in the
+    VISp area::
+        rf_analysis = ReceptiveFieldMapping(
+            session,
+            filter={
+            'location': 'probeC',
+            'ecephys_structure_acronym': 'VISp'
+            }
+            )
 
     To get a table of the individual unit metrics ranked by unit ID::
         metrics_table_df = rf_analysis.metrics()
 
     """
-    def __init__(self, ecephys_session, col_pos_x='x_position', col_pos_y='y_position', trial_duration=0.25,
-                 minimum_spike_count=10.0, mask_threshold=0.5, **kwargs):
-        super(ReceptiveFieldMapping, self).__init__(ecephys_session, trial_duration=trial_duration, **kwargs)
+
+    def __init__(
+        self,
+        ecephys_session,
+        col_pos_x="x_position",
+        col_pos_y="y_position",
+        trial_duration=0.25,
+        minimum_spike_count=10.0,
+        mask_threshold=0.5,
+        **kwargs
+    ):
+        super(ReceptiveFieldMapping, self).__init__(
+            ecephys_session, trial_duration=trial_duration, **kwargs
+        )
 
         self._pos_x = None
         self._pos_y = None
@@ -48,19 +69,13 @@ class ReceptiveFieldMapping(StimulusAnalysis):
         self._minimum_spike_count = minimum_spike_count
         self._mask_threshold = mask_threshold
 
-        #if self._params is not None:
-        #    self._params = self._params['receptive_field_mapping']
-        #    self._stimulus_key = self._params['stimulus_key']
-        #    self._minimum_spike_count = self._params.get('minimum_spike_count', minimum_spike_count)
-        #    self._mask_threshold = self._params.get('mask_threshold', mask_threshold)
-
     @property
     def name(self):
-        return 'Receptive Field Mapping'
+        return "Receptive Field Mapping"
 
     @property
     def elevations(self):
-        """ Array of stimulus elevations """
+        """Array of stimulus elevations"""
         if self._pos_y is None:
             self._get_stim_table_stats()
 
@@ -68,7 +83,7 @@ class ReceptiveFieldMapping(StimulusAnalysis):
 
     @property
     def azimuths(self):
-        """ Array of stimulus azimuths """
+        """Array of stimulus azimuths"""
         if self._pos_x is None:
             self._get_stim_table_stats()
 
@@ -76,7 +91,7 @@ class ReceptiveFieldMapping(StimulusAnalysis):
 
     @property
     def number_elevations(self):
-        """ Number of stimulus elevations """
+        """Number of stimulus elevations"""
         if self._pos_y is None:
             self._get_stim_table_stats()
 
@@ -84,77 +99,107 @@ class ReceptiveFieldMapping(StimulusAnalysis):
 
     @property
     def number_azimuths(self):
-        """ Number of stimulus azimuths """
+        """Number of stimulus azimuths"""
         if self._pos_x is None:
             self._get_stim_table_stats()
 
-        return len(self._pos_y)  # TODO: Save this instead of calculating every time.
+        return len(
+            self._pos_y
+        )  # TODO: Save this instead of calculating every time.
 
     @property
     def null_condition(self):
-        """ Stimulus condition ID for null stimulus (not used, so set to -1) """
+        """Stimulus condition ID for null stimulus (not used,
+        so set to -1)"""
         # TODO: Remove
         return -1
 
     @property
     def receptive_fields(self):
-        """ Spatial receptive fields for N units (9 x 9 x N matrix of responses) """
+        """Spatial receptive fields for N units
+        (9 x 9 x N matrix of responses)"""
         if self._rf_matrix is None:
             bin_edges = np.linspace(0, 0.249, 3)
 
-            self.stim_table.loc[:, self._col_pos_y] = 40.0 - self.stim_table[self._col_pos_y]
-            presentationwise_response_matrix = self.ecephys_session.presentationwise_spike_counts(
-                bin_edges=bin_edges,
-                stimulus_presentation_ids=self.stim_table.index.values,
-                unit_ids=self.unit_ids,
+            self.stim_table.loc[:, self._col_pos_y] = (
+                40.0 - self.stim_table[self._col_pos_y]
+            )
+            presentationwise_response_matrix = (
+                self.ecephys_session.presentationwise_spike_counts(
+                    bin_edges=bin_edges,
+                    stimulus_presentation_ids=self.stim_table.index.values,
+                    unit_ids=self.unit_ids,
+                )
             )
 
-            self._rf_matrix = self._response_by_stimulus_position(presentationwise_response_matrix, self.stim_table)
+            self._rf_matrix = self._response_by_stimulus_position(
+                presentationwise_response_matrix, self.stim_table
+            )
 
         return self._rf_matrix
-    
 
     @property
     def METRICS_COLUMNS(self):
-        return [('azimuth_rf', np.float64), 
-                ('elevation_rf', np.float64), 
-                ('width_rf', np.float64), 
-                ('height_rf', np.float64),
-                ('area_rf', np.float64), 
-                ('p_value_rf', np.float64), 
-                ('on_screen_rf', bool), 
-                ('firing_rate_rf', np.float64),
-                ('fano_rf', np.float64), 
-                ('time_to_peak_rf', np.float64), 
-                ('lifetime_sparseness_rf', np.float64),
-                ('run_mod_rf', np.float64), 
-                ('run_pval_rf', np.float64)
-                ]
+        return [
+            ("azimuth_rf", np.float64),
+            ("elevation_rf", np.float64),
+            ("width_rf", np.float64),
+            ("height_rf", np.float64),
+            ("area_rf", np.float64),
+            ("p_value_rf", np.float64),
+            ("on_screen_rf", bool),
+            ("firing_rate_rf", np.float64),
+            ("fano_rf", np.float64),
+            ("time_to_peak_rf", np.float64),
+            ("lifetime_sparseness_rf", np.float64),
+            ("run_mod_rf", np.float64),
+            ("run_pval_rf", np.float64),
+        ]
 
     @property
     def metrics(self):
         if self._metrics is None:
-            logger.info('Calculating metrics for ' + self.name)
+            logger.info("Calculating metrics for " + self.name)
             unit_ids = self.unit_ids
             metrics_df = self.empty_metrics_table()
 
             if len(self.stim_table) > 0:
-                metrics_df.loc[:, ['azimuth_rf',
-                                   'elevation_rf',
-                                   'width_rf',
-                                   'height_rf',
-                                   'area_rf',
-                                   'p_value_rf',
-                                   'on_screen_rf',
-                                   ]] = [self._get_rf_stats(unit) for unit in unit_ids]
-                metrics_df['firing_rate_rf'] = [self._get_overall_firing_rate(unit) for unit in unit_ids]
-                metrics_df['fano_rf'] = [self._get_fano_factor(unit, self._get_preferred_condition(unit))
-                                         for unit in unit_ids]
-                metrics_df['time_to_peak_rf'] = [self._get_time_to_peak(unit, self._get_preferred_condition(unit))
-                                                 for unit in unit_ids]
-                metrics_df['lifetime_sparseness_rf'] = [self._get_lifetime_sparseness(unit) for unit in unit_ids]
-                metrics_df.loc[:, ['run_pval_rf', 'run_mod_rf']] = \
-                        [self._get_running_modulation(unit, self._get_preferred_condition(unit)) for unit in unit_ids]
+                metrics_df.loc[
+                    :,
+                    [
+                        "azimuth_rf",
+                        "elevation_rf",
+                        "width_rf",
+                        "height_rf",
+                        "area_rf",
+                        "p_value_rf",
+                        "on_screen_rf",
+                    ],
+                ] = [self._get_rf_stats(unit) for unit in unit_ids]
+                metrics_df["firing_rate_rf"] = [
+                    self._get_overall_firing_rate(unit) for unit in unit_ids
+                ]
+                metrics_df["fano_rf"] = [
+                    self._get_fano_factor(
+                        unit, self._get_preferred_condition(unit)
+                    )
+                    for unit in unit_ids
+                ]
+                metrics_df["time_to_peak_rf"] = [
+                    self._get_time_to_peak(
+                        unit, self._get_preferred_condition(unit)
+                    )
+                    for unit in unit_ids
+                ]
+                metrics_df["lifetime_sparseness_rf"] = [
+                    self._get_lifetime_sparseness(unit) for unit in unit_ids
+                ]
+                metrics_df.loc[:, ["run_pval_rf", "run_mod_rf"]] = [
+                    self._get_running_modulation(
+                        unit, self._get_preferred_condition(unit)
+                    )
+                    for unit in unit_ids
+                ]
 
             self._metrics = metrics_df
 
@@ -162,12 +207,14 @@ class ReceptiveFieldMapping(StimulusAnalysis):
 
     @classmethod
     def known_stimulus_keys(cls):
-        return ['receptive_field_mapping', 'gabor', "gabors"]
+        return ["receptive_field_mapping", "gabor", "gabors"]
 
     def _find_stimulus_key(self, stim_table):
-        known_keys_lc = [k.lower() for k in self.__class__.known_stimulus_keys()]
+        known_keys_lc = [
+            k.lower() for k in self.__class__.known_stimulus_keys()
+        ]
 
-        for table_key in stim_table['stimulus_name'].unique():
+        for table_key in stim_table["stimulus_name"].unique():
             table_key_lc = table_key.lower()
             for known_key in known_keys_lc:
                 if table_key_lc.startswith(known_key):
@@ -177,21 +224,26 @@ class ReceptiveFieldMapping(StimulusAnalysis):
             return None
 
     def _get_stim_table_stats(self):
-        """ Extract azimuths and elevations from stimulus table."""
+        """Extract azimuths and elevations from stimulus table."""
 
-        self._pos_y = np.sort(self.stimulus_conditions.loc[self.stimulus_conditions[self._col_pos_y]
-                                                           != 'null'][self._col_pos_y].unique())
-        self._pos_x = np.sort(self.stimulus_conditions.loc[self.stimulus_conditions[self._col_pos_x]
-                                                           != 'null'][self._col_pos_x].unique())
+        self._pos_y = np.sort(
+            self.stimulus_conditions.loc[
+                self.stimulus_conditions[self._col_pos_y] != "null"
+            ][self._col_pos_y].unique()
+        )
+        self._pos_x = np.sort(
+            self.stimulus_conditions.loc[
+                self.stimulus_conditions[self._col_pos_x] != "null"
+            ][self._col_pos_x].unique()
+        )
 
     def get_receptive_field(self, unit_id):
-        """ Alias for _get_rf
-        """
-        
+        """Alias for _get_rf"""
+
         return self._get_rf(unit_id)
 
     def _get_rf(self, unit_id):
-        """ Extract the receptive field for one unit
+        """Extract the receptive field for one unit
 
         Parameters
         ----------
@@ -202,12 +254,19 @@ class ReceptiveFieldMapping(StimulusAnalysis):
         -------
         receptive_field : 9 x 9 numpy array
         """
-        return self.receptive_fields['spike_counts'].sel(unit_id=unit_id).data
+        return self.receptive_fields["spike_counts"].sel(unit_id=unit_id).data
 
-
-    def _response_by_stimulus_position(self, dataset, presentations, row_key=None, column_key=None, unit_key='unit_id',
-                                       time_key='time_relative_to_stimulus_onset', spike_count_key='spike_count'):
-        """ Calculate the unit's response to different locations
+    def _response_by_stimulus_position(
+        self,
+        dataset,
+        presentations,
+        row_key=None,
+        column_key=None,
+        unit_key="unit_id",
+        time_key="time_relative_to_stimulus_onset",
+        spike_count_key="spike_count",
+    ):
+        """Calculate the unit's response to different locations
         of the Gabor patch
 
         Returns
@@ -229,12 +288,16 @@ class ReceptiveFieldMapping(StimulusAnalysis):
         dataset[column_key] = presentations.loc[:, column_key]
         dataset = dataset.to_dataframe()
 
-        dataset = dataset.reset_index(unit_key).groupby([row_key, column_key, unit_key]).sum()
+        dataset = (
+            dataset.reset_index(unit_key)
+            .groupby([row_key, column_key, unit_key])
+            .sum()
+        )
 
         return dataset.to_xarray()
 
     def _get_rf_stats(self, unit_id):
-        """ Calculate a variety of metrics for one unit's receptive field
+        """Calculate a variety of metrics for one unit's receptive field
 
         Parameters
         ----------
@@ -244,38 +307,55 @@ class ReceptiveFieldMapping(StimulusAnalysis):
         Returns
         -------
         azimuth :
-            preferred azimuth in degrees, based on center of mass of thresholded RF
+            preferred azimuth in degrees, based on center of mass
+            of thresholded RF
         elevation :
-            preferred elevation in degrees, based on center of mass of thresholded RF
+            preferred elevation in degrees, based on center of mass
+            of thresholded RF
         width :
             receptive field width in degrees, based on Gaussian fit
         height :
             receptive field height in degrees, based on Gaussian fit
         area :
-            receptive field area in degrees^2, based on thresholded RF area
+            receptive field area in degrees^2, based on thresholded
+            RF area
         p_value :
-            probability that a significant receptive field is present, based on categorical chi-square test
+            probability that a significant receptive field is present
+            based on categorical chi-square test
         on_screen :
-            True if the receptive field is away from the screen edge, based on Gaussian fit
+            True if the receptive field is away from the screen edge
+            based on Gaussian fit
         """
         rf = self._get_rf(unit_id)
-        spikes_per_trial = self.presentationwise_statistics.xs(unit_id, level=1)['spike_counts'].values
-
+        spikes_per_trial = self.presentationwise_statistics.xs(
+            unit_id, level=1
+        )["spike_counts"].values
 
         if np.sum(spikes_per_trial) < self._minimum_spike_count:
             return np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, False
 
-        p_value = chisq_from_stim_table(self.stim_table, [self._col_pos_x, self._col_pos_y],
-                                        np.expand_dims(spikes_per_trial,1))
+        p_value = chisq_from_stim_table(
+            self.stim_table,
+            [self._col_pos_x, self._col_pos_y],
+            np.expand_dims(spikes_per_trial, 1),
+        )
 
-        #print(self._params)
-        #exit()
-        rf_thresh, azimuth, elevation, area = threshold_rf(rf, self._mask_threshold)
+        # print(self._params)
+        # exit()
+        rf_thresh, azimuth, elevation, area = threshold_rf(
+            rf, self._mask_threshold
+        )
 
         if is_rf_inverted(rf_thresh):
             rf = invert_rf(rf)
 
-        (peak_height, center_y, center_x, width_y, width_x), success = fit_2d_gaussian(rf)
+        (
+            peak_height,
+            center_y,
+            center_x,
+            width_y,
+            width_x,
+        ), success = fit_2d_gaussian(rf)
         on_screen = rf_on_screen(rf, center_y, center_x)
 
         height_deg = convert_pixels_to_degrees(width_y)
@@ -284,45 +364,82 @@ class ReceptiveFieldMapping(StimulusAnalysis):
         elevation_deg = convert_elevation_to_degrees(elevation)
         area_deg = convert_pixel_area_to_degrees(area)
 
-        return azimuth_deg, elevation_deg, width_deg, height_deg, area_deg, p_value[0], on_screen
+        return (
+            azimuth_deg,
+            elevation_deg,
+            width_deg,
+            height_deg,
+            area_deg,
+            p_value[0],
+            on_screen,
+        )
 
-    ## VISUALIZATION ##
+    # VISUALIZATION
     def plot_raster(self, stimulus_condition_id, unit_id):
-    
-        """ Plot raster for one condition and one unit """
 
-        idx_elev = np.where(self.elevations == self.stimulus_conditions.loc[stimulus_condition_id][self._col_pos_y])[0]
-        idx_azi = np.where(self.azimuths == self.stimulus_conditions.loc[stimulus_condition_id][self._col_pos_x])[0]
-        
+        """Plot raster for one condition and one unit"""
+
+        idx_elev = np.where(
+            self.elevations
+            == self.stimulus_conditions.loc[stimulus_condition_id][
+                self._col_pos_y
+            ]
+        )[0]
+        idx_azi = np.where(
+            self.azimuths
+            == self.stimulus_conditions.loc[stimulus_condition_id][
+                self._col_pos_x
+            ]
+        )[0]
+
         if len(idx_elev) == len(idx_azi) == 1:
-     
-            presentation_ids = self.presentationwise_statistics.xs(unit_id, level=1)[
-                self.presentationwise_statistics.xs(unit_id, level=1)[
-                    'stimulus_condition_id'] == stimulus_condition_id].index.values
-            
-            df = self.presentationwise_spike_times[ \
-                (self.presentationwise_spike_times['stimulus_presentation_id'].isin(presentation_ids)) & \
-                (self.presentationwise_spike_times['unit_id'] == unit_id) ]
-                
-            x = df.index.values - self.stim_table.loc[df.stimulus_presentation_id].start_time
-            _, y = np.unique(df.stimulus_presentation_id, return_inverse=True) 
-            
-            idx_elev = self.number_elevations - idx_elev - 1 # reverse the elevation index so it matches the RF
 
-            plt.subplot(self.number_elevations, self.number_azimuths, idx_elev*self.number_azimuths + idx_azi + 1)
-            plt.scatter(x, y, c='k', s=1, alpha=0.25)
-            plt.axis('off')
+            presentation_ids = self.presentationwise_statistics.xs(
+                unit_id, level=1
+            )[
+                self.presentationwise_statistics.xs(unit_id, level=1)[
+                    "stimulus_condition_id"
+                ]
+                == stimulus_condition_id
+            ].index.values
+
+            df = self.presentationwise_spike_times[
+                (
+                    self.presentationwise_spike_times[
+                        "stimulus_presentation_id"
+                    ].isin(presentation_ids)
+                )
+                & (self.presentationwise_spike_times["unit_id"] == unit_id)
+            ]
+
+            x = (
+                df.index.values
+                - self.stim_table.loc[df.stimulus_presentation_id].start_time
+            )
+            _, y = np.unique(df.stimulus_presentation_id, return_inverse=True)
+
+            idx_elev = (
+                self.number_elevations - idx_elev - 1
+            )  # reverse the elevation index so it matches the RF
+
+            plt.subplot(
+                self.number_elevations,
+                self.number_azimuths,
+                idx_elev * self.number_azimuths + idx_azi + 1,
+            )
+            plt.scatter(x, y, c="k", s=1, alpha=0.25)
+            plt.axis("off")
 
     def plot_rf(self, unit_id):
-        """ Plot the spike counts across conditions """
-        plt.imshow(self._get_rf(unit_id), cmap='Greys')
-        plt.axis('off')
+        """Plot the spike counts across conditions"""
+        plt.imshow(self._get_rf(unit_id), cmap="Greys")
+        plt.axis("off")
 
 
-#### HELPER FUNCTIONS ####
+# HELPER FUNCTIONS
 def _gaussian_function_2d(peak_height, center_y, center_x, width_y, width_x):
     """Returns a 2D Gaussian function
-    
+
     Parameters
     ----------
     peak_height :
@@ -335,28 +452,30 @@ def _gaussian_function_2d(peak_height, center_y, center_x, width_y, width_x):
         width of distribution along x-axis
     width_x :
         width of distribution along y-axis
-    
+
     Returns
     -------
     f(x,y) : function
-        Returns the value of the distribution at a particular x,y coordinate
-    
-    """
-    
-    return lambda y, x: peak_height * np.exp(
-        -(((center_y - y) / width_y)**2 +
-        ((center_x - x) / width_x)**2)/2)
+        Returns the value of the distribution at a
+        particular x,y coordinate
 
+    """
+
+    return lambda y, x: peak_height * np.exp(
+        -(((center_y - y) / width_y) ** 2 + ((center_x - x) / width_x) ** 2)
+        / 2
+    )
 
 
 def gaussian_moments_2d(data):
-    """Finds the moments of a 2D Gaussian distribution, given an input matrix
-    
+    """Finds the moments of a 2D Gaussian distribution,
+    given an input matrix
+
     Parameters
     ----------
     data : numpy.ndarray
         2D matrix
-        
+
     Returns
     -------
     peak_height :
@@ -370,28 +489,38 @@ def gaussian_moments_2d(data):
     width_x :
         width of distribution along y-axis
     """
-    
+
     total = data.sum()
     height = data.max()
-    
-    Y, X = np.indices(data.shape)
-    center_y = (Y*data).sum()/total
-    center_x = (X*data).sum()/total
 
-    if np.isnan(center_y) or np.isinf(center_y) or np.isnan(center_x) or np.isinf(center_x):
+    Y, X = np.indices(data.shape)
+    center_y = (Y * data).sum() / total
+    center_x = (X * data).sum() / total
+
+    if (
+        np.isnan(center_y)
+        or np.isinf(center_y)
+        or np.isnan(center_x)
+        or np.isinf(center_x)
+    ):
         return None
 
-    col = data[:, int(center_x)]    
+    col = data[:, int(center_x)]
     row = data[int(center_y), :]
 
-    width_y = np.sqrt(np.abs((np.arange(row.size)-center_y)**2*row).sum()/row.sum())
-    width_x = np.sqrt(np.abs((np.arange(col.size)-center_x)**2*col).sum()/col.sum())
+    width_y = np.sqrt(
+        np.abs((np.arange(row.size) - center_y) ** 2 * row).sum() / row.sum()
+    )
+    width_x = np.sqrt(
+        np.abs((np.arange(col.size) - center_x) ** 2 * col).sum() / col.sum()
+    )
 
     return height, center_y, center_x, width_y, width_x
 
 
 def fit_2d_gaussian(matrix):
-    """Fits a receptive field with a 2-dimensional Gaussian distribution
+    """Fits a receptive field with a 2-dimensional Gaussian
+    distribution
 
     Parameters
     ----------
@@ -414,7 +543,11 @@ def fit_2d_gaussian(matrix):
     if params is None:
         return (np.nan, np.nan, np.nan, np.nan, np.nan), False
 
-    errorfunction = lambda p: np.ravel(_gaussian_function_2d(*p)(*np.indices(matrix.shape)) - matrix)
+    def errorfunction(p):
+        return np.ravel(
+            _gaussian_function_2d(*p)(*np.indices(matrix.shape)) - matrix
+        )
+
     fit_params, ier = leastsq(errorfunction, params)
     success = True if ier < 5 else False
 
@@ -422,7 +555,8 @@ def fit_2d_gaussian(matrix):
 
 
 def is_rf_inverted(rf_thresh):
-    """Checks if the receptive field mapping timulus is suppressing or exciting the cell
+    """Checks if the receptive field mapping timulus is suppressing
+    or exciting the cell
 
     Parameters
     ----------
@@ -436,10 +570,10 @@ def is_rf_inverted(rf_thresh):
     """
     edge_mask = np.zeros(rf_thresh.shape)
 
-    edge_mask[:,0] = 1
-    edge_mask[:,-1] = 1
-    edge_mask[0,:] = 1
-    edge_mask[-1,:] = 1
+    edge_mask[:, 0] = 1
+    edge_mask[:, -1] = 1
+    edge_mask[0, :] = 1
+    edge_mask[-1, :] = 1
 
     num_edge_pixels = np.sum(rf_thresh * edge_mask)
 
@@ -462,16 +596,17 @@ def invert_rf(rf):
 
 
 def threshold_rf(rf, threshold):
-    """Creates a spatial mask based on the receptive field peak, and returns the x, y coordinates of the center of
-    mass, as well as the area.
-    
+    """Creates a spatial mask based on the receptive field peak
+    and returns the x, y coordinates of the center of mass,
+    as well as the area.
+
     Parameters
     ----------
     rf : numpy.ndarray
         2D matrix of spike counts
     threshold : float
         Threshold as ratio of the RF's standard deviation
-        
+
     Returns
     -------
     threshold_rf : numpy.ndarray
@@ -484,19 +619,21 @@ def threshold_rf(rf, threshold):
         area of mask
     """
     rf_filt = ndi.gaussian_filter(rf, 1)
-    
+
     threshold_value = np.max(rf_filt) - np.std(rf_filt) * threshold
-        
-    rf_thresh = np.zeros(rf.shape, dtype='bool')
+
+    rf_thresh = np.zeros(rf.shape, dtype="bool")
     rf_thresh[rf_filt > threshold_value] = True
 
     labels, num_features = ndi.label(rf_thresh)
-    
-    best_label = np.argmax(ndi.maximum(rf_filt, labels=labels, index=np.unique(labels)))
+
+    best_label = np.argmax(
+        ndi.maximum(rf_filt, labels=labels, index=np.unique(labels))
+    )
 
     labels[labels != best_label] = 0
     labels[labels > 0] = 1
-    
+
     center_y, center_x = ndi.measurements.center_of_mass(labels)
     area = float(np.sum(labels))
 
@@ -504,18 +641,24 @@ def threshold_rf(rf, threshold):
 
 
 def rf_on_screen(rf, center_y, center_x):
-    """Checks whether the receptive field is on the screen, given the center location."""
+    """Checks whether the receptive field is on the screen, given the
+    center location."""
     return 0 < center_y < rf.shape[0] and 0 < center_x < rf.shape[1]
 
 
-def convert_elevation_to_degrees(elevation_in_pixels, elevation_offset_degrees=-30):
-    """Converts a pixel-based elevation into degrees relative to center of gaze
+def convert_elevation_to_degrees(
+    elevation_in_pixels, elevation_offset_degrees=-30
+):
+    """Converts a pixel-based elevation into degrees relative to
+    center of gaze
 
-    The receptive field computed by this class is oriented such that the
-    pixel values are in the correct relative location when using matplotlib.pyplot.imshow(),
-    which places (0,0) in the upper-left corner of the figure.
+    The receptive field computed by this class is oriented such
+    that the pixel values are in the correct relative location
+    when using matplotlib.pyplot.imshow(), which places (0,0)
+    in the upper-left corner of the figure.
 
-    Therefore, we need to invert the elevation value prior to converting to degrees.
+    Therefore, we need to invert the elevation value prior
+    to converting to degrees.
 
     Parameters
     ----------
@@ -526,13 +669,17 @@ def convert_elevation_to_degrees(elevation_in_pixels, elevation_offset_degrees=-
     -------
     elevation_in_degrees : float
     """
-    elevation_in_degrees = convert_pixels_to_degrees(8 - elevation_in_pixels) + elevation_offset_degrees
-    
+    elevation_in_degrees = (
+        convert_pixels_to_degrees(8 - elevation_in_pixels)
+        + elevation_offset_degrees
+    )
+
     return elevation_in_degrees
 
 
 def convert_azimuth_to_degrees(azimuth_in_pixels, azimuth_offset_degrees=10):
-    """Converts a pixel-based azimuth into degrees relative to center of gaze
+    """Converts a pixel-based azimuth into degrees relative
+    to center of gaze
 
     Parameters
     ----------
@@ -543,8 +690,10 @@ def convert_azimuth_to_degrees(azimuth_in_pixels, azimuth_offset_degrees=10):
     -------
     azimuth_in_degrees : float
     """
-    azimuth_in_degrees = convert_pixels_to_degrees((azimuth_in_pixels)) + azimuth_offset_degrees
-    
+    azimuth_in_degrees = (
+        convert_pixels_to_degrees((azimuth_in_pixels)) + azimuth_offset_degrees
+    )
+
     return azimuth_in_degrees
 
 
@@ -566,9 +715,11 @@ def convert_pixels_to_degrees(value_in_pixels, degrees_to_pixels_ratio=10):
 def convert_pixel_area_to_degrees(area_in_pixels):
     """Converts a pixel-based area measure into degrees
 
-    Each pixel is a square with side of length <degrees_to_pixels_ratio>
+    Each pixel is a square with side of length
+    <degrees_to_pixels_ratio>
 
-    So the area in degrees is area_in_pixels * <degrees to_pixels_ratio>^2
+    So the area in degrees is
+    area_in_pixels * <degrees to_pixels_ratio>^2
 
     Parameters
     ----------

--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/receptive_field_mapping.py
@@ -343,14 +343,10 @@ def _gaussian_function_2d(peak_height, center_y, center_x, width_y, width_x):
     
     """
     
-    return lambda y, x: peak_height \
-                       * np.exp( \
-                       -( \
-                         ((center_y - y) / width_y)**2 \
-                       + ((center_x - x) / width_x)**2 \
-                        ) \
-                        / 2 \
-                        )
+    return lambda y, x: peak_height * np.exp(
+        -(((center_y - y) / width_y)**2 +
+        ((center_x - x) / width_x)**2)/2)
+
 
 
 def gaussian_moments_2d(data):

--- a/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_receptive_field_mapping.py
+++ b/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_receptive_field_mapping.py
@@ -1,30 +1,67 @@
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
+import pytest
+
+from allensdk.brain_observatory.ecephys.ecephys_session import EcephysSession
+from allensdk.brain_observatory.ecephys.stimulus_analysis.receptive_field_mapping import ( # noqa
+    ReceptiveFieldMapping,
+    fit_2d_gaussian,
+    threshold_rf,
+)
 
 from .conftest import MockSessionApi
-from allensdk.brain_observatory.ecephys.ecephys_session import EcephysSession
-from allensdk.brain_observatory.ecephys.stimulus_analysis.receptive_field_mapping import \
-    ReceptiveFieldMapping, \
-    fit_2d_gaussian, \
-    threshold_rf
+
 
 class MockRFMSessionApi(MockSessionApi):
     def get_stimulus_presentations(self):
-        features = np.array(np.meshgrid([30.0, -20.0, 40.0, 20.0, 0.0, -30.0, -40.0, 10.0, -10.0],  # x_position
-                                        [10.0, -10.0, 30.0, 40.0, -40.0, -30.0, -20.0, 20.0, 0.0])  # y_position
-                            ).reshape(2, 81)
+        features = np.array(
+            np.meshgrid(
+                [
+                    30.0,
+                    -20.0,
+                    40.0,
+                    20.0,
+                    0.0,
+                    -30.0,
+                    -40.0,
+                    10.0,
+                    -10.0,
+                ],  # x_position
+                [10.0, -10.0, 30.0, 40.0, -40.0, -30.0, -20.0, 20.0, 0.0],
+            )  # y_position
+        ).reshape(2, 81)
 
-        return pd.DataFrame({
-            'start_time': np.concatenate(([0.0], np.linspace(0.5, 20.50, 81, endpoint=True), [20.75])),
-            'stop_time': np.concatenate(([0.5], np.linspace(0.75, 20.75, 81, endpoint=True), [21.25])),
-            'stimulus_name': ['spontaneous'] + ['gabors']*81 + ['spontaneous'],
-            'stimulus_block': [0] + [1]*81 + [0],
-            'duration': [0.5] + [0.25]*81 + [0.5],
-            'stimulus_index': [0] + [1]*81 + [0],
-            'x_position': np.concatenate(([np.nan], features[0, :], [np.nan])),
-            'y_position': np.concatenate(([np.nan], features[1, :], [np.nan]))
-        }, index=pd.Index(name='id', data=np.arange(83)))
+        return pd.DataFrame(
+            {
+                "start_time": np.concatenate(
+                    (
+                        [0.0],
+                        np.linspace(0.5, 20.50, 81, endpoint=True),
+                        [20.75],
+                    )
+                ),
+                "stop_time": np.concatenate(
+                    (
+                        [0.5],
+                        np.linspace(0.75, 20.75, 81, endpoint=True),
+                        [21.25],
+                    )
+                ),
+                "stimulus_name": ["spontaneous"]
+                + ["gabors"] * 81
+                + ["spontaneous"],
+                "stimulus_block": [0] + [1] * 81 + [0],
+                "duration": [0.5] + [0.25] * 81 + [0.5],
+                "stimulus_index": [0] + [1] * 81 + [0],
+                "x_position": np.concatenate(
+                    ([np.nan], features[0, :], [np.nan])
+                ),
+                "y_position": np.concatenate(
+                    ([np.nan], features[1, :], [np.nan])
+                ),
+            },
+            index=pd.Index(name="id", data=np.arange(83)),
+        )
 
 
 @pytest.fixture
@@ -35,153 +72,234 @@ def ecephys_api():
 def test_load(ecephys_api):
     session = EcephysSession(api=ecephys_api)
     rfm = ReceptiveFieldMapping(ecephys_session=session)
-    assert(rfm.name == 'Receptive Field Mapping')
-    assert(set(rfm.unit_ids) == set(range(6)))
-    assert(len(rfm.conditionwise_statistics) == 81*6)
-    assert(rfm.conditionwise_psth.shape == (81, 249, 6))
-    assert(not rfm.presentationwise_spike_times.empty)
-    assert(len(rfm.presentationwise_statistics) == 81*6)
-    assert(len(rfm.stimulus_conditions) == 81)
+    assert rfm.name == "Receptive Field Mapping"
+    assert set(rfm.unit_ids) == set(range(6))
+    assert len(rfm.conditionwise_statistics) == 81 * 6
+    assert rfm.conditionwise_psth.shape == (81, 249, 6)
+    assert not rfm.presentationwise_spike_times.empty
+    assert len(rfm.presentationwise_statistics) == 81 * 6
+    assert len(rfm.stimulus_conditions) == 81
 
 
 def test_stimulus(ecephys_api):
     session = EcephysSession(api=ecephys_api)
     rfm = ReceptiveFieldMapping(ecephys_session=session)
-    assert(isinstance(rfm.stim_table, pd.DataFrame))
-    assert(len(rfm.stim_table) == 81)
-    assert(set(rfm.stim_table.columns).issuperset({'x_position', 'y_position', 'start_time', 'stop_time'}))
+    assert isinstance(rfm.stim_table, pd.DataFrame)
+    assert len(rfm.stim_table) == 81
+    assert set(rfm.stim_table.columns).issuperset(
+        {"x_position", "y_position", "start_time", "stop_time"}
+    )
 
-    assert(set(rfm.azimuths) == {30.0, -20.0, 40.0, 20.0, 0.0, -30.0, -40.0, 10.0, -10.0})
-    assert(rfm.number_azimuths == 9)
+    assert set(rfm.azimuths) == {
+        30.0,
+        -20.0,
+        40.0,
+        20.0,
+        0.0,
+        -30.0,
+        -40.0,
+        10.0,
+        -10.0,
+    }
+    assert rfm.number_azimuths == 9
 
-    assert(set(rfm.elevations) == {10.0, -10.0, 30.0, 40.0, -40.0, -30.0, -20.0, 20.0, 0.0})
-    assert(rfm.number_elevations == 9)
+    assert set(rfm.elevations) == {
+        10.0,
+        -10.0,
+        30.0,
+        40.0,
+        -40.0,
+        -30.0,
+        -20.0,
+        20.0,
+        0.0,
+    }
+    assert rfm.number_elevations == 9
 
 
 def test_metrics(ecephys_api):
     session = EcephysSession(api=ecephys_api)
-    rfm = ReceptiveFieldMapping(ecephys_session=session, minimum_spike_count=1.0, trial_duration=0.25,
-                                mask_threshold=0.5)
-    assert(isinstance(rfm.metrics, pd.DataFrame))
-    assert(len(rfm.metrics) == 6)
-    assert(rfm.metrics.index.names == ['unit_id'])
+    rfm = ReceptiveFieldMapping(
+        ecephys_session=session,
+        minimum_spike_count=1.0,
+        trial_duration=0.25,
+        mask_threshold=0.5,
+    )
+    assert isinstance(rfm.metrics, pd.DataFrame)
+    assert len(rfm.metrics) == 6
+    assert rfm.metrics.index.names == ["unit_id"]
 
-    # TODO: Methods are too sensitive and will have different values depending on the version of scipy
-    assert('azimuth_rf' in rfm.metrics.columns)
-    assert('elevation_rf' in rfm.metrics.columns)
-    assert('width_rf' in rfm.metrics.columns)
-    assert('height_rf' in rfm.metrics.columns)
-    # Different versions of scipy will return unit 1 as either a 0.0 or a nan
-    #assert(np.allclose(rfm.metrics['height_rf'].loc[[0, 1, 2, 3, 4, 5]],
-    #                   [np.nan, 0.0, 129.522395, np.nan, np.nan, np.nan], equal_nan=True))
+    # TODO: Methods are too sensitive and will have different
+    # values depending on the version of scipy
+    assert "azimuth_rf" in rfm.metrics.columns
+    assert "elevation_rf" in rfm.metrics.columns
+    assert "width_rf" in rfm.metrics.columns
+    assert "height_rf" in rfm.metrics.columns
+    # Different versions of scipy will return unit 1 as either
+    # a 0.0 or a nan
 
-    assert('area_rf' in rfm.metrics.columns)
-    assert(np.allclose(rfm.metrics['area_rf'].loc[[0, 1, 2, 3, 4, 5]],
-                       [0.0, 0.0, 0.0, np.nan, 0.0, 0.0], equal_nan=True))
+    assert "area_rf" in rfm.metrics.columns
+    assert np.allclose(
+        rfm.metrics["area_rf"].loc[[0, 1, 2, 3, 4, 5]],
+        [0.0, 0.0, 0.0, np.nan, 0.0, 0.0],
+        equal_nan=True,
+    )
 
-    assert('p_value_rf' in rfm.metrics.columns)
-    assert('on_screen_rf' in rfm.metrics.columns)
-    assert('firing_rate_rf' in rfm.metrics.columns)
-    assert('fano_rf' in rfm.metrics.columns)
-    assert('time_to_peak_rf' in rfm.metrics.columns)
-    assert('lifetime_sparseness_rf' in rfm.metrics.columns)
-    assert('run_pval_rf' in rfm.metrics.columns)
-    assert('run_mod_rf' in rfm.metrics.columns)
+    assert "p_value_rf" in rfm.metrics.columns
+    assert "on_screen_rf" in rfm.metrics.columns
+    assert "firing_rate_rf" in rfm.metrics.columns
+    assert "fano_rf" in rfm.metrics.columns
+    assert "time_to_peak_rf" in rfm.metrics.columns
+    assert "lifetime_sparseness_rf" in rfm.metrics.columns
+    assert "run_pval_rf" in rfm.metrics.columns
+    assert "run_mod_rf" in rfm.metrics.columns
 
 
 def test_receptive_fields(ecephys_api):
     # Also test_response_by_stimulus_position()
     session = EcephysSession(api=ecephys_api)
     rfm = ReceptiveFieldMapping(ecephys_session=session)
-    assert(rfm.receptive_fields)
-    assert(type(rfm.receptive_fields))
-    assert('spike_counts' in rfm.receptive_fields)
-    assert(rfm.receptive_fields['spike_counts'].shape == (9, 9, 6))  # x, y, units
-    assert(set(rfm.receptive_fields['spike_counts'].coords) == {'y_position', 'x_position', 'unit_id'})
-    assert(np.all(rfm.receptive_fields['spike_counts'].coords['x_position']
-                  == [-40.0, -30.0, -20.0, -10.0, 0.0, 10.0, 20.0, 30.0, 40.0]))
-    assert(np.all(rfm.receptive_fields['spike_counts'].coords['y_position']
-                  == [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]))
+    assert rfm.receptive_fields
+    assert type(rfm.receptive_fields)
+    assert "spike_counts" in rfm.receptive_fields
+    assert rfm.receptive_fields["spike_counts"].shape == (
+        9,
+        9,
+        6,
+    )  # x, y, units
+    assert set(rfm.receptive_fields["spike_counts"].coords) == {
+        "y_position",
+        "x_position",
+        "unit_id",
+    }
+    assert np.all(
+        rfm.receptive_fields["spike_counts"].coords["x_position"]
+        == [-40.0, -30.0, -20.0, -10.0, 0.0, 10.0, 20.0, 30.0, 40.0]
+    )
+    assert np.all(
+        rfm.receptive_fields["spike_counts"].coords["y_position"]
+        == [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+    )
 
-    # Some randomly sampled testing to make sure everything works like it should
-    assert(rfm.receptive_fields['spike_counts'][{'unit_id': 0}].values.sum() == 4)
-    assert(rfm.receptive_fields['spike_counts'][{'unit_id': 3}].values.sum() == 0)
-    assert(rfm.receptive_fields['spike_counts'][{'unit_id': 2, 'x_position': 8, 'y_position': 3}] == 3)
-    assert(np.all(rfm.receptive_fields['spike_counts'][{'x_position': 2, 'y_position': 5}] == [1, 0, 0, 0, 1, 1]))
+    # Some randomly sampled testing to make sure everything works as expected
+    assert (
+        rfm.receptive_fields["spike_counts"][{"unit_id": 0}].values.sum() == 4
+    )
+    assert (
+        rfm.receptive_fields["spike_counts"][{"unit_id": 3}].values.sum() == 0
+    )
+    assert (
+        rfm.receptive_fields["spike_counts"][
+            {"unit_id": 2, "x_position": 8, "y_position": 3}
+        ]
+        == 3
+    )
+    assert np.all(
+        rfm.receptive_fields["spike_counts"][
+            {"x_position": 2, "y_position": 5}
+        ]
+        == [1, 0, 0, 0, 1, 1]
+    )
 
 
-
-##  Some special receptive fields for testing
+# Some special receptive fields for testing
 
 # Data taken from real example
-rf_field_real = np.array([[7440, 5704,  11408, 8184, 9920, 5952, 11904, 11904, 9672],
-                          [8184, 12152, 10912, 12648, 15128, 19096, 17112, 14384, 11656],
-                          [12152, 17856, 25048, 36208, 47368, 30256, 20336, 10912, 10168],
-                          [15624, 31000, 53568, 92752, 119288, 69440, 31496, 16120, 10416],
-                          [12152, 23560, 32984, 74896, 93496, 52328, 28024, 19592, 11656],
-                          [9672, 7192, 10912, 16120, 16368, 18600, 14880, 6696, 11408],
-                          [11656, 7688, 6696, 5456, 11408, 9672, 11160, 12152, 7936],
-                          [6696, 6696, 9424, 8928, 6200, 11160, 7688, 6200, 9672],
-                          [8928, 10912, 9176, 8432, 7688, 9424, 5704, 8184, 14384]], dtype=np.float64)
+rf_field_real = np.array(
+    [
+        [7440, 5704, 11408, 8184, 9920, 5952, 11904, 11904, 9672],
+        [8184, 12152, 10912, 12648, 15128, 19096, 17112, 14384, 11656],
+        [12152, 17856, 25048, 36208, 47368, 30256, 20336, 10912, 10168],
+        [15624, 31000, 53568, 92752, 119288, 69440, 31496, 16120, 10416],
+        [12152, 23560, 32984, 74896, 93496, 52328, 28024, 19592, 11656],
+        [9672, 7192, 10912, 16120, 16368, 18600, 14880, 6696, 11408],
+        [11656, 7688, 6696, 5456, 11408, 9672, 11160, 12152, 7936],
+        [6696, 6696, 9424, 8928, 6200, 11160, 7688, 6200, 9672],
+        [8928, 10912, 9176, 8432, 7688, 9424, 5704, 8184, 14384],
+    ],
+    dtype=np.float64,
+)
 
 # RF as a typical gaussian
 x, y = np.meshgrid(np.linspace(-1, 1, 9), np.linspace(-1, 1, 9))
-rf_field_gaussian = np.exp(-((np.sqrt(x*x + y*y) - 0.0)**2 /(2.0*1.0**2)))
+rf_field_gaussian = np.exp(
+    -((np.sqrt(x * x + y * y) - 0.0) ** 2 / (2.0 * 1.0**2))
+)
 
 # Only activity at one of the corners of the field
 rf_field_edge = np.zeros((9, 9))
 rf_field_edge[8, 8] = 5.0
 
 
-@pytest.mark.parametrize('rf,threshold,expected_mask,expected_x,expected_y,expected_area',
-                         [
-                             (np.zeros((9, 9)), 0.5, np.zeros((9, 9)), np.nan, np.nan, 0.0), # No firing
-                             (np.full((9, 9), 100.0), 0.5, np.zeros((9, 9)), np.nan, np.nan, 0.0),  # completely consistant firing, no center
-                             (rf_field_real, 0.5, None, 3.5, 3.0, 2.0),  # example from real data
-                             (rf_field_gaussian, 0.5, None, 4.0, 4.0, 9.0),
-                             (rf_field_edge, 0.05, None, 8.0, 8.0, 1.0)
-                         ])
-def test_threshold_rf(rf, threshold, expected_mask, expected_x, expected_y, expected_area):
+@pytest.mark.parametrize(
+    "rf,threshold,expected_mask,expected_x,expected_y,expected_area",
+    [
+        (
+            np.zeros((9, 9)),
+            0.5,
+            np.zeros((9, 9)),
+            np.nan,
+            np.nan,
+            0.0,
+        ),  # No firing
+        (
+            np.full((9, 9), 100.0),
+            0.5,
+            np.zeros((9, 9)),
+            np.nan,
+            np.nan,
+            0.0,
+        ),  # completely consistant firing, no center
+        (rf_field_real, 0.5, None, 3.5, 3.0, 2.0),  # example from real data
+        (rf_field_gaussian, 0.5, None, 4.0, 4.0, 9.0),
+        (rf_field_edge, 0.05, None, 8.0, 8.0, 1.0),
+    ],
+)
+def test_threshold_rf(
+    rf, threshold, expected_mask, expected_x, expected_y, expected_area
+):
     mask_rf, x, y, area = threshold_rf(rf, threshold)
-    assert(np.isclose(x, expected_x, equal_nan=True))
-    assert(np.isclose(y, expected_y, equal_nan=True))
-    assert(np.isclose(area, expected_area, equal_nan=True))
+    assert np.isclose(x, expected_x, equal_nan=True)
+    assert np.isclose(y, expected_y, equal_nan=True)
+    assert np.isclose(area, expected_area, equal_nan=True)
     if expected_mask is not None:
-        # TODO: Find a better way to check the resulting mask, it should match up with the center/area
-        assert(np.allclose(mask_rf, expected_mask, equal_nan=True))
+        # TODO: Find a better way to check the resulting mask,
+        # it should match up with the center/area
+        assert np.allclose(mask_rf, expected_mask, equal_nan=True)
 
 
-@pytest.mark.parametrize('matrix,expected',
-                         [
-                             (rf_field_real, (np.array([1.04990549e+05, 3.24465782e+00, 3.74217921e+00, 1.04486140e+00, 1.66478893e+00]), True)),
-                             (rf_field_gaussian, (np.array([1.0, 4.0, 4.0, 4.0, 4.0]), True)),
-                             (np.zeros((9, 9)), ((np.nan, np.nan, np.nan, np.nan, np.nan), False)),
-                             ## These edge cases are too sensitive and will produce different values depending on the
-                             ## version of scipy is compiled against.
-                             # (np.full((9, 9), 20.5), (np.array([20.5000000, 3.62601891, 3.55521927, 1.20266006e+05, 1.08161135e+05]), True)),
-                             # (rf_field_edge, (np.array([5.0, 8.0, 8.0, 0.0, 0.0]), True))
-                         ])
+@pytest.mark.parametrize(
+    "matrix,expected",
+    [
+        (
+            rf_field_real,
+            (
+                np.array(
+                    [
+                        1.04990549e05,
+                        3.24465782e00,
+                        3.74217921e00,
+                        1.04486140e00,
+                        1.66478893e00,
+                    ]
+                ),
+                True,
+            ),
+        ),
+        (rf_field_gaussian, (np.array([1.0, 4.0, 4.0, 4.0, 4.0]), True)),
+        (np.zeros((9, 9)), ((np.nan, np.nan, np.nan, np.nan, np.nan), False)),
+        (rf_field_edge, (np.array([5.0, 8.0, 8.0, 0.0, 0.0]), True)),
+    ],
+)
 def test_fit_2d_gaussian(matrix, expected):
     fit_params, success = fit_2d_gaussian(matrix)
-    assert(np.allclose(fit_params, expected[0], equal_nan=True))
-    assert(success == expected[1])
+    assert np.allclose(fit_params, expected[0], equal_nan=True)
+    np.testing.assert_array_almost_equal(success, expected[1])
 
 
-if __name__ == '__main__':
-    # test_load()
-    # test_stimulus()
+if __name__ == "__main__":
     test_metrics()
-    # test_receptive_fields()
-
-    # test_threshold_rf(np.zeros((9, 9)), 0.5, np.zeros((9, 9)), np.nan, np.nan, 0.0)  # No firing
-    # test_threshold_rf(np.full((9, 9), 100.0), 0.5, np.zeros((9, 9)), np.nan, np.nan, 0.0)  # completely consistant firing, no center
-    # test_threshold_rf(rf_field_real, 0.5, None, 3.5, 3.0, 2.0)  # example from real data
-    # test_threshold_rf(rf_field_gaussian, 0.5, None, 4.0, 4.0, 9.0)
-    # test_threshold_rf(rf_field_edge, 0.05, None, 8.0, 8.0, 1.0)
-
-    # test_fit_2d_gaussian(rf_field_real, (np.array([1.04991433e+05, 3.74217858e+00, 3.24465965e+00, 1.66477569e+00, 1.04485211e+00]), True))
-    # test_fit_2d_gaussian(rf_field_gaussian, (np.array([1.0, 4.0, 4.0, 4.0, 4.0]), True))
-    # test_fit_2d_gaussian(np.zeros((9, 9)), ((np.nan, np.nan, np.nan, np.nan, np.nan), False))
-    # test_fit_2d_gaussian(np.full((9, 9), 20.5), (np.array([20.5000000, 3.62601891, 3.55521927, 1.20266006e+05, 1.08161135e+05]), True))
-    test_fit_2d_gaussian(rf_field_edge, (np.array([5.0, 8.0, 8.0, 0.0, 0.0]), True))
+    test_fit_2d_gaussian(
+        rf_field_edge, (np.array([5.0, 8.0, 8.0, 0.0, 0.0]), True)
+    )
     pass

--- a/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_receptive_field_mapping.py
+++ b/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_receptive_field_mapping.py
@@ -153,7 +153,7 @@ def test_threshold_rf(rf, threshold, expected_mask, expected_x, expected_y, expe
 
 @pytest.mark.parametrize('matrix,expected',
                          [
-                             (rf_field_real, (np.array([1.04991433e+05, 3.74217858e+00, 3.24465965e+00, 1.66477569e+00, 1.04485211e+00]), True)),
+                             (rf_field_real, (np.array([1.04990549e+05, 3.24465782e+00, 3.74217921e+00, 1.04486140e+00, 1.66478893e+00]), True)),
                              (rf_field_gaussian, (np.array([1.0, 4.0, 4.0, 4.0, 4.0]), True)),
                              (np.zeros((9, 9)), ((np.nan, np.nan, np.nan, np.nan, np.nan), False)),
                              ## These edge cases are too sensitive and will produce different values depending on the


### PR DESCRIPTION
## Summary
https://github.com/AllenInstitute/AllenSDK/issues/2655

`_gaussian_function_2d` expects an input of (x, y), while the fitting function is assuming `_gaussian_function_2d` takes an input of (y, x). 

This causes the x, y values to be flipped for the respected x, y parameters (e.g. center_y, center_x, width_y, width_x)

Micha opened a ticket to report this issue. He suggested a fix to flip the input of the estimated gaussian in the error function after it takes in the incorrect (y, x) indices. 

A simpler fix would be to correct the _gaussian_function_2d to take in (y, x) input.

## Test result of fix:

**Before the fix:**
```
import numpy as np
import matplotlib.pyplot as plt
from allensdk.brain_observatory.ecephys.stimulus_analysis.receptive_field_mapping import (
    fit_2d_gaussian, _gaussian_function_2d)

# Simulate fake highly non-uniform RF 
# (in non-uniform dimensions, to ensure not to confuse x,y)
rf_raw=np.zeros((9,11))
rf_raw[2:8,7]=10
rf_raw[2:8,6]=3
rf_raw[2:8,8]=3

# fit, and apply fitted function 
(peak_height, cy,cx,wy,wx),success=fit_2d_gaussian(rf_raw)
y, x=np.indices((rf_raw.shape)) # rows, cols --> y,x 
rf_fitted=_gaussian_function_2d(peak_height, cy,cx,wy,wx)(x, y)

# compare 
fig,axes=plt.subplots(1,2,figsize=(4,2),sharey=True,sharex=True)
axes[0].imshow(rf_raw)
axes[0].set_title('original RF')
axes[1].imshow(rf_fitted)
axes[1].set_title('fitted RF \n (current function)')
```
![image](https://user-images.githubusercontent.com/10882060/233743214-a4f83521-f3e2-4656-b762-fee3518f0ed2.png)

**After the fix and updating `rf_fitted` to abide by the input specification for `_gaussian_function_2d`**
```
import numpy as np
import matplotlib.pyplot as plt
from allensdk.brain_observatory.ecephys.stimulus_analysis.receptive_field_mapping import (
    fit_2d_gaussian, _gaussian_function_2d)

# Simulate fake highly non-uniform RF 
# (in non-uniform dimensions, to ensure not to confuse x,y)
rf_raw=np.zeros((9,11))
rf_raw[2:8,7]=10
rf_raw[2:8,6]=3
rf_raw[2:8,8]=3

# fit, and apply fitted function 
(peak_height, cy,cx,wy,wx),success=fit_2d_gaussian(rf_raw)
y, x=np.indices((rf_raw.shape)) # rows, cols --> y,x 
rf_fitted=_gaussian_function_2d(peak_height, cy,cx,wy,wx)(y, x)

# compare 
fig,axes=plt.subplots(1,2,figsize=(4,2),sharey=True,sharex=True)
axes[0].imshow(rf_raw)
axes[0].set_title('original RF')
axes[1].imshow(rf_fitted)
axes[1].set_title('fitted RF \n (current function)')
```
![image](https://user-images.githubusercontent.com/10882060/233743118-443197e8-a4da-4815-a862-f4a67675dacf.png)
