### PR TITLE
unpin hdmf and pynwb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2-binary
-hdmf
+hdmf!=3.5.*,!=3.6.*,!=3.7.*,!=3.8.*
 h5py
 matplotlib
 numpy<1.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2-binary
-hdmf<=3.4.7
+hdmf
 h5py
 matplotlib
 numpy<1.24
@@ -19,7 +19,7 @@ simpleitk
 argschema
 glymur
 xarray<2023.2.0
-pynwb<=2.3.3
+pynwb
 tables
 seaborn
 aiohttp


### PR DESCRIPTION
hdmf version testing

* 3.9.0 PASS
* 3.8.0 FAILED
  * FAILED allensdk/test/brain_observatory/ecephys/test_write_nwb.py::test_write_probe_lfp_file_roundtrip[True] - ValueError: io has already been set for this container (name=root, type=<class 'pynwb.file.NWBFile'>)
  * FAILED allensdk/test/brain_observatory/ecephys/test_write_nwb.py::test_write_probe_lfp_file_roundtrip[False] - ValueError: io has already been set for this container (name=root, type=<class 'pynwb.file.NWBFile'>)
* 3.7.0 FAILED
  * FAILED allensdk/test/brain_observatory/ecephys/test_write_nwb.py::test_write_probe_lfp_file_roundtrip[True] - ValueError: io has already been set for this container (name=root, type=<class 'pynwb.file.NWBFile'>)
  * FAILED allensdk/test/brain_observatory/ecephys/test_write_nwb.py::test_write_probe_lfp_file_roundtrip[False] - ValueError: io has already been set for this container (name=root, type=<class 'pynwb.file.NWBFile'>)
* 3.5.0 FAILED
  * FAILED allensdk/test/brain_observatory/ecephys/test_write_nwb.py:test_add_invalid_times - ValueError: Invalid dataset identifier (invalid dataset identifier)
* 3.4.7 PASS

Fixed issue link https://github.com/hdmf-dev/hdmf/issues/914
