### PR TITLE
Update numpy version constraint to allow 1.24.x

### DIFF
--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache_data_model/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache_data_model/conftest.py
@@ -128,9 +128,10 @@ def driver_lookup(behavior_session_id_list):
                 ["aa", "bb"],
                 ["cc"],
                 ["cc", "dd"])
-    chosen = rng.choice(possible,
-                        size=len(behavior_session_id_list),
-                        replace=True)
+    # Use integers to index into possible since numpy 1.24+ doesn't support
+    # choice() with sequences of inhomogeneous shapes (lists of different lengths)
+    indices = rng.integers(0, len(possible), size=len(behavior_session_id_list))
+    chosen = [possible[i] for i in indices]
     return {ii: val
             for ii, val in zip(behavior_session_id_list,
                                chosen)}

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -11,7 +11,7 @@ jupyter
 psycopg2-binary
 h5py
 matplotlib
-numpy<1.24
+numpy<1.25
 pandas==1.5.3
 jinja2
 scipy<1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ psycopg2-binary
 hdmf!=3.5.*,!=3.6.*,!=3.7.*,!=3.8.*
 h5py
 matplotlib
-numpy<1.24
+numpy<1.25
 pandas==1.5.3
 jinja2
 scipy<1.11


### PR DESCRIPTION
<!--Thank you for contributing to AllenSDK, your work and time will help to
advance open science! For full contribution guidelines check out our
guide on GitHub here, https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md-->

# Overview:
<!-- Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the full contribution guidelines.
example: 
Science team is not able to load max or avg projections for experiment
session #x. A image cannot be created because input pixel
resolution is (0,0). It was found through investigation that the
experiment database query was returning a 0 pixel resolution for this
experiment.-->

- Update numpy<1.24 to numpy<1.25 in requirements.txt and doc_requirements.txt
- Fix numpy 1.24+ compatibility issue in test conftest.py where rng.choice() no longer accepts sequences with inhomogeneous shapes (lists of different lengths). Use rng.integers() to generate indices instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Addresses:
<!-- Add a link to the issue on Github board
example: 
Addresses issue [#1234](git_hub_ticket_url)-->

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Updates requirements files and compatibility issue

# Changes:
<!-- Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials(unit tests,
integration tests, etc
example:
- Check for 0 pixel resolution coming from LIMs
- Assignment of default value of x in case of zero return
- Unit tests for the resolution gettr function to test for various edge cases
-->
See above.

# Validation:
<!-- Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration
example:
- Screenshot of max projection from failing session
- Screenshot of avg projection from failing session
- Screenshot of passing unit tests
- Description of unit test cases
- Attached script to create max and avg projections of behavior session
- Windows 10.x.x.x, Surface Book 2 baseline, Conda Version 1.x.x-->
### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

Tests that were failing due to numpy compatibility were fixed. There are still many test errors due to other issues that will be addressed in a separate PR.

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [ ] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [ ] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [ ] My code passes all AllenSDK tests

# Notes:
<!-- Use this section to add anything you think worth mentioning to the
reader of the issue
example:
I noticed that values from the database query for pixel resolution are returning zero
I have made a new issue to address this error at #5678. I believe this is an 
error as all sessions should have a pixel resolution.-->
