### PR TITLE
fix for nans in table["color"].str.match(color_triplet_re)

### DIFF
--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py
@@ -90,7 +90,7 @@ class EcephysNwbSessionApi(NwbApi, EcephysSessionApi):
             # coded as rgb triplets and the other as -1 or 1
             if "color_triplet" not in table.columns:
                 table["color_triplet"] = pd.Series("", index=table.index)
-            rgb_color_match = table["color"].str.match(color_triplet_re)
+            rgb_color_match = table["color"].str.match(color_triplet_re).astype(bool)
             table.loc[rgb_color_match, "color_triplet"] = table.loc[
                 rgb_color_match, "color"]
             table.loc[rgb_color_match, "color"] = ""


### PR DESCRIPTION
# Overview:
rf_mapping.get_receptive_field fails with following error: 
```
File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb_session_api.py:95, in EcephysNwbSessionApi.get_stimulus_presentations(self)
     93     print("wvfdvwcw")
     94 rgb_color_match = table["color"].str.match(color_triplet_re)#.astype(bool)
---> 95 table.loc[rgb_color_match, "color_triplet"] = table.loc[
     96     rgb_color_match, "color"]
     97 table.loc[rgb_color_match, "color"] = ""
     99 # make sure the color column's values are numeric

File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/pandas/core/indexing.py:1184, in _LocationIndexer.__getitem__(self, key)
   1182     if self._is_scalar_access(key):
   1183         return self.obj._get_value(*key, takeable=self._takeable)
-> 1184     return self._getitem_tuple(key)
   1185 else:
   1186     # we by definition only have the 0th axis
   1187     axis = self.axis or 0

File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/pandas/core/indexing.py:1368, in _LocIndexer._getitem_tuple(self, tup)
   1366 with suppress(IndexingError):
   1367     tup = self._expand_ellipsis(tup)
-> 1368     return self._getitem_lowerdim(tup)
   1370 # no multi-index, so validate all of the indexers
   1371 tup = self._validate_tuple_indexer(tup)

File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/pandas/core/indexing.py:1089, in _LocationIndexer._getitem_lowerdim(self, tup)
   1087             return section
   1088         # This is an elided recursive call to iloc/loc
-> 1089         return getattr(section, self.name)[new_key]
   1091 raise IndexingError("not applicable")

File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/pandas/core/indexing.py:1191, in _LocationIndexer.__getitem__(self, key)
   1189 maybe_callable = com.apply_if_callable(key, self.obj)
   1190 maybe_callable = self._check_deprecated_callable_usage(key, maybe_callable)
-> 1191 return self._getitem_axis(maybe_callable, axis=axis)

File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/pandas/core/indexing.py:1412, in _LocIndexer._getitem_axis(self, key, axis)
   1410     self._validate_key(key, axis)
   1411     return self._get_slice_axis(key, axis=axis)
-> 1412 elif com.is_bool_indexer(key):
   1413     return self._getbool_axis(key, axis=axis)
   1414 elif is_list_like_indexer(key):
   1415     # an iterable multi-selection

File /alzheimer/Roberto/Software/mambaforge/envs/Visual_decoding/lib/python3.11/site-packages/pandas/core/common.py:136, in is_bool_indexer(key)
    132     na_msg = "Cannot mask with non-boolean array containing NA / NaN values"
    133     if lib.is_bool_array(key_array, skipna=True):
    134         # Don't raise on e.g. ["A", "B", np.nan], see
    135         #  test_loc_getitem_list_of_labels_categoricalindex_with_na
--> 136         raise ValueError(na_msg)
    137     return False
    138 return True

ValueError: Cannot mask with non-boolean array containing NA / NaN values
```
you can reproduce it here:
```

from allensdk.brain_observatory.behavior.behavior_project_cache.behavior_neuropixels_project_cache import VisualBehaviorNeuropixelsProjectCache
from Utils.Settings import output_folder_calculations, neuropixel_dataset_behavior
from allensdk.brain_observatory.ecephys.stimulus_analysis.receptive_field_mapping import ReceptiveFieldMapping
from allensdk.brain_observatory.ecephys.ecephys_session import EcephysSession
import numpy as np


cache = VisualBehaviorNeuropixelsProjectCache.from_s3_cache(cache_dir=neuropixel_dataset_behavior)

sessions = cache.get_ecephys_session_table(filter_abnormalities=True)
ecephys_session_id = sessions.index[62]

session = EcephysSession.from_nwb_path(
                path=f"{neuropixel_dataset_behavior}/visual-behavior-neuropixels-0.5.0/behavior_ecephys_sessions/{ecephys_session_id}/ecephys_session_{ecephys_session_id}.nwb", nwb_version=2,  api_kwargs={
        "amplitude_cutoff_maximum": 0.1,
        "presence_ratio_minimum": 0.9,
        "isi_violations_maximum": 0.5,
        "filter_by_validity": True
    })

area = "VISp"
units = session.units

sel_units = units[units["structure_acronym"] == area]

rf_mapping = ReceptiveFieldMapping(session, col_pos_x="position_x",
        col_pos_y="position_y")

RF = rf_mapping.get_receptive_field(sel_units.index[0])
```