### PR TITLE
Fix for namespaces issue

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -9,9 +9,6 @@ import pynwb
 
 from .ecephys_session_api import EcephysSessionApi
 from allensdk.brain_observatory.nwb.nwb_api import NwbApi
-import \
-    allensdk.brain_observatory.ecephys.nwb  # noqa Necessary to import pyNWB
-# namespaces
 from allensdk.brain_observatory.ecephys import get_unit_filter_value
 from allensdk.brain_observatory.nwb import check_nwbfile_version
 from .._channels import Channels

--- a/allensdk/brain_observatory/nwb/nwb_api.py
+++ b/allensdk/brain_observatory/nwb/nwb_api.py
@@ -10,10 +10,6 @@ from allensdk.brain_observatory.behavior.data_objects.stimuli.presentations \
 from allensdk.brain_observatory.running_speed import RunningSpeed
 from allensdk.brain_observatory.behavior.image_api import ImageApi
 
-namespace_path = Path(__file__).parent / \
-                 'ndx-aibs-behavior-ophys.namespace.yaml'
-pynwb.load_namespaces(str(namespace_path))
-
 
 class NwbApi:
 
@@ -24,7 +20,7 @@ class NwbApi:
         if hasattr(self, '_nwbfile'):
             return self._nwbfile
 
-        io = pynwb.NWBHDF5IO(self.path, 'r')
+        io = pynwb.NWBHDF5IO(self.path, 'r', load_namespaces=True)
         return io.read()
 
     def __init__(self, path, **kwargs):


### PR DESCRIPTION
# Overview:
Conflicting namespaces for ecephys files (neuropixels nwb files) mean that `EcephysSession`s and `BehaviourEcephysSession`s cannot be imported simultaneously. Foregoing manual namespace loading in the `NwbApi` and relying on loading fromt he nwb files themselves seems to fix this.

# Addresses:

Addresses #2713

# Type of Fix:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Changes:
- Delete lines that load a conflicting namespace in the `nwb_api file and the `ecephys_nwb_session_api` file
- Set the NwbApi to load namespaces from nwb files

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
