### PR TITLE
Bugfix/im read

### DIFF
--- a/allensdk/brain_observatory/behavior/data_objects/projections.py
+++ b/allensdk/brain_observatory/behavior/data_objects/projections.py
@@ -1,4 +1,4 @@
-from matplotlib import image as mpimg
+from PIL import Image as PILImage
 from pynwb import NWBFile
 
 from allensdk.core import DataObject
@@ -150,7 +150,7 @@ class Projections(DataObject, LimsReadableInterface, JsonReadableInterface,
         :param pixel_size
             pixel size in um
         """
-        img = mpimg.imread(filepath)
+        img = PILImage.open(filepath)
         img = ImageApi.serialize(img, [pixel_size / 1000.,
                                        pixel_size / 1000.], 'mm')
         img = ImageApi.deserialize(img=img)


### PR DESCRIPTION

# Overview:
Currently, the projections.py code for ophys projections uses imread to process the image paths it receives from LIMS. This is problematic, as the images are were changed to be integer representations for newer experiments are normalized from 0-255. Because the images are png files, imread will automatically cast them to float32 values ranging from 0-1.

# Addresses:
Issue https://github.com/AllenInstitute/AllenSDK/issues/2672


# Sample inputs/outputs 
For experiment 1194754135 , here is a comparison of the table generated in an NWB file for the average image.

Using imread:
![image](https://github.com/AllenInstitute/AllenSDK/assets/87045911/42ae960c-befe-4ff0-837b-ceecd811abb4)

With the updated code:
![image](https://github.com/AllenInstitute/AllenSDK/assets/87045911/bf8d7934-1cfd-4ad0-9180-49444a5adb5a)

Note the change from floating points to unsigned ints. 


# Type of Fix:

- [ ] Bug fix (non-breaking change which fixes an issue)


# Solution:
Using
       img = PILImage.open(filepath)
preserves the integer representation of the new projection files, and should still work with the older floating point projection files.

# Changes:
replaced imread for projections to PILImage

# Validation:
Generated an NWB file that passes validation by dandi 


