### PR TITLE
ticket/PSB-260: Bug fix to VBN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.16.2] = 2023-11-29
+- See release notes on Github
+- Commit code used to create new VBN data release.
+- Update VBN changelog..
+
 ## [2.16.1] = 2023-11-13
 - See release notes on Github
 - Update testing

--- a/allensdk/__init__.py
+++ b/allensdk/__init__.py
@@ -35,7 +35,7 @@
 #
 import logging
 
-__version__ = '2.16.1'
+__version__ = '2.16.2'
 
 
 try:

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/tables/metadata_table_schemas.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/tables/metadata_table_schemas.py
@@ -11,7 +11,8 @@ to validating typing against expected values in the session objects.
 class BehaviorSessionMetadataSchema(RaisingSchema):
     age_in_days = Int(required=True, description="Subject age")
     behavior_session_id = Int(
-        required=True,
+        required=False,
+        allow_none=True,
         description=(
             "Unique identifier for the "
             "behavior session to write into "
@@ -19,41 +20,59 @@ class BehaviorSessionMetadataSchema(RaisingSchema):
         ),
     )
     cre_line = String(
-        required=True, description="Genetic cre line of the subject."
+        required=False,
+        allow_none=True,
+        description="Genetic cre line of the subject."
     )
     date_of_acquisition = String(
-        required=True,
+        required=False,
+        allow_none=True,
         description=(
             "Date of acquisition of " "behavior session, in string " "format"
         ),
     )
     driver_line = List(
         String,
-        required=True,
+        required=False,
+        allow_none=True,
         cli_as_single_argument=True,
         description="Genetic driver line(s) of subject",
     )
     equipment_name = String(
-        required=True, description=("Name of the equipment used.")
+        required=False,
+        allow_none=True,
+        description=("Name of the equipment used.")
     )
     full_genotype = String(
-        required=True, description="Full genotype of subject"
+        required=False,
+        allow_none=True,
+        description="Full genotype of subject"
     )
     mouse_id = String(
-        required=True,
+        required=False,
+        allow_none=True,
         description="LabTracks ID of the subject. aka external_specimen_name.",
     )
     project_code = String(
-        rquired=True,
+        rquired=False,
+        allow_none=True,
         description="LabTracks ID of the subject. aka external_specimen_name.",
     )
     reporter_line = String(
-        required=True, description="Genetic reporter line(s) of subject"
+        required=False,
+        allow_none=True,
+        description="Genetic reporter line(s) of subject"
     )
     session_type = String(
-        required=True, description="Full name of session type."
+        required=False,
+        allow_none=True,
+        description="Full name of session type."
     )
-    sex = String(required=True, description="Subject sex")
+    sex = String(
+        required=False,
+        allow_none=True,
+        description="Subject sex"
+    )
 
     @mm.post_load
     def convert_date_time(self, data, **kwargs):

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
@@ -597,10 +597,18 @@ class Presentations(
             found, return input_df unmodified.
         """
         if "omitted" in input_df.columns and len(input_df) > 0:
-            first_row = input_df.iloc[0]
-            if not pd.isna(first_row["omitted"]):
-                if first_row["omitted"]:
-                    input_df = input_df.drop(first_row.name, axis=0)
+            if "stimulus_block" in input_df.columns:
+                for stim_block in input_df['stimulus_block'].unique():
+                    first_row = input_df[
+                        input_df['stimulus_block'] == stim_block].iloc[0]
+                    if not pd.isna(first_row["omitted"]):
+                        if first_row["omitted"]:
+                            input_df = input_df.drop(first_row.name, axis=0)
+            else:
+                first_row = input_df.iloc[0]
+                if not pd.isna(first_row["omitted"]):
+                    if first_row["omitted"]:
+                        input_df = input_df.drop(first_row.name, axis=0)
         return input_df
 
     @staticmethod

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/presentations.py
@@ -596,19 +596,28 @@ class Presentations(
             Dataframe with omitted stimulus removed from first row or if not
             found, return input_df unmodified.
         """
+
+        def safe_omitted_check(input_df: pd.Series,
+                               stimulus_block: Optional[int]):
+            if stimulus_block is not None:
+                first_row = input_df[
+                    input_df['stimulus_block'] == stim_block].iloc[0]
+            else:
+                first_row = input_df.iloc[0]
+
+            if not pd.isna(first_row["omitted"]):
+                if first_row["omitted"]:
+                    input_df = input_df.drop(first_row.name, axis=0)
+            return input_df
+
         if "omitted" in input_df.columns and len(input_df) > 0:
             if "stimulus_block" in input_df.columns:
                 for stim_block in input_df['stimulus_block'].unique():
-                    first_row = input_df[
-                        input_df['stimulus_block'] == stim_block].iloc[0]
-                    if not pd.isna(first_row["omitted"]):
-                        if first_row["omitted"]:
-                            input_df = input_df.drop(first_row.name, axis=0)
+                    input_df = safe_omitted_check(input_df=input_df,
+                                                  stimulus_block=stim_block)
             else:
-                first_row = input_df.iloc[0]
-                if not pd.isna(first_row["omitted"]):
-                    if first_row["omitted"]:
-                        input_df = input_df.drop(first_row.name, axis=0)
+                input_df = safe_omitted_check(input_df=input_df,
+                                              stimulus_block=None)
         return input_df
 
     @staticmethod

--- a/allensdk/brain_observatory/behavior/write_nwb/behavior/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/behavior/__main__.py
@@ -27,6 +27,9 @@ class WriteBehaviorNWB(argschema.ArgSchemaParser):
             nwb_filepath=bs_id_dir / f"behavior_session_{bs_id}.nwb",
             skip_metadata=self.args["skip_metadata_key"],
             skip_stim=self.args["skip_stimulus_file_key"],
+            include_experiment_description=self.args[
+                'include_experiment_description'
+            ]
         )
         logging.info("File successfully created")
 
@@ -43,6 +46,7 @@ class WriteBehaviorNWB(argschema.ArgSchemaParser):
         nwb_filepath: Path,
         skip_metadata: List[str],
         skip_stim: List[str],
+        include_experiment_description=True
     ) -> str:
         """Load and write a BehaviorSession as NWB.
 
@@ -61,6 +65,8 @@ class WriteBehaviorNWB(argschema.ArgSchemaParser):
             List of metadata keys to skip when comparing data.
         skip_stim : list of str
             List of stimulus file keys to skip when comparing data.
+        include_experiment_description : bool
+            If True, include experiment description in NWB file.
 
         Returns
         -------
@@ -79,7 +85,11 @@ class WriteBehaviorNWB(argschema.ArgSchemaParser):
             session_data=behavior_session_metadata,
             serializer=BehaviorSession,
         )
-        nwb_writer.write_nwb(skip_metadata=skip_metadata, skip_stim=skip_stim)
+        nwb_writer.write_nwb(
+            skip_metadata=skip_metadata,
+            skip_stim=skip_stim,
+            include_experiment_description=include_experiment_description
+        )
 
         return str(nwb_filepath)
 

--- a/allensdk/brain_observatory/behavior/write_nwb/nwb_writer_utils.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/nwb_writer_utils.py
@@ -13,6 +13,7 @@ class OphysNwbWriter(NWBWriter):
         self,
         lims_session: BehaviorSession,
         ophys_experiment_ids: Optional[List[int]] = None,
+        **kwargs
     ) -> BehaviorSession:
         """Call session methods to update certain values within the session.
 

--- a/allensdk/brain_observatory/behavior/write_nwb/ophys/__main__.py
+++ b/allensdk/brain_observatory/behavior/write_nwb/ophys/__main__.py
@@ -29,6 +29,9 @@ class WriteOphysNWB(argschema.ArgSchemaParser):
             nwb_filepath=oe_id_dir / f"behavior_ophys_experiment_{oe_id}.nwb",
             skip_metadata=self.args["skip_metadata_key"],
             skip_stim=self.args["skip_stimulus_file_key"],
+            include_experiment_description=self.args[
+                'include_experiment_description'
+            ]
         )
         logging.info("File successfully created")
 
@@ -43,6 +46,7 @@ class WriteOphysNWB(argschema.ArgSchemaParser):
         nwb_filepath: Path,
         skip_metadata: List[str],
         skip_stim: List[str],
+        include_experiment_description=True
     ) -> str:
         """Load and write a BehaviorOphysExperiment as NWB.
 
@@ -61,6 +65,8 @@ class WriteOphysNWB(argschema.ArgSchemaParser):
             List of metadata keys to skip when comparing data.
         skip_stim : list of str
             List of stimulus file keys to skip when comparing data.
+        include_experiment_description : bool
+            If True, include experiment description in NWB file.
 
         Returns
         -------
@@ -83,6 +89,7 @@ class WriteOphysNWB(argschema.ArgSchemaParser):
             ophys_experiment_ids=self.args["ophys_container_experiment_ids"],
             skip_metadata=skip_metadata,
             skip_stim=skip_stim,
+            include_experiment_description=include_experiment_description
         )
 
         return str(nwb_filepath)

--- a/allensdk/brain_observatory/ecephys/_current_source_density.py
+++ b/allensdk/brain_observatory/ecephys/_current_source_density.py
@@ -50,9 +50,10 @@ class CurrentSourceDensity(DataObject, JsonReadableInterface):
 
     @classmethod
     def from_json(cls, probe_meta: dict) -> "CurrentSourceDensity":
+        scale = probe_meta.get("scale_mean_waveform_and_csd", 1)
         with h5py.File(probe_meta['csd_path'], "r") as csd_file:
             return CurrentSourceDensity(
-                data=csd_file["current_source_density"][:],
+                data=csd_file["current_source_density"][:] / scale,
                 timestamps=csd_file["timestamps"][:],
                 interpolated_channel_locations=csd_file["csd_locations"][:]
             )

--- a/allensdk/brain_observatory/ecephys/_units.py
+++ b/allensdk/brain_observatory/ecephys/_units.py
@@ -47,7 +47,8 @@ class Units(DataObject, JsonReadableInterface, NwbReadableInterface):
         )
         mean_waveforms = _read_waveforms_to_dictionary(
             probe['mean_waveforms_path'],
-            local_to_global_unit_map
+            local_to_global_unit_map,
+            mean_waveform_scale=probe.get('scale_mean_waveform_and_csd', 1)
         )
         spike_amplitudes = _read_spike_amplitudes_to_dictionary(
             probe["spike_amplitudes_path"],
@@ -132,6 +133,7 @@ def _read_waveforms_to_dictionary(
         waveforms_path,
         local_to_global_unit_map=None,
         peak_channel_map=None,
+        mean_waveform_scale=1,
 ):
     """ Builds a lookup table for unitwise waveform data
 
@@ -146,6 +148,8 @@ def _read_waveforms_to_dictionary(
         Maps unit identifiers to indices of peak channels. If provided,
         the output will contain only samples on the peak
         channel for each unit.
+    mean_waveform_scale : float, optional
+        Divide out a scaling from the mean_waveform. Default 1.
 
     Returns
     -------
@@ -171,7 +175,7 @@ def _read_waveforms_to_dictionary(
         if peak_channel_map is not None:
             waveform = waveform[:, peak_channel_map[unit_id]]
 
-        output_waveforms[unit_id] = np.squeeze(waveform)
+        output_waveforms[unit_id] = np.squeeze(waveform) / mean_waveform_scale
 
     return output_waveforms
 

--- a/allensdk/brain_observatory/ecephys/_units.py
+++ b/allensdk/brain_observatory/ecephys/_units.py
@@ -129,7 +129,9 @@ def _read_spike_amplitudes_to_dictionary(
 
 
 def _read_waveforms_to_dictionary(
-        waveforms_path, local_to_global_unit_map=None, peak_channel_map=None
+        waveforms_path,
+        local_to_global_unit_map=None,
+        peak_channel_map=None,
 ):
     """ Builds a lookup table for unitwise waveform data
 

--- a/allensdk/brain_observatory/ecephys/write_nwb/schemas.py
+++ b/allensdk/brain_observatory/ecephys/write_nwb/schemas.py
@@ -204,6 +204,16 @@ class Probe(RaisingSchema):
         help="""amplitude scale factor converting raw amplitudes to Volts.
                 Default converts from bits -> uV -> V""",
     )
+    scale_mean_waveform_and_csd = Float(
+        default=1,
+        allow_none=True,
+        help="""Amount to scale the mean waveform and CSD by. (data / scale).
+                This is a fix for a set of data documented in the change log.
+                The values for unit amplitudes were changed in the input_json
+                file and do not use this scale.
+                If the data in LIMS for these sessions is updated, this scaling
+                is not needed. Default is 1"""
+    )
 
 
 class InvalidEpoch(RaisingSchema):

--- a/doc_template/index.rst
+++ b/doc_template/index.rst
@@ -118,6 +118,12 @@ The Allen SDK provides Python code for accessing experimental metadata along wit
 
 See the `mouse connectivity section <connectivity.html>`_ for more details.
 
+What's new - 2.16.2
+----------------------------------------------------------------------
+- See full release notes on Github
+- Commit code used to create new VBN data release.
+- Update VBN changelog.
+
 What's new - 2.16.1
 ----------------------------------------------------------------------
 - See full release notes on Github

--- a/doc_template/visual_behavior_neuropixels.rst
+++ b/doc_template/visual_behavior_neuropixels.rst
@@ -36,6 +36,18 @@ Visual Behavior - Neuropixels
 DATA FILE CHANGELOG
 -------------------
 
+**v0.5.0**
+
+- Updated stimulus presentations tables.
+- Add LFP sample rate when loading from cache.
+- Fixed scaling of LFP data in multiple sessions. Amplitudes were off by a
+  factor of 2 for most ecephys sessions. The scaling is also
+  corrected in released metadata tables.
+    - All ecephys sessions except those listed here had the issue with the
+      LFP amplitude scaling: 1059678195, 1108334384, 1108531612, 1109680280,
+      1109889304, 1111013640, 1111216934, 1112302803, 1112515874, 1113751921,
+      1113957627, 1115077618, 1115356973, 1118324999, 1118512505
+
 **v0.4.0-fix**
 
 - Added stimulus presentations columns that are computed on load:

--- a/doc_template/visual_behavior_neuropixels.rst
+++ b/doc_template/visual_behavior_neuropixels.rst
@@ -39,14 +39,18 @@ DATA FILE CHANGELOG
 **v0.5.0**
 
 - Updated stimulus presentations tables.
-- Add LFP sample rate when loading from cache.
+- Add LFP sample rate when loading from cache. (Value is duplicated in the
+  probes metadata table.)
 - Fixed scaling of LFP data in multiple sessions. Amplitudes were off by a
-  factor of 2 for most ecephys sessions. The scaling is also
-  corrected in released metadata tables.
-    - All ecephys sessions except those listed here had the issue with the
-      LFP amplitude scaling: 1059678195, 1108334384, 1108531612, 1109680280,
-      1109889304, 1111013640, 1111216934, 1112302803, 1112515874, 1113751921,
-      1113957627, 1115077618, 1115356973, 1118324999, 1118512505
+  factor of 2 for most ecephys sessions. Specifically changed were units
+  table in the session amplitude, recovery_slope, and repolarization_slopelfp data, mean
+  waveform, and current source density data in the NWB files. The scaling is
+  also corrected in released metadata tables.
+    - All ecephys sessions had this issue except those listed here: 1059678195,
+      1108334384, 1108531612, 1109680280, 1109889304, 1111013640, 1111216934,
+      1112302803, 1112515874, 1113751921, 1113957627, 1115077618, 1115356973,
+      1118324999, 1118512505
+- Added quality column to units table.
 
 **v0.4.0-fix**
 


### PR DESCRIPTION
Expand logic to drop an omitted stimulus as first to the replay block of VBN.

Added logic to allow for VBN data to run through behavior nwb creation. Missing column not in VBN behavior_sessions metadata table.