### PR TITLE
Provide accurate documentation for brain_observatory_cache.get_eye_tracking

### DIFF
--- a/allensdk/core/brain_observatory_cache.py
+++ b/allensdk/core/brain_observatory_cache.py
@@ -654,9 +654,15 @@ class BrainObservatoryCache(Cache):
         Returns
         -------
         `numpy.ndarray`
-            Contents of array unknown. Assumed to be [n_frames, 5] where
-            the meaning of the values in each column are unknown.
-            Ask Saskia De Vries saskiad@alleninstitute.org
+            Shape of array is (n_frames, 5). Values at axis=1 store the following data:
+                [:, 0] is the frame number
+                [:, 1] is the DLC-computed eye area in cm^2
+                [:, 2] is the pupil area in cm^2
+                [:, 3] is the x (azimuth) position of the pupil in degrees
+                [:, 4] is the y (altitude/elevation) position of the pupil in degrees
+            DLC refers to DeepLabCut (Mathis et al., 2018, Nature), a tool used to track eyes from videos.
+            See King et al., 2023, eNeuro, and de Vries et al., 2018, Nature for more info on eye tracking methods.
+            Contact saskiad@alleninstitute.org and chase.king@alleninstitute.org with any questions.
         """
         cloud_cache = S3CloudCache(
             cache_dir=Path(self.manifest_path).parent / "s3_cache",

--- a/allensdk/core/brain_observatory_cache.py
+++ b/allensdk/core/brain_observatory_cache.py
@@ -654,15 +654,18 @@ class BrainObservatoryCache(Cache):
         Returns
         -------
         `numpy.ndarray`
-            Shape of array is (n_frames, 5). Values at axis=1 store the following data:
+            Shape of array is (n_frames, 5). Values at axis=1 store the following:
                 [:, 0] is the frame number
-                [:, 1] is the DLC-computed eye area in cm^2
+                [:, 1] is the computed eye area in cm^2
                 [:, 2] is the pupil area in cm^2
                 [:, 3] is the x (azimuth) position of the pupil in degrees
-                [:, 4] is the y (altitude/elevation) position of the pupil in degrees
-            DLC refers to DeepLabCut (Mathis et al., 2018, Nature), a tool used to track eyes from videos.
-            See King et al., 2023, eNeuro, and de Vries et al., 2018, Nature for more info on eye tracking methods.
-            Contact saskiad@alleninstitute.org and chase.king@alleninstitute.org with any questions.
+                [:, 4] is the y (altitude) position of the pupil in degrees
+            Metrics are computed using DeepLabCut (Mathis et al., 2018, Nature)
+            from videos of the mouse's eye during experimentation.
+            See King et al., 2023, eNeuro, and de Vries et al., 2018, Nature for
+            more info on eye tracking methods.
+            Contact saskiad@alleninstitute.org and chase.king@alleninstitute.org
+            with any questions.
         """
         cloud_cache = S3CloudCache(
             cache_dir=Path(self.manifest_path).parent / "s3_cache",

--- a/allensdk/core/brain_observatory_cache.py
+++ b/allensdk/core/brain_observatory_cache.py
@@ -655,7 +655,8 @@ class BrainObservatoryCache(Cache):
         -------
         `numpy.ndarray`
             Shape of array is (n_frames, 5). Values at axis=1 store the following:
-                [:, 0] is the frame number
+                [:, 0] is the 2-photon frame number. Can be parsed as int and
+                    uses the same indexing as calcium imaging frames.
                 [:, 1] is the computed eye area in cm^2
                 [:, 2] is the pupil area in cm^2
                 [:, 3] is the x (azimuth) position of the pupil in degrees

--- a/allensdk/core/brain_observatory_cache.py
+++ b/allensdk/core/brain_observatory_cache.py
@@ -656,7 +656,7 @@ class BrainObservatoryCache(Cache):
         `numpy.ndarray`
             Shape of array is (n_frames, 5). Values at axis=1 store the following:
                 [:, 0] is the 2-photon frame number. Can be parsed as int and
-                    uses the same indexing as calcium imaging frames.
+                    used to index calcium imaging dF/F arrays, for example.
                 [:, 1] is the computed eye area in cm^2
                 [:, 2] is the pupil area in cm^2
                 [:, 3] is the x (azimuth) position of the pupil in degrees


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
I was involved in generating eye tracking files and packaging them into a format that can be used in the BrainObservatoryCache. I noticed the method to access these data did not have proper documentation; this commit gives the method proper documentation to ensure the user knows what the method returns.

# Type of Fix:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [x] Documentation Change

# Solution:
Implements correct documentation for the method

# Changes:
Documentation on the get_eye_tracking method in brain_observatory cache is amended to describe the returned data array. Changes are entirely in method documentation comments and thus unit tests are not needed.

# Validation:
N/A

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
