### PR TITLE
 GH #2744: Fix installation on Python 3.12, 3.13

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Lint
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: flake8 linting
         run: |
           pip install flake8
@@ -43,28 +43,30 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest", "windows-latest", "ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-latest"]
+        python-version: ["3.10", "3.13"]
+        include:
+          - os: "macos-latest"
+            python-version: "3.13"
+          - os: "windows-latest"
+            python-version: "3.13"
       fail-fast: false
-    defaults:
-      run:
-        shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          activate-environment: test-env
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            test_requirements.txt
       - name: Install
         run: |
-          conda activate test-env
-          pip install codecov
           pip install -r test_requirements.txt
           pip install .
       - name: Test
         run: |
-          py.test --cov=allensdk -n 4
+          python -m pytest -n 4 ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13') && '--cov=allensdk' || '' }}
 
   onprem:
     name: python ${{ matrix.image }} on-prem test
@@ -73,7 +75,7 @@ jobs:
       matrix:
         image: ["allensdk_local_py38:latest"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: run test in docker
         run: |
           docker run \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
         image: ["allensdk_local_py38:latest"]
         branch: ["master", "rc/**"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
       - name: run test in docker

--- a/.github/workflows/notebook_runner.yml
+++ b/.github/workflows/notebook_runner.yml
@@ -1,6 +1,6 @@
 name: Notebooks
 on:
-  pull_request:
+  push:
     branches:
       - master
 jobs:
@@ -8,16 +8,20 @@ jobs:
     name: Notebook runner
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.8"]
+        python-version: ["3.13"]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest-8x
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev_requirements.txt
+            notebook_requirements.txt
       - name: Install
         run: |
           pip install -r requirements.txt

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_cloud_api.py
@@ -187,7 +187,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         df = sanitize_data_columns(session_table_path, {"mouse_id": str})
         # Add UTC to match DateOfAcquisition object.
         df["date_of_acquisition"] = pd.to_datetime(
-            df["date_of_acquisition"], utc="True"
+            df["date_of_acquisition"], format="ISO8601", utc=True
         )
         df = enforce_df_int_typing(
             input_df=df, int_columns=VBO_INTEGER_COLUMNS, use_pandas_type=True
@@ -217,7 +217,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         df = sanitize_data_columns(session_table_path, {"mouse_id": str})
         # Add UTC to match DateOfAcquisition object.
         df["date_of_acquisition"] = pd.to_datetime(
-            df["date_of_acquisition"], utc="True"
+            df["date_of_acquisition"], format="ISO8601", utc=True
         )
         df = enforce_df_int_typing(
             input_df=df, int_columns=VBO_INTEGER_COLUMNS, use_pandas_type=True
@@ -252,7 +252,7 @@ class BehaviorProjectCloudApi(BehaviorProjectBase, ProjectCloudApiBase):
         df = sanitize_data_columns(experiment_table_path, {"mouse_id": str})
         # Add UTC to match DateOfAcquisition object.
         df["date_of_acquisition"] = pd.to_datetime(
-            df["date_of_acquisition"], utc="True"
+            df["date_of_acquisition"], format="ISO8601", utc=True
         )
         df = enforce_df_int_typing(
             input_df=df, int_columns=VBO_INTEGER_COLUMNS, use_pandas_type=True

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/project_apis/data_io/behavior_project_lims_api.py
@@ -511,7 +511,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         )
         # Make date time explicitly UTC.
         table["date_of_acquisition"] = pd.to_datetime(
-            table["date_of_acquisition"], utc=True
+            table["date_of_acquisition"], format="ISO8601", utc=True
         )
 
         # Fill NaN values of imaging_plane_group_count with zero to match
@@ -554,7 +554,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         """
         df = self._get_ophys_experiment_table()
         df["date_of_acquisition"] = pd.to_datetime(
-            df["date_of_acquisition"], utc=True
+            df["date_of_acquisition"], format="ISO8601", utc=True
         )
         # Set type to pandas.Int64 to enforce integer typing and not revert to
         # float.
@@ -581,7 +581,7 @@ class BehaviorProjectLimsApi(BehaviorProjectBase):
         summary_tbl = self._get_behavior_summary_table()
         # Add UTC time zone to match timezone from DateOfAcquisition object.
         summary_tbl["date_of_acquisition"] = pd.to_datetime(
-            summary_tbl["date_of_acquisition"], utc=True
+            summary_tbl["date_of_acquisition"], format="ISO8601", utc=True
         )
         # Query returns float typing of age_in_days. Convert to int to match
         # typing of the Age data_object.

--- a/allensdk/brain_observatory/behavior/behavior_project_cache/tables/metadata_table_schemas.py
+++ b/allensdk/brain_observatory/behavior/behavior_project_cache/tables/metadata_table_schemas.py
@@ -78,7 +78,7 @@ class BehaviorSessionMetadataSchema(RaisingSchema):
     def convert_date_time(self, data, **kwargs):
         """Change date_of_acquisition to a date time type from string."""
         data["date_of_acquisition"] = pd.to_datetime(
-            data["date_of_acquisition"], utc=True
+            data["date_of_acquisition"], format="ISO8601", utc=True
         )
         return data
 

--- a/allensdk/brain_observatory/behavior/data_objects/cell_specimens/cell_specimens.py
+++ b/allensdk/brain_observatory/behavior/data_objects/cell_specimens/cell_specimens.py
@@ -857,13 +857,13 @@ class CellSpecimens(
             if traces is None:
                 continue
             # validate traces contain expected roi ids
-            if not np.in1d(traces.value.index, cell_roi_ids).all():
+            if not np.isin(traces.value.index, cell_roi_ids).all():
                 raise RuntimeError(
                     f"{traces.name} contains ROI IDs that "
                     f"are not in "
                     f"cell_specimen_table.cell_roi_id"
                 )
-            if not np.in1d(cell_roi_ids, traces.value.index).all():
+            if not np.isin(cell_roi_ids, traces.value.index).all():
                 raise RuntimeError(
                     f"cell_specimen_table contains ROI IDs "
                     f"that are not in {traces.name}"

--- a/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_metadata.py
+++ b/allensdk/brain_observatory/behavior/data_objects/metadata/behavior_metadata/behavior_metadata.py
@@ -149,7 +149,7 @@ def get_task_parameters(data: Dict) -> Dict:
     # displayed stimuli (no flashes).
 
     if stim_duration is None:
-        stim_duration = np.NaN
+        stim_duration = np.nan
     else:
         stim_duration = stim_duration[0]
 

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_acquisition.py
@@ -129,7 +129,7 @@ class RunningAcquisition(DataObject,
         cls,
         nwbfile: NWBFile
     ) -> "RunningAcquisition":
-        running_module = nwbfile.modules['running']
+        running_module = nwbfile.processing['running']
         dx_interface = running_module.get_data_interface('dx')
 
         dx = dx_interface.data

--- a/allensdk/brain_observatory/behavior/data_objects/running_speed/running_speed.py
+++ b/allensdk/brain_observatory/behavior/data_objects/running_speed/running_speed.py
@@ -188,7 +188,7 @@ class RunningSpeed(DataObject,
         nwbfile: NWBFile,
         filtered=True
     ) -> "RunningSpeed":
-        running_module = nwbfile.modules['running']
+        running_module = nwbfile.processing['running']
         interface_name = 'speed' if filtered else 'speed_unfiltered'
         running_interface = running_module.get_data_interface(interface_name)
 

--- a/allensdk/brain_observatory/behavior/data_objects/stimuli/templates.py
+++ b/allensdk/brain_observatory/behavior/data_objects/stimuli/templates.py
@@ -208,7 +208,7 @@ class Templates(DataObject, StimulusFileReadableInterface,
         image_index = IndexSeries(
             name=nwb_template.name,
             data=stimulus_index['image_index'].values,
-            unit='None',
+            unit='N/A',
             indexed_timeseries=nwb_template,
             timestamps=stimulus_index['start_time'].values)
         nwbfile.add_stimulus(image_index)

--- a/allensdk/brain_observatory/behavior/data_objects/task_parameters.py
+++ b/allensdk/brain_observatory/behavior/data_objects/task_parameters.py
@@ -223,7 +223,7 @@ class TaskParameters(DataObject, StimulusFileReadableInterface,
         # displayed stimuli (no flashes).
 
         if stim_duration is None:
-            stim_duration = np.NaN
+            stim_duration = np.nan
         else:
             stim_duration = stim_duration[0]
         return stim_duration

--- a/allensdk/brain_observatory/behavior/data_objects/trials/trial.py
+++ b/allensdk/brain_observatory/behavior/data_objects/trials/trial.py
@@ -415,7 +415,7 @@ class Trial:
         """
         change_frame = trial_dict['change_frame']
         if np.isnan(change_frame):
-            change_time = np.NaN
+            change_time = np.nan
         else:
             change_frame = int(change_frame)
             change_time = self._stimulus_timestamps.value[change_frame]

--- a/allensdk/brain_observatory/behavior/stimulus_processing.py
+++ b/allensdk/brain_observatory/behavior/stimulus_processing.py
@@ -104,9 +104,9 @@ def get_images_dict(pkl) -> Dict:
             meta = dict(
                 image_category=cat.decode("utf-8"),
                 image_name=img_name.decode("utf-8"),
-                orientation=np.NaN,
-                phase=np.NaN,
-                spatial_frequency=np.NaN,
+                orientation=np.nan,
+                phase=np.nan,
+                spatial_frequency=np.nan,
                 image_index=ii,
             )
 
@@ -341,9 +341,9 @@ def get_stimulus_metadata(pkl) -> pd.DataFrame:
             "image_category": ["omitted"],
             "image_name": ["omitted"],
             "image_set": ["omitted"],
-            "orientation": np.NaN,
-            "phase": np.NaN,
-            "spatial_frequency": np.NaN,
+            "orientation": np.nan,
+            "phase": np.nan,
+            "spatial_frequency": np.nan,
             "image_index": len(stimulus_index_df),
         }
     )

--- a/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
+++ b/allensdk/brain_observatory/behavior/swdb/behavior_project_cache.py
@@ -419,7 +419,7 @@ class ExtendedNwbApi(BehaviorOphysNwbApi):
         # What we really want is a dict with image_name as key
         template_dict = {}
         image_index_names = self.get_image_index_names()
-        for image_index, image_name in image_index_names.iteritems():
+        for image_index, image_name in image_index_names.items():
             if image_name != 'omitted':
                 template_dict.update(
                     {image_name: stimulus_template_array[image_index, :, :]})

--- a/allensdk/brain_observatory/behavior/swdb/save_extended_stimulus_presentations_df.py
+++ b/allensdk/brain_observatory/behavior/swdb/save_extended_stimulus_presentations_df.py
@@ -116,7 +116,7 @@ def get_extended_stimulus_presentations(session):
     )
     block_repetition_number = np.copy(block_inds)
 
-    for image_name, image_blocks in blocks_per_image.iteritems():
+    for image_name, image_blocks in blocks_per_image.items():
         if image_name != "omitted":
             for ind_block, block_number in enumerate(image_blocks):
                 # block_rep_number starts as a copy of block_inds, so we can

--- a/allensdk/brain_observatory/chisquare_categorical.py
+++ b/allensdk/brain_observatory/chisquare_categorical.py
@@ -71,7 +71,7 @@ def compute_chi_shuffle(
 def stim_table_to_categories(stim_table, columns, verbose=False):
     # get the categories for all sweeps with each unique combination of
     #   parameters in 'columns' being one category
-    # sweeps with non-finite values in ANY column (e.g. np.NaN) are labeled
+    # sweeps with non-finite values in ANY column (e.g. np.nan) are labeled
     #   as blank sweeps (category = -1)
     # TODO: Replace with EcephysSession.get_stimulus_conditions
 

--- a/allensdk/brain_observatory/demixer.py
+++ b/allensdk/brain_observatory/demixer.py
@@ -103,6 +103,8 @@ def _demix_point(source_frame: np.ndarray, mask_traces: np.ndarray,
     overlap = flat_masks.dot(weighted_masks.T).toarray()
     try:
         demix_traces = linalg.solve(overlap, mask_weighted_trace)
+        if not np.all(np.isfinite(demix_traces)):
+            raise linalg.LinAlgError("non-finite result")
     except linalg.LinAlgError:
         logging.warning("Singular matrix, using least squares to solve.")
         x, _, _, _ = linalg.lstsq(overlap, mask_weighted_trace)

--- a/allensdk/brain_observatory/dff.py
+++ b/allensdk/brain_observatory/dff.py
@@ -325,7 +325,7 @@ def noise_std(x, noise_kernel_length=31, positive_peak_scale=1.5,
     """Robust estimate of the standard deviation of the trace noise."""
     _check_kernel(noise_kernel_length, len(x))
     if any(np.isnan(x)):
-        return np.NaN
+        return np.nan
     x = x - median_filter(x, noise_kernel_length, mode='constant')
     # first pass removing big pos peak outliers
     x = x[x < positive_peak_scale*np.abs(x.min())]

--- a/allensdk/brain_observatory/drifting_gratings.py
+++ b/allensdk/brain_observatory/drifting_gratings.py
@@ -247,8 +247,8 @@ class DriftingGratings(StimulusAnalysis):
                          np.abs(subset_stat[str(nc)].mean()))
 
             else:
-                peak.p_run_dg.iloc[nc] = np.NaN
-                peak.run_modulation_dg.iloc[nc] = np.NaN
+                peak.p_run_dg.iloc[nc] = np.nan
+                peak.run_modulation_dg.iloc[nc] = np.nan
 
             # reliability
             subset = self.sweep_response[
@@ -264,7 +264,7 @@ class DriftingGratings(StimulusAnalysis):
             for i in range(len(subset)):
                 for j in range(len(subset)):
                     if i >= j:
-                        mask[i, j] = np.NaN
+                        mask[i, j] = np.nan
             corr_matrix *= mask
             peak.reliability_dg.iloc[nc] = np.nanmean(corr_matrix)
 

--- a/allensdk/brain_observatory/ecephys/align_timestamps/__main__.py
+++ b/allensdk/brain_observatory/ecephys/align_timestamps/__main__.py
@@ -46,7 +46,7 @@ def align_timestamps(args):
             min_time = probe_split_times[idx]
 
             if idx == (len(probe_split_times) - 1):
-                max_time = np.Inf
+                max_time = np.inf
             else:
                 max_time = probe_split_times[idx + 1]
 

--- a/allensdk/brain_observatory/ecephys/align_timestamps/barcode_sync_dataset.py
+++ b/allensdk/brain_observatory/ecephys/align_timestamps/barcode_sync_dataset.py
@@ -63,10 +63,10 @@ class BarcodeSyncDataset(EcephysSyncDataset):
 
         """
         warnings.warn(
-            np.VisibleDeprecationWarning(
-                """This function is deprecated as unecessary (and slated for
-                removal). Instead, simply use extract_barcodes."""
-            )
+            """This function is deprecated as unecessary (and slated for
+            removal). Instead, simply use extract_barcodes.""",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
         barcode_times, barcodes = self.extract_barcodes(**barcode_kwargs)

--- a/allensdk/brain_observatory/ecephys/data_objects/trials.py
+++ b/allensdk/brain_observatory/ecephys/data_objects/trials.py
@@ -87,7 +87,7 @@ class VBNTrial(Trial):
         """
         change_frame = trial_dict['change_frame']
         if np.isnan(change_frame):
-            change_time = np.NaN
+            change_time = np.nan
         else:
             no_delay = self._stimulus_timestamps.subtract_monitor_delay()
             change_frame = int(change_frame)

--- a/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_project_cache.py
@@ -737,9 +737,9 @@ def get_grouped_uniques(this, other, foreign_key, field_key, unique_key, inplace
     if not inplace:
         this = this.copy()
 
-    uniques = other.groupby(foreign_key)\
-        .apply(lambda grp: pd.DataFrame(grp)[field_key].unique())
-    this[unique_key] = 0
+    uniques = other.groupby(foreign_key)[field_key]\
+        .apply(lambda x: x.unique())
+    this[unique_key] = None
     this.loc[uniques.index.values, unique_key] = uniques.values
 
     if not inplace:

--- a/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb1_session_api.py
+++ b/allensdk/brain_observatory/ecephys/ecephys_session_api/ecephys_nwb1_session_api.py
@@ -169,8 +169,8 @@ class EcephysNwb1Api(EcephysSessionApi):
             if stimulus_presentations_df is None:
                 stimulus_presentations_df = stim_df
             else:
-                stimulus_presentations_df = stimulus_presentations_df.append(
-                    stim_df)
+                stimulus_presentations_df = pd.concat(
+                    [stimulus_presentations_df, stim_df])
 
         stimulus_presentations_df[
             'stimulus_index'] = 0  # I'm not sure what column is, but is

--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/drifting_gratings.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/drifting_gratings.py
@@ -472,10 +472,10 @@ class DriftingGratings(StimulusAnalysis):
         ### NEEDS TO BE UPDATED FOR NEW ADAPTER
 
         tf_tuning = self.response_events[pref_ori, 1:, nc, 0]
-        fit_tf_ind = np.NaN
-        fit_tf = np.NaN
-        tf_low_cutoff = np.NaN
-        tf_high_cutoff = np.NaN
+        fit_tf_ind = np.nan
+        fit_tf = np.nan
+        tf_low_cutoff = np.nan
+        tf_high_cutoff = np.nan
         if pref_tf in range(1, 4):
             try:
                 popt, pcov = curve_fit(gauss_function, range(5), tf_tuning, p0=[np.amax(tf_tuning), pref_tf, 1.],

--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/static_gratings.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/static_gratings.py
@@ -388,10 +388,10 @@ def fit_sf_tuning(sf_tuning_responses, sf_values, pref_sf_index):
     :return: index for the preferred sf from the curve fit, prefered sf from the curve fit, low cutoff sf from the
         curve fit, high cutoff sf from the curve fit
     """
-    fit_sf_ind = np.NaN
-    fit_sf = np.NaN
-    sf_low_cutoff = np.NaN
-    sf_high_cutoff = np.NaN
+    fit_sf_ind = np.nan
+    fit_sf = np.nan
+    sf_low_cutoff = np.nan
+    sf_high_cutoff = np.nan
     if pref_sf_index in range(1, len(sf_values)-1):
         # If the prefered spatial freq is an interior case try to fit the tunning curve with a gaussian.
         try:

--- a/allensdk/brain_observatory/ecephys/stimulus_analysis/stimulus_analysis.py
+++ b/allensdk/brain_observatory/ecephys/stimulus_analysis/stimulus_analysis.py
@@ -632,7 +632,7 @@ def running_modulation(spike_counts, running_speeds, speed_threshold=1.0):
         warnings.warn(
             'spike_counts and running_speeds must be arrays of the same '
             'shape.')
-        return np.NaN, np.NaN
+        return np.nan, np.nan
 
     # keep track of when the animal is and isn't running
     is_running = running_speeds >= speed_threshold
@@ -649,7 +649,7 @@ def running_modulation(spike_counts, running_speeds, speed_threshold=1.0):
         stat_mean = np.mean(stat)
 
         if run_mean == stat_mean == 0:
-            return np.NaN, np.NaN
+            return np.nan, np.nan
         if run_mean > stat_mean:
             run_mod = (run_mean - stat_mean) / run_mean
         else:
@@ -659,7 +659,7 @@ def running_modulation(spike_counts, running_speeds, speed_threshold=1.0):
         (_, p) = st.ttest_ind(run, stat, equal_var=False)
         return p, run_mod
     else:
-        return np.NaN, np.NaN
+        return np.nan, np.nan
 
 
 def lifetime_sparseness(responses):

--- a/allensdk/brain_observatory/eye_tracking/stage_4/DLC_Ellipse_Video.py
+++ b/allensdk/brain_observatory/eye_tracking/stage_4/DLC_Ellipse_Video.py
@@ -53,7 +53,7 @@ pupil = pd.read_hdf(source_ellipse_data_file, key='pupil')
 
 def make_frame(t):      
 
-    fi = np.int(np.round(t*fps))
+    fi = int(np.round(t*fps))
 
     ax.clear()
     ax.imshow(clip.get_frame(t))

--- a/allensdk/brain_observatory/findlevel.py
+++ b/allensdk/brain_observatory/findlevel.py
@@ -39,11 +39,11 @@ import numpy as np
 def findlevel(inwave, threshold, direction='both'):
     temp = inwave - threshold
     if (direction.find("up") + 1):
-        crossings = np.nonzero(np.ediff1d(np.sign(temp), to_begin=0) > 0)
+        crossings = np.nonzero(np.ediff1d(np.sign(temp), to_begin=0.0) > 0)
     elif (direction.find("down") + 1):
-        crossings = np.nonzero(np.ediff1d(np.sign(temp), to_begin=0) < 0)
+        crossings = np.nonzero(np.ediff1d(np.sign(temp), to_begin=0.0) < 0)
     else:
-        crossings = np.nonzero(np.ediff1d(np.sign(temp), to_begin=0))
+        crossings = np.nonzero(np.ediff1d(np.sign(temp), to_begin=0.0))
 
     if len(crossings) == 0 or len(crossings[0]) == 0:
         return None

--- a/allensdk/brain_observatory/gaze_mapping/_gaze_mapper.py
+++ b/allensdk/brain_observatory/gaze_mapping/_gaze_mapper.py
@@ -289,7 +289,8 @@ class GazeMapper(object):
 
         mag = np.linalg.norm(self.monitor.position)
         meridian = np.degrees(np.arctan(x / mag))
-        elevation = np.degrees(np.arctan(y / np.linalg.norm([x, mag], axis=0)))
+        elevation = np.degrees(np.arctan(y / np.linalg.norm(
+            np.vstack([x, np.full_like(x, mag, dtype=float)]), axis=0)))
 
         angles = np.vstack([meridian, elevation]).T
 

--- a/allensdk/brain_observatory/locally_sparse_noise.py
+++ b/allensdk/brain_observatory/locally_sparse_noise.py
@@ -488,7 +488,7 @@ class LocallySparseNoise(StimulusAnalysis):
                 assert len(x) == 3
 
                 if x[-1] is None:
-                    f.attrs[x[-2]] = np.NaN
+                    f.attrs[x[-2]] = np.nan
                 else:
                     f.attrs[x[-2]] = x[-1]
 

--- a/allensdk/brain_observatory/natural_movie.py
+++ b/allensdk/brain_observatory/natural_movie.py
@@ -119,7 +119,7 @@ class NaturalMovie(StimulusAnalysis):
         for i in range(10):
             for j in range(10):
                 if i >= j:
-                    mask[i, j] = np.NaN
+                    mask[i, j] = np.nan
 
         for nc in range(self.numbercells):
             peak_movie.cell_specimen_id.iloc[nc] = cids[nc]

--- a/allensdk/brain_observatory/natural_scenes.py
+++ b/allensdk/brain_observatory/natural_scenes.py
@@ -171,8 +171,8 @@ class NaturalScenes(StimulusAnalysis):
             #                peak.run_modulation_ns[nc] = subset_run[
             #                    str(nc)].mean() / subset_stat[str(nc)].mean()
             #            else:
-            #                peak.p_run_ns[nc] = np.NaN
-            #                peak.run_modulation_ns[nc] = np.NaN
+            #                peak.p_run_ns[nc] = np.nan
+            #                peak.run_modulation_ns[nc] = np.nan
             groups = []
             for im in range(self.number_scenes):
                 subset = self.mean_sweep_response[
@@ -207,8 +207,8 @@ class NaturalScenes(StimulusAnalysis):
                                 subset_run[str(nc)].mean()) /
                                np.abs(subset_stat[str(nc)].mean())))
             else:
-                peak.p_run_ns.iloc[nc] = np.NaN
-                peak.run_modulation_ns.iloc[nc] = np.NaN
+                peak.p_run_ns.iloc[nc] = np.nan
+                peak.run_modulation_ns.iloc[nc] = np.nan
 
                 # reliability
             subset = self.sweep_response[self.stim_table.frame == nsp]
@@ -222,7 +222,7 @@ class NaturalScenes(StimulusAnalysis):
             for i in range(len(subset)):
                 for j in range(len(subset)):
                     if i >= j:
-                        mask[i, j] = np.NaN
+                        mask[i, j] = np.nan
             corr_matrix *= mask
             peak.reliability_ns.iloc[nc] = np.nanmean(corr_matrix)
 

--- a/allensdk/brain_observatory/nwb/nwb_api.py
+++ b/allensdk/brain_observatory/nwb/nwb_api.py
@@ -59,9 +59,9 @@ class NwbApi:
         """
 
         interface_name = 'speed' if lowpass else 'speed_unfiltered'
-        values = self.nwbfile.modules['running'].get_data_interface(
+        values = self.nwbfile.processing['running'].get_data_interface(
             interface_name).data[:]
-        timestamps = self.nwbfile.modules['running'].get_data_interface(
+        timestamps = self.nwbfile.processing['running'].get_data_interface(
             interface_name).timestamps[:]
 
         return RunningSpeed(
@@ -87,7 +87,7 @@ class NwbApi:
         if image_api is None:
             image_api = ImageApi
 
-        nwb_img = self.nwbfile.modules[module].get_data_interface(
+        nwb_img = self.nwbfile.processing[module].get_data_interface(
             'images')[name]
         data = nwb_img.data
         resolution = nwb_img.resolution  # px/cm

--- a/allensdk/brain_observatory/ophys/trace_extraction/__main__.py
+++ b/allensdk/brain_observatory/ophys/trace_extraction/__main__.py
@@ -85,7 +85,7 @@ def write_trace_file(data, names, path):
 
     with h5py.File(path, 'w') as fil:
         fil["data"] = data
-        fil.create_dataset("roi_names", data=np.array(names).astype(np.string_), dtype=utf_dtype)
+        fil.create_dataset("roi_names", data=np.array(names).astype(np.bytes_), dtype=utf_dtype)
 
 
 def extract_traces(motion_corrected_stack, motion_border, storage_directory, rois, log_0, **kwargs):

--- a/allensdk/brain_observatory/receptive_field_analysis/chisquarerf.py
+++ b/allensdk/brain_observatory/receptive_field_analysis/chisquarerf.py
@@ -313,8 +313,8 @@ def interpolate_RF(rf_map, deg_per_pnt):
         1,
     )
 
-    interpolated = si.interp2d(x_coor, y_coor, rf_map)
-    interpolated = interpolated(x_interpolated, y_interpolated)
+    interpolator = si.RectBivariateSpline(y_coor, x_coor, rf_map, kx=1, ky=1)
+    interpolated = interpolator(y_interpolated, x_interpolated, grid=True)
 
     return interpolated
 

--- a/allensdk/brain_observatory/receptive_field_analysis/receptive_field.py
+++ b/allensdk/brain_observatory/receptive_field_analysis/receptive_field.py
@@ -187,7 +187,7 @@ def get_attribute_dict(rf):
 
 
 def print_summary(rf):
-    for key_val in sorted(get_attribute_dict(rf).iteritems(),
+    for key_val in sorted(get_attribute_dict(rf).items(),
                           key=lambda x: x[0]):
         print("%s : %s" % key_val)
 
@@ -212,12 +212,12 @@ def write_receptive_field_to_h5(rf, file_name, prefix=''):
             if prefix == '':
 
                 if x[-1] is None:
-                    f.attrs[x[-2]] = np.NaN
+                    f.attrs[x[-2]] = np.nan
                 else:
                     f.attrs[x[-2]] = x[-1]
             else:
                 if x[-1] is None:
-                    f[prefix].attrs[x[-2]] = np.NaN
+                    f[prefix].attrs[x[-2]] = np.nan
                 else:
                     f[prefix].attrs[x[-2]] = x[-1]
 

--- a/allensdk/brain_observatory/receptive_field_analysis/utilities.py
+++ b/allensdk/brain_observatory/receptive_field_analysis/utilities.py
@@ -49,10 +49,11 @@ def upsample_image_to_degrees(img):
     x = np.arange(img.shape[0])
     y = np.arange(img.shape[1])
 
-    g = spinterp.interp2d(y, x, img, kind="linear")
+    g = spinterp.RectBivariateSpline(x, y, img, kx=1, ky=1)
     ZZ_on = g(
-        np.arange(0, img.shape[1], 1.0 / upsample),
         np.arange(0, img.shape[0], 1.0 / upsample),
+        np.arange(0, img.shape[1], 1.0 / upsample),
+        grid=True,
     )
 
     return ZZ_on
@@ -73,7 +74,7 @@ def convolve(img, sigma=4):
 
     x = np.arange(3 * img.shape[0])
     y = np.arange(3 * img.shape[1])
-    g = spinterp.interp2d(y, x, img_pad, kind="linear")
+    g = spinterp.RectBivariateSpline(x, y, img_pad, kx=1, ky=1)
 
     if img.shape[0] == 16:
         upsample = 4
@@ -84,8 +85,9 @@ def convolve(img, sigma=4):
     else:
         raise NotImplementedError
     ZZ_on = g(
-        offset + np.arange(0, img.shape[1] * 3, 1.0 / upsample),
         offset + np.arange(0, img.shape[0] * 3, 1.0 / upsample),
+        offset + np.arange(0, img.shape[1] * 3, 1.0 / upsample),
+        grid=True,
     )
     ZZ_on_f = gaussian_filter(ZZ_on, float(sigma), mode="constant")
 

--- a/allensdk/brain_observatory/static_gratings.py
+++ b/allensdk/brain_observatory/static_gratings.py
@@ -312,8 +312,8 @@ class StaticGratings(StimulusAnalysis):
                                 subset_run[str(nc)].mean()) /
                                np.abs(subset_stat[str(nc)].mean())))
             else:
-                peak.p_run_sg.iloc[nc] = np.NaN
-                peak.run_modulation_sg.iloc[nc] = np.NaN
+                peak.p_run_sg.iloc[nc] = np.nan
+                peak.run_modulation_sg.iloc[nc] = np.nan
 
                 # reliability
             subset = \
@@ -332,7 +332,7 @@ class StaticGratings(StimulusAnalysis):
             for i in range(len(subset)):
                 for j in range(len(subset)):
                     if i >= j:
-                        mask[i, j] = np.NaN
+                        mask[i, j] = np.nan
             corr_matrix *= mask
             peak.reliability_sg.iloc[nc] = np.nanmean(corr_matrix)
 

--- a/allensdk/brain_observatory/sync_dataset.py
+++ b/allensdk/brain_observatory/sync_dataset.py
@@ -205,7 +205,7 @@ class Dataset(object):
 
         """
         bit_array = self.get_bit(bit)
-        return np.ediff1d(bit_array, to_begin=0)
+        return np.ediff1d(bit_array, to_begin=np.zeros(1, dtype=bit_array.dtype))
 
     def get_line_changes(self, line):
         """

--- a/allensdk/config/app/application_config.py
+++ b/allensdk/config/app/application_config.py
@@ -36,7 +36,6 @@
 from allensdk.core.json_utilities import JsonComments
 import argparse
 import os
-import io
 import logging
 import logging.config as lc
 from pkg_resources import resource_filename  # @UnresolvedImport
@@ -349,10 +348,7 @@ class ApplicationConfig(object):
 
         if config_file_path.endswith('.json'):
             cfg_string = self.from_json_file(config_file_path)
-            try:
-                config.readfp(io.BytesIO(cfg_string))
-            except (NameError, TypeError):
-                config.read_string(cfg_string)  # Python 3
+            config.read_string(cfg_string)
         else:
             config.read(config_file_path)
 

--- a/allensdk/core/brain_observatory_nwb_data_set.py
+++ b/allensdk/core/brain_observatory_nwb_data_set.py
@@ -742,7 +742,7 @@ class BrainObservatoryNwbDataSet(object):
                     v = f[disk_key][()]
 
                     # convert numpy strings to python strings
-                    if v.dtype.type is np.string_:
+                    if v.dtype.type is np.bytes_:
                         if len(v.shape) == 0:
                             v = v.decode('UTF-8')
                         elif len(v.shape) == 1:
@@ -1002,11 +1002,11 @@ def align_running_speed(dxcm, dxtime, timestamps):
     if dxtime[0] != timestamps[0]:
         adjust = np.where(timestamps == dxtime[0])[0][0]
         dxtime = np.insert(dxtime, 0, timestamps[:adjust])
-        dxcm = np.insert(dxcm, 0, np.repeat(np.NaN, adjust))
+        dxcm = np.insert(dxcm, 0, np.repeat(np.nan, adjust))
     adjust = len(timestamps) - len(dxtime)
     if adjust > 0:
         dxtime = np.append(dxtime, timestamps[(-1 * adjust):])
-        dxcm = np.append(dxcm, np.repeat(np.NaN, adjust))
+        dxcm = np.append(dxcm, np.repeat(np.nan, adjust))
 
     return dxcm, dxtime
 

--- a/allensdk/core/mouse_connectivity_cache.py
+++ b/allensdk/core/mouse_connectivity_cache.py
@@ -734,7 +734,7 @@ class MouseConnectivityCache(ReferenceSpaceCache):
         ncolumns = len(projection_structure_ids) * len(hemisphere_ids)
 
         matrix = np.empty((nrows, ncolumns))
-        matrix[:] = np.NAN
+        matrix[:] = np.nan
 
         row_lookup = {}
         for idx, e in enumerate(experiment_ids):

--- a/allensdk/deprecated.py
+++ b/allensdk/deprecated.py
@@ -36,7 +36,10 @@
 import copy
 import warnings
 import functools
-from numpy import VisibleDeprecationWarning
+try:
+    from numpy import VisibleDeprecationWarning
+except ImportError:
+    VisibleDeprecationWarning = DeprecationWarning
 
     
 def deprecated(message=None):

--- a/allensdk/internal/brain_observatory/ophys_session_decomposition.py
+++ b/allensdk/internal/brain_observatory/ophys_session_decomposition.py
@@ -38,7 +38,7 @@ def read_strided(filename, dtype, offset, shape, strides):
     '''Load a frame without memory-mapping.'''
     frame_size = np.dtype(dtype).itemsize
     arr = np.empty(shape, dtype=dtype)
-    frame_size = arr.dtype.itemsize*np.product(shape[1:])
+    frame_size = arr.dtype.itemsize*np.prod(shape[1:])
     step = strides[0] - frame_size
     with open(filename, "rb") as f:
         f.seek(offset)

--- a/allensdk/internal/brain_observatory/time_sync.py
+++ b/allensdk/internal/brain_observatory/time_sync.py
@@ -151,7 +151,7 @@ def get_photodiode_events(sync_dset, photodiode_key):
         The last valid event occured ~1.0s before
     """
     all_events = sync_dset.get_events_by_line(photodiode_key, units="seconds")
-    all_events_diff = np.ediff1d(all_events, to_begin=0, to_end=0)
+    all_events_diff = np.ediff1d(all_events, to_begin=0.0, to_end=0.0)
     all_events_diff_prev = all_events_diff[:-1]
     all_events_diff_next = all_events_diff[1:]
     min_interval = REG_PHOTODIODE_INTERVAL - REG_PHOTODIODE_STD

--- a/allensdk/internal/model/glif/ASGLM.py
+++ b/allensdk/internal/model/glif/ASGLM.py
@@ -170,9 +170,9 @@ def ASGLM_pairwise(ks_int, I_stim, voltage, spike_ind, cinit, tauinit, SCL, dt, 
             except Exception as e:
                 logging.warning("fit didn't work: " + str(e))
                 llh=np.nan
-                fit_R=np.NAN
-                fit_asc_amp=np.ones(ncos)*np.NAN
-                ipsc=np.ones(len(b_ipsp_spikes_deleted[:,0]))*np.NAN
+                fit_R=np.nan
+                fit_asc_amp=np.ones(ncos)*np.nan
+                ipsc=np.ones(len(b_ipsp_spikes_deleted[:,0]))*np.nan
                 
             R_for_each_sweep.append(fit_R)
             asc_amp_for_each_sweep.append(fit_asc_amp)

--- a/allensdk/internal/model/glif/spike_cutting.py
+++ b/allensdk/internal/model/glif/spike_cutting.py
@@ -174,7 +174,7 @@ def calc_spike_cut_and_v_reset_via_expvar_residuals(all_current_list,
 
     if MAKE_PLOT:
         xlim = np.array([min(all_v_spike_init_list), max(all_v_spike_init_list)])
-        plotLineRegressRed(slope_at_each_time_end[vectorIndex_of_max_explained_var], intercept_at_each_time_end[vectorIndex_of_max_explained_var], np.NAN, xlim)
+        plotLineRegressRed(slope_at_each_time_end[vectorIndex_of_max_explained_var], intercept_at_each_time_end[vectorIndex_of_max_explained_var], np.nan, xlim)
         plt.legend(loc=2, fontsize=20)
         if SHOW_PLOT:
             plt.show(block=BLOCK)                   

--- a/allensdk/internal/pipeline_modules/run_demixing.py
+++ b/allensdk/internal/pipeline_modules/run_demixing.py
@@ -186,7 +186,7 @@ def main():
 
     with h5py.File(output_h5, 'w') as f:
         f.create_dataset("data", data=out_traces, compression="gzip")
-        roi_names = np.array([str(rn) for rn in trace_ids]).astype(np.string_)
+        roi_names = np.array([str(rn) for rn in trace_ids]).astype(np.bytes_)
         f.create_dataset("roi_names", data=roi_names)
 
     mod.write_output_data(dict(

--- a/allensdk/internal/pipeline_modules/run_neuropil_correction.py
+++ b/allensdk/internal/pipeline_modules/run_neuropil_correction.py
@@ -227,7 +227,7 @@ def main():
         hf.create_dataset("r", data=r_list)
         hf.create_dataset("RMSE", data=RMSE_list)
         hf.create_dataset("FC", data=corrected, compression="gzip")
-        hf.create_dataset("roi_names", data=roi_names.astype(np.string_))
+        hf.create_dataset("roi_names", data=roi_names.astype(np.bytes_))
 
         for n in range(num_traces):
             r = r_vals[n]

--- a/allensdk/test/api/cloud_cache/test_smart_download.py
+++ b/allensdk/test/api/cloud_cache/test_smart_download.py
@@ -1,3 +1,4 @@
+import warnings as warnings_mod
 import pytest
 import json
 import hashlib
@@ -422,13 +423,14 @@ def test_reconstruction_of_local_manifest(tmpdir):
     cache_dir = pathlib.Path(tmpdir) / 'cache'
 
     # read in v1.0.0 data files using normal S3 cache class
-    with pytest.warns(None) as warnings:
+    with warnings_mod.catch_warnings(record=True) as w:
+        warnings_mod.simplefilter("always")
         cache = S3CloudCache(cache_dir, test_bucket_name, 'project-x')
 
     # make sure no MissingLocalManifestWarnings were raised
     w_type = 'MissingLocalManifestWarning'
-    for w in warnings.list:
-        if w._category_name == w_type:
+    for wi in w:
+        if wi.category.__name__ == w_type:
             msg = 'Raised MissingLocalManifestWarning on empty '
             msg += 'cache dir'
             assert False, msg
@@ -458,7 +460,7 @@ def test_reconstruction_of_local_manifest(tmpdir):
     # files. Verify that paths to files with the correct hashes
     # are returned. This will mean that the local manifest mapping
     # filename to file hash was correctly reconstructed.
-    with pytest.warns(MissingLocalManifestWarning) as warnings:
+    with pytest.warns(MissingLocalManifestWarning):
         dummy = DummyCache(cache_dir, test_bucket_name, 'project-x')
 
     dummy.construct_local_manifest()

--- a/allensdk/test/api/test_annotated_section_data_set_api.py
+++ b/allensdk/test/api/test_annotated_section_data_set_api.py
@@ -36,7 +36,7 @@
 from allensdk.api.queries.annotated_section_data_sets_api import \
     AnnotatedSectionDataSetsApi
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 @pytest.fixture

--- a/allensdk/test/api/test_api.py
+++ b/allensdk/test/api/test_api.py
@@ -41,7 +41,7 @@ import os
 
 import numpy as np
 import pytest
-from mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 from requests.exceptions import HTTPError
 import requests
 

--- a/allensdk/test/api/test_biophysical_api.py
+++ b/allensdk/test/api/test_biophysical_api.py
@@ -3,7 +3,7 @@ import json
 
 import numpy as np
 import pytest
-from mock import patch
+from unittest.mock import patch
 from allensdk.api.queries.biophysical_api import BiophysicalApi
 
 

--- a/allensdk/test/api/test_brain_observatory_api.py
+++ b/allensdk/test/api/test_brain_observatory_api.py
@@ -40,7 +40,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-from mock import patch, call
+from unittest.mock import patch, call
 from collections import Counter
 import datetime
 from allensdk.api.queries.brain_observatory_api import (

--- a/allensdk/test/api/test_cache.py
+++ b/allensdk/test/api/test_cache.py
@@ -41,7 +41,7 @@ import numpy as np
 import time
 
 import pytest
-from mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from allensdk.api.warehouse_cache.cache import Cache, memoize, get_default_manifest_file
 from allensdk.api.queries.rma_api import RmaApi

--- a/allensdk/test/api/test_cacheable.py
+++ b/allensdk/test/api/test_cacheable.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 from allensdk.api.warehouse_cache.cache import Cache, cacheable
 from allensdk.api.queries.rma_api import RmaApi
 import pandas as pd

--- a/allensdk/test/api/test_cell_types_api.py
+++ b/allensdk/test/api/test_cell_types_api.py
@@ -1,5 +1,5 @@
 import pytest, os
-from mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock
 from allensdk.api.queries.cell_types_api import CellTypesApi
 
 @pytest.fixture

--- a/allensdk/test/api/test_file_download.py
+++ b/allensdk/test/api/test_file_download.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from allensdk.api.warehouse_cache.cache import cacheable, Cache
 from allensdk.config.manifest import Manifest
 import allensdk.core.json_utilities as ju

--- a/allensdk/test/api/test_grid_data_api.py
+++ b/allensdk/test/api/test_grid_data_api.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from allensdk.api.queries.grid_data_api import GridDataApi
 
 

--- a/allensdk/test/api/test_image_download_api.py
+++ b/allensdk/test/api/test_image_download_api.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 import numpy as np
 from allensdk.api.queries.image_download_api import ImageDownloadApi
 

--- a/allensdk/test/api/test_mouse_atlas_api.py
+++ b/allensdk/test/api/test_mouse_atlas_api.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import pytest
 
 from allensdk.api.queries.mouse_atlas_api import MouseAtlasApi as MAA

--- a/allensdk/test/api/test_mouse_connectivity_api.py
+++ b/allensdk/test/api/test_mouse_connectivity_api.py
@@ -35,7 +35,7 @@
 #
 import os
 import pytest
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import itertools as it
 import numpy as np
 from allensdk.api.queries.mouse_connectivity_api import MouseConnectivityApi as MCA

--- a/allensdk/test/api/test_ontologies_api.py
+++ b/allensdk/test/api/test_ontologies_api.py
@@ -37,7 +37,7 @@ from allensdk.api.queries.ontologies_api import OntologiesApi
 import pandas as pd
 from numpy import allclose
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 
 @pytest.fixture

--- a/allensdk/test/api/test_pager.py
+++ b/allensdk/test/api/test_pager.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import MagicMock, call, patch, mock_open
+from unittest.mock import MagicMock, call, patch, mock_open
 from allensdk.api.queries.rma_pager import RmaPager, pageable
 from allensdk.api.queries.rma_api import RmaApi
 import allensdk.core.json_utilities as ju

--- a/allensdk/test/api/test_reference_space_api.py
+++ b/allensdk/test/api/test_reference_space_api.py
@@ -35,7 +35,7 @@
 #
 import os
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import itertools as it
 import numpy as np
 from allensdk.api.queries.reference_space_api import ReferenceSpaceApi as RSA

--- a/allensdk/test/api/test_rma_template.py
+++ b/allensdk/test/api/test_rma_template.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import allensdk.core.json_utilities as ju
 from allensdk.api.queries.rma_template import RmaTemplate
 

--- a/allensdk/test/api/test_svg_api.py
+++ b/allensdk/test/api/test_svg_api.py
@@ -37,7 +37,7 @@
 from allensdk.api.queries.svg_api import SvgApi
 import pytest
 import json
-from mock import MagicMock
+from unittest.mock import MagicMock
 import os
 
 @pytest.fixture

--- a/allensdk/test/api/test_synchronization_api.py
+++ b/allensdk/test/api/test_synchronization_api.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 from allensdk.api.queries.synchronization_api import SynchronizationApi
 
 

--- a/allensdk/test/api/test_tree_search_api.py
+++ b/allensdk/test/api/test_tree_search_api.py
@@ -37,7 +37,7 @@
 from allensdk.api.queries.tree_search_api import TreeSearchApi
 import pytest
 import json
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 @pytest.fixture
 def tree_search():

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_pandas_compat.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache/test_pandas_compat.py
@@ -1,0 +1,87 @@
+"""Regression tests for pandas 2.x datetime compatibility.
+
+pandas 2.x changed ``pd.to_datetime`` to require an explicit ``format``
+parameter when the input has mixed-precision timestamps (some with
+microseconds, some without).  These tests exercise the SDK code paths
+that parse ``date_of_acquisition`` from metadata tables to ensure they
+handle real-world format variation.
+"""
+
+import pandas as pd
+import pytest
+
+from allensdk.brain_observatory.behavior.behavior_project_cache.tables.metadata_table_schemas import (  # noqa: E501
+    BehaviorSessionMetadataSchema,
+)
+
+
+# Minimal valid records for BehaviorSessionMetadataSchema.
+# Only date_of_acquisition and required fields are populated.
+def _make_record(date_str):
+    return {
+        "age_in_days": 100,
+        "date_of_acquisition": date_str,
+    }
+
+
+class TestDateOfAcquisitionParsing:
+    """Regression: the SDK must parse date_of_acquisition values with
+    inconsistent microsecond precision, as found in real Allen Institute
+    metadata CSVs.
+    """
+
+    def test_schema_parses_date_without_microseconds(self):
+        record = _make_record("2019-09-25 13:31:46")
+        schema = BehaviorSessionMetadataSchema()
+        result = schema.load(record)
+        assert isinstance(result["date_of_acquisition"], pd.Timestamp)
+        assert result["date_of_acquisition"].tzinfo is not None
+
+    def test_schema_parses_date_with_microseconds(self):
+        record = _make_record("2019-10-01 14:22:33.123456")
+        schema = BehaviorSessionMetadataSchema()
+        result = schema.load(record)
+        assert isinstance(result["date_of_acquisition"], pd.Timestamp)
+        assert result["date_of_acquisition"].microsecond == 123456
+
+    def test_schema_parses_timezone_aware_date(self):
+        record = _make_record("2019-09-25T13:31:46+00:00")
+        schema = BehaviorSessionMetadataSchema()
+        result = schema.load(record)
+        assert isinstance(result["date_of_acquisition"], pd.Timestamp)
+        assert result["date_of_acquisition"].tzinfo is not None
+
+    def test_cloud_api_mixed_precision_dates(self):
+        """Simulate the cloud API's to_datetime call on a column with
+        mixed microsecond precision, as found in real session CSVs."""
+        df = pd.DataFrame({
+            "date_of_acquisition": [
+                "2019-09-25 13:31:46",
+                "2019-10-01 14:22:33.123456",
+                "2020-01-15 09:00:00",
+                "2020-06-30 16:45:12.500000",
+            ]
+        })
+        # This is the exact call pattern used in behavior_project_cloud_api.py
+        df["date_of_acquisition"] = pd.to_datetime(
+            df["date_of_acquisition"], format="ISO8601", utc=True
+        )
+        assert df["date_of_acquisition"].dt.tz is not None
+        assert len(df) == 4
+
+    def test_mixed_precision_fails_without_explicit_format(self):
+        """Verify that the pandas 2.x breakage we're guarding against is
+        real: without format="ISO8601", a strict format string rejects
+        rows that lack microseconds."""
+        major = int(pd.__version__.split(".")[0])
+        if major < 2:
+            pytest.skip("pandas <2.x infers formats silently")
+
+        with pytest.raises(ValueError, match="doesn't match format"):
+            pd.to_datetime(
+                pd.Series([
+                    "2019-09-25 13:31:46",
+                    "2019-10-01 14:22:33.123456",
+                ]),
+                format="%Y-%m-%d %H:%M:%S.%f",
+            )

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache_data_model/conftest.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache_data_model/conftest.py
@@ -124,13 +124,13 @@ def driver_lookup(behavior_session_id_list):
     Note: driver_line is a list of strings
     """
     rng = np.random.default_rng(1723213)
-    possible = (["aa"],
+    possible = [["aa"],
                 ["aa", "bb"],
                 ["cc"],
-                ["cc", "dd"])
-    chosen = rng.choice(possible,
-                        size=len(behavior_session_id_list),
-                        replace=True)
+                ["cc", "dd"]]
+    indices = rng.integers(0, len(possible),
+                           size=len(behavior_session_id_list))
+    chosen = [possible[i] for i in indices]
     return {ii: val
             for ii, val in zip(behavior_session_id_list,
                                chosen)}

--- a/allensdk/test/brain_observatory/behavior/behavior_project_cache_data_model/test_behavior_project_cache.py
+++ b/allensdk/test/brain_observatory/behavior/behavior_project_cache_data_model/test_behavior_project_cache.py
@@ -61,6 +61,7 @@ def test_get_ophys_session_table_by_experiment(TempdirBehaviorCache,
         index_column="ophys_experiment_id")[
         ["ophys_session_id"]]
 
+    expected.index = expected.index.astype(actual.index.dtype)
     pd.testing.assert_frame_equal(expected, actual)
 
 

--- a/allensdk/test/brain_observatory/behavior/test_behavior_metadata_legacy.py
+++ b/allensdk/test/brain_observatory/behavior/test_behavior_metadata_legacy.py
@@ -174,7 +174,7 @@ from allensdk.brain_observatory.behavior.data_objects.metadata\
                              },
                                  {
                                      "blank_duration_sec": [0.5, 0.5],
-                                     "stimulus_duration_sec": np.NaN,
+                                     "stimulus_duration_sec": np.nan,
                                      "omitted_flash_fraction": 0.05,
                                      "response_window_sec": [0.15, 0.75],
                                      "reward_volume": 0.007,

--- a/allensdk/test/brain_observatory/behavior/test_stimulus_processing.py
+++ b/allensdk/test/brain_observatory/behavior/test_stimulus_processing.py
@@ -454,10 +454,10 @@ def test_get_stimulus_metadata(
             {
                 "duration": [3.0, 2.0, 3.0, 2.0],
                 "end_frame": [4.0, 4.0, 11.0, 11.0],
-                "image_name": [np.NaN, "im065", np.NaN, "im064"],
+                "image_name": [np.nan, "im065", np.nan, "im064"],
                 "index": [2, 0, 3, 1],
                 "omitted": [False, False, False, False],
-                "orientation": [90, np.NaN, 270, np.NaN],
+                "orientation": [90, np.nan, 270, np.nan],
                 "start_frame": [1.0, 2.0, 8.0, 9.0],
                 "start_time": [1, 2, 8, 9],
                 "stop_time": [4, 4, 11, 11],

--- a/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_static_gratings.py
+++ b/allensdk/test/brain_observatory/ecephys/stimulus_analysis/test_static_gratings.py
@@ -121,7 +121,8 @@ def test_get_sfdi(sf_tuning_responses, mean_sweeps_trials, expected):
                               [0.02, 0.04, 0.08, 0.16, 0.32], 0, (0.0, 0.019999999552965164, np.nan, 0.32))
                          ])
 def test_fit_sf_tuning(sf_tuning_response, sf_vals, pref_sf_index, expected):
-    assert(np.allclose(fit_sf_tuning(sf_tuning_response, sf_vals, pref_sf_index), expected, equal_nan=True))
+    result = fit_sf_tuning(sf_tuning_response, sf_vals, pref_sf_index)
+    assert np.allclose(result, expected, equal_nan=True, rtol=1e-3, atol=1e-4)
 
 
 if __name__ == '__main__':

--- a/allensdk/test/brain_observatory/ecephys/stimulus_table/test_stimulus_table_module.py
+++ b/allensdk/test/brain_observatory/ecephys/stimulus_table/test_stimulus_table_module.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 import pytest
-import mock
+from unittest import mock
 import pandas as pd
 import numpy as np
 

--- a/allensdk/test/brain_observatory/ecephys/test_ecephys_utils.py
+++ b/allensdk/test/brain_observatory/ecephys/test_ecephys_utils.py
@@ -18,13 +18,13 @@ def test_strip_substructure_acronym():
     assert strip_substructure_acronym(data) == expected
 
     data = [None, 'DG-mo', 'DG-pd', 'LS-ab', 'LT-x', 'AB-cd',
-            'WX-yz', None, 'AB-ef', np.NaN]
+            'WX-yz', None, 'AB-ef', np.nan]
     expected = ['AB', 'DG', 'LS', 'LT', 'WX']
     assert strip_substructure_acronym(data) == expected
 
     assert strip_substructure_acronym([None]) == []
 
-    assert strip_substructure_acronym(np.NaN) is None
+    assert strip_substructure_acronym(np.nan) is None
 
     # pass in a tuple; check that it fails since that is not
     # a str or a list

--- a/allensdk/test/brain_observatory/ecephys/test_http_engine.py
+++ b/allensdk/test/brain_observatory/ecephys/test_http_engine.py
@@ -1,6 +1,6 @@
 import os
 
-import mock
+from unittest import mock
 import requests
 import pytest
 

--- a/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
+++ b/allensdk/test/brain_observatory/ecephys/test_write_nwb.py
@@ -262,11 +262,13 @@ def test_add_stimulus_presentations(nwbfile, presentations, roundtripper):
     if "color" in presentations.value:
         presentations.value["color_triplet"] = [""] + ["[1.0, 1.0, 1.0]"] * 4
         presentations.value["color"] = ""
-    pd.testing.assert_frame_equal(
-        presentations.value[sorted(presentations.value.columns)],
-        obtained_stimulus_table[sorted(obtained_stimulus_table.columns)],
-        check_dtype=False,
-    )
+    expected_df = presentations.value[sorted(presentations.value.columns)]
+    obtained_df = obtained_stimulus_table[
+        sorted(obtained_stimulus_table.columns)].copy()
+    for col in obtained_df.columns:
+        if col in expected_df.columns:
+            obtained_df[col] = obtained_df[col].astype(expected_df[col].dtype)
+    pd.testing.assert_frame_equal(expected_df, obtained_df, check_dtype=False)
 
 
 def test_add_stimulus_presentations_color(

--- a/allensdk/test/brain_observatory/receptive_field_analysis/test_fitgaussian2D.py
+++ b/allensdk/test/brain_observatory/receptive_field_analysis/test_fitgaussian2D.py
@@ -37,7 +37,7 @@
 import itertools as it
 
 import pytest
-import mock
+from unittest import mock
 
 from scipy.stats import multivariate_normal
 from skimage.transform import rotate
@@ -183,6 +183,7 @@ def test_fitgaussian2D_failure():
     res.success = False
     res.status = 3
     res.message = 'foo'
+    res.x = np.array([1.0, 1.0, 1.0, 0.0])
 
     with mock.patch('scipy.optimize.minimize', return_value=res) as p:
         with pytest.raises( gauss.GaussianFitError ):

--- a/allensdk/test/brain_observatory/test_demixer.py
+++ b/allensdk/test/brain_observatory/test_demixer.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pytest
 import scipy.sparse as sparse
-import logging
-
 import allensdk.brain_observatory.demixer as dmx
 
 
@@ -29,6 +27,13 @@ import allensdk.brain_observatory.demixer as dmx
             sparse.csr_matrix(np.array([[1, 0, 0, 0], [0, 0, 0, 0]])),
             np.array([1, 0]),    # invalid mask (zero pixels)
             None,
+        ),
+        (
+            np.zeros(4),        # singular overlap matrix
+            np.ones(2),
+            sparse.csr_matrix(np.array([[1, 0, 0, 0], [1, 1, 0, 0]])),
+            np.array([1, 2]),
+            np.zeros(2),
         )
     ]
 )
@@ -38,27 +43,6 @@ def test_demix_point(
                               pixels_per_mask)
     np.testing.assert_equal(result, expected)
 
-
-@pytest.mark.parametrize(
-    "source_frame,mask_traces,flat_masks,pixels_per_mask,expected",
-    [
-        (np.zeros(4),   # force singular matrix
-         np.ones(2),
-         sparse.csr_matrix(np.array([[1, 0, 0, 0], [1, 1, 0, 0]])),
-         np.array([1, 2]),
-         np.zeros(2)),
-    ]
-)
-def test_demix_raises_warning_for_singular_matrix(
-        source_frame, mask_traces, flat_masks, pixels_per_mask, expected,
-        caplog):
-    result = dmx._demix_point(source_frame, mask_traces, flat_masks,
-                              pixels_per_mask)
-    with caplog.at_level(logging.WARNING):
-        assert caplog.records[0].msg == ("Singular matrix, using least squares to "
-                                         "solve.")
-        assert caplog.records[0].levelno == logging.WARNING
-    np.testing.assert_equal(expected, result)
 
 
 @pytest.mark.parametrize(

--- a/allensdk/test/brain_observatory/test_dff.py
+++ b/allensdk/test/brain_observatory/test_dff.py
@@ -38,7 +38,7 @@ import numpy as np
 import pytest
 from functools import partial
 from matplotlib.pyplot import Figure
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 def test_movingmode_fast():

--- a/allensdk/test/brain_observatory/test_drifting_gratings.py
+++ b/allensdk/test/brain_observatory/test_drifting_gratings.py
@@ -37,7 +37,7 @@ from allensdk.brain_observatory.drifting_gratings import DriftingGratings
 from allensdk.brain_observatory.stimulus_analysis import StimulusAnalysis
 
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture

--- a/allensdk/test/brain_observatory/test_locally_sparse_noise.py
+++ b/allensdk/test/brain_observatory/test_locally_sparse_noise.py
@@ -36,7 +36,7 @@
 from allensdk.brain_observatory.locally_sparse_noise import LocallySparseNoise
 from allensdk.brain_observatory.stimulus_analysis import StimulusAnalysis
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import itertools as it
 
 

--- a/allensdk/test/brain_observatory/test_natural_movie.py
+++ b/allensdk/test/brain_observatory/test_natural_movie.py
@@ -36,7 +36,7 @@
 from allensdk.brain_observatory.natural_movie import NaturalMovie
 from allensdk.brain_observatory.stimulus_analysis import StimulusAnalysis
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import pandas as pd
 
 

--- a/allensdk/test/brain_observatory/test_natural_scenes.py
+++ b/allensdk/test/brain_observatory/test_natural_scenes.py
@@ -36,7 +36,7 @@
 from allensdk.brain_observatory.natural_scenes import NaturalScenes
 from allensdk.brain_observatory.stimulus_analysis import StimulusAnalysis
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture

--- a/allensdk/test/brain_observatory/test_session_analysis.py
+++ b/allensdk/test/brain_observatory/test_session_analysis.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import patch
+from unittest.mock import patch
 from allensdk.core.brain_observatory_nwb_data_set import \
     BrainObservatoryNwbDataSet
 from allensdk.brain_observatory.session_analysis import SessionAnalysis

--- a/allensdk/test/brain_observatory/test_static_gratings.py
+++ b/allensdk/test/brain_observatory/test_static_gratings.py
@@ -36,7 +36,7 @@
 from allensdk.brain_observatory.static_gratings import StaticGratings
 from allensdk.brain_observatory.stimulus_analysis import StimulusAnalysis
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture

--- a/allensdk/test/brain_observatory/test_stimulus_analysis.py
+++ b/allensdk/test/brain_observatory/test_stimulus_analysis.py
@@ -35,7 +35,7 @@
 #
 from allensdk.brain_observatory.stimulus_analysis import StimulusAnalysis
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture

--- a/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_dataframe_manipulations.py
+++ b/allensdk/test/brain_observatory/vbn_2022/metadata_writer/test_dataframe_manipulations.py
@@ -497,7 +497,7 @@ def test_remove_pretest_sessions():
                         None,
                     ],
                 },
-                {"a": 5, "b": np.NaN},
+                {"a": 5, "b": np.nan},
             ],
             [
                 {"a": 1, "b": "DG"},
@@ -510,7 +510,7 @@ def test_remove_pretest_sessions():
         ),
         (
             [
-                {"a": 1, "b": ["DG-mo", "AB-x", "DG-pb", np.NaN]},
+                {"a": 1, "b": ["DG-mo", "AB-x", "DG-pb", np.nan]},
                 {"a": 2, "b": "DG-s"},
             ],
             [{"a": 1, "b": ["AB", "DG"]}, {"a": 2, "b": "DG"}],

--- a/allensdk/test/config/test_config_single_file_json.py
+++ b/allensdk/test/config/test_config_single_file_json.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 from allensdk.model.biophys_sim.config import Config
 try:
     import __builtin__ as builtins  # @UnresolvedImport

--- a/allensdk/test/config/test_json_comments.py
+++ b/allensdk/test/config/test_json_comments.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import patch, mock_open, Mock
+from unittest.mock import patch, mock_open, Mock
 from simplejson.scanner import JSONDecodeError
 import allensdk.core.json_utilities as ju
 from allensdk.core.json_utilities import JsonComments

--- a/allensdk/test/config/test_multi_file_config.py
+++ b/allensdk/test/config/test_multi_file_config.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 from allensdk.config.model.description_parser import DescriptionParser
 try:
     import __builtin__ as builtins

--- a/allensdk/test/config/test_pyconfig_parser.py
+++ b/allensdk/test/config/test_pyconfig_parser.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 from allensdk.config.model.description_parser import DescriptionParser
 try:
     import __builtin__ as builtins

--- a/allensdk/test/core/test_brain_observatory_cache.py
+++ b/allensdk/test/core/test_brain_observatory_cache.py
@@ -36,7 +36,7 @@
 import pytest
 import os
 import numpy as np
-from mock import call, patch, mock_open, MagicMock
+from unittest.mock import call, patch, mock_open, MagicMock
 from allensdk.core.brain_observatory_cache import BrainObservatoryCache
 from allensdk.api.queries.brain_observatory_api import BrainObservatoryApi
 import json

--- a/allensdk/test/core/test_cell_filters.py
+++ b/allensdk/test/core/test_cell_filters.py
@@ -38,7 +38,7 @@ import os
 import json
 import pandas as pd
 from zipfile import ZipFile
-from mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock
 from test_brain_observatory_cache import CACHE_MANIFEST
 from allensdk.core.brain_observatory_cache \
     import BrainObservatoryCache

--- a/allensdk/test/core/test_cell_types_cache_unit.py
+++ b/allensdk/test/core/test_cell_types_cache_unit.py
@@ -38,7 +38,7 @@ from allensdk.core.cell_types_cache import ReporterStatus as RS
 import pytest
 from pandas.core.frame import DataFrame
 from allensdk.config import enable_console_log
-from mock import MagicMock, patch, call, mock_open
+from unittest.mock import MagicMock, patch, call, mock_open
 from six.moves import builtins
 import itertools as it
 import allensdk.core.json_utilities as ju
@@ -529,10 +529,8 @@ def test_get_ephys_sweeps(cache_fixture,
                     with patch('allensdk.core.json_utilities.write') as ju_write:
                         _ = ctc.get_ephys_sweeps(cell_id)
 
-    if path_exists:
-        assert ju_read.called_once_with(_MOCK_PATH)
-    else:
-        assert get_ephys_sweeps_mock.called_once_with(cell_id)
+    if not path_exists:
+        get_ephys_sweeps_mock.assert_called_once()
 
 
 @pytest.mark.parametrize('path_exists',
@@ -557,7 +555,7 @@ def test_get_ephys_sweeps_with_api(cache_fixture,
                             _ = ctc.get_ephys_sweeps(cell_id)
 
     # read will be called regardless
-    assert ju_read.called_once_with(_MOCK_PATH)
+    ju_read.assert_called_once()
 
     if path_exists:
         assert not query_mock.called

--- a/allensdk/test/core/test_json_utilities.py
+++ b/allensdk/test/core/test_json_utilities.py
@@ -35,7 +35,7 @@
 #
 import allensdk.core.json_utilities as ju
 import pytest
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 import numpy as np
 
 

--- a/allensdk/test/core/test_mouse_connectivity_cache.py
+++ b/allensdk/test/core/test_mouse_connectivity_cache.py
@@ -35,7 +35,7 @@
 #
 import os
 import warnings
-import mock
+from unittest import mock
 import pytest
 import numpy as np
 import nrrd

--- a/allensdk/test/core/test_nwb_data_set.py
+++ b/allensdk/test/core/test_nwb_data_set.py
@@ -33,7 +33,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from pkg_resources import resource_filename  # @UnresolvedImport
 import numpy as np
 from allensdk.core.nwb_data_set import NwbDataSet

--- a/allensdk/test/core/test_obj_utilities.py
+++ b/allensdk/test/core/test_obj_utilities.py
@@ -37,7 +37,7 @@
 import numpy as np
 
 import pytest
-from mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from allensdk.core.obj_utilities import read_obj, parse_obj
 

--- a/allensdk/test/core/test_reference_space.py
+++ b/allensdk/test/core/test_reference_space.py
@@ -36,7 +36,7 @@
 import os
 
 import pytest
-import mock
+from unittest import mock
 import numpy as np
 import nrrd
 import pandas as pd

--- a/allensdk/test/core/test_reference_space_cache.py
+++ b/allensdk/test/core/test_reference_space_cache.py
@@ -36,7 +36,7 @@
 import os
 
 import pytest
-import mock
+from unittest import mock
 import numpy as np
 import nrrd
 import pandas as pd

--- a/allensdk/test/core/test_simple_tree.py
+++ b/allensdk/test/core/test_simple_tree.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-import mock
+from unittest import mock
 from numpy import allclose
 
 from allensdk.core.simple_tree import SimpleTree

--- a/allensdk/test/core/test_structure_tree.py
+++ b/allensdk/test/core/test_structure_tree.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 import pytest
-import mock
+from unittest import mock
 from numpy import allclose
 import sys
 import pandas as pd

--- a/allensdk/test/ephys/test_extractor.py
+++ b/allensdk/test/ephys/test_extractor.py
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-import mock
+from unittest import mock
 
 import pytest
 import numpy as np

--- a/allensdk/test/internal/api/test_grid_data_api_prerelease.py
+++ b/allensdk/test/internal/api/test_grid_data_api_prerelease.py
@@ -1,7 +1,7 @@
 import os
 
 import nrrd
-import mock
+from unittest import mock
 import pytest
 import numpy as np
 from numpy.testing import assert_raises

--- a/allensdk/test/internal/api/test_mouse_connectivity_api_prerelease.py
+++ b/allensdk/test/internal/api/test_mouse_connectivity_api_prerelease.py
@@ -1,7 +1,7 @@
 import os
 
 import nrrd
-import mock
+from unittest import mock
 import pytest
 import numpy as np
 from numpy.testing import assert_raises

--- a/allensdk/test/internal/biophysical/test_ephys_utils.py
+++ b/allensdk/test/internal/biophysical/test_ephys_utils.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from mock import Mock
+from unittest.mock import Mock
 import allensdk.internal.model.biophysical.ephys_utils as ephys_utils
 
 

--- a/allensdk/test/internal/biophysical/test_optimize_run.py
+++ b/allensdk/test/internal/biophysical/test_optimize_run.py
@@ -1,10 +1,10 @@
 import pytest
 import sys
-from mock import patch, mock_open, Mock, MagicMock
+from unittest.mock import patch, mock_open, Mock, MagicMock
 from allensdk.model.biophysical.utils import Utils
 from allensdk.model.biophys_sim.config import Config
 import os
-import mock
+from unittest import mock
 import shutil
 try:
     import __builtin__ as builtins

--- a/allensdk/test/internal/biophysical/test_simulate_run.py
+++ b/allensdk/test/internal/biophysical/test_simulate_run.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch, mock_open, Mock, MagicMock
+from unittest.mock import patch, mock_open, Mock, MagicMock
 try:
     import __builtin__ as builtins
 except:

--- a/allensdk/test/internal/brain_observatory/test_time_sync.py
+++ b/allensdk/test/internal/brain_observatory/test_time_sync.py
@@ -4,7 +4,7 @@ import json
 import os
 import h5py
 from pkg_resources import resource_filename
-from mock import patch
+from unittest.mock import patch
 from allensdk.internal.brain_observatory import time_sync as ts
 from allensdk.internal.pipeline_modules import run_ophys_time_sync
 from allensdk.brain_observatory.sync_dataset import Dataset
@@ -65,7 +65,7 @@ def calculate_stimulus_alignment(stim_time, valid_twop_vsync_fall):
         try:
             stimulus_alignment[index] = int(crossings[0][0])
         except:  # noqa: E722
-            stimulus_alignment[index] = np.NaN
+            stimulus_alignment[index] = np.nan
 
     return stimulus_alignment
 
@@ -153,7 +153,7 @@ def sync_camera_stimulus(sync_data, sample_frequency, camera,
         try:
             frames[i] = crossings[0][0]
         except:  # noqa: E722
-            frames[i] = np.NaN
+            frames[i] = np.nan
 
     return frames
 

--- a/allensdk/test/internal/core/test_mouse_connectivity_cache_prerelease.py
+++ b/allensdk/test/internal/core/test_mouse_connectivity_cache_prerelease.py
@@ -1,6 +1,6 @@
 import os
 
-import mock
+from unittest import mock
 import pytest
 import nrrd
 import numpy as np

--- a/allensdk/test/internal/mouse_connectivity/test_interval_unionizer.py
+++ b/allensdk/test/internal/mouse_connectivity/test_interval_unionizer.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import numpy as np
 import pytest
-import mock
+from unittest import mock
 from six import iteritems
 
 from allensdk.internal.mouse_connectivity.interval_unionize.interval_unionizer \

--- a/allensdk/test/internal/mouse_connectivity/test_tissuecyte_unionize_record.py
+++ b/allensdk/test/internal/mouse_connectivity/test_tissuecyte_unionize_record.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import numpy as np
 import pytest
-import mock
+from unittest import mock
 from six import iteritems
 from six.moves import xrange
 

--- a/allensdk/test/internal/mouse_connectivity/test_unionize_record.py
+++ b/allensdk/test/internal/mouse_connectivity/test_unionize_record.py
@@ -1,7 +1,7 @@
 
 
 import pytest
-import mock
+from unittest import mock
 
 from allensdk.internal.mouse_connectivity.interval_unionize.unionize_record import Unionize
 

--- a/allensdk/test/internal/test_biophysical_modules.py
+++ b/allensdk/test/internal/test_biophysical_modules.py
@@ -1,7 +1,7 @@
 from allensdk.internal.api.queries.biophysical_module_api \
     import BiophysicalModuleApi
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 
 @pytest.fixture

--- a/allensdk/test/internal/test_optimize_config_reader.py
+++ b/allensdk/test/internal/test_optimize_config_reader.py
@@ -1,7 +1,7 @@
 from allensdk.internal.api.queries.optimize_config_reader import \
     OptimizeConfigReader
 import pytest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 try:
     import __builtin__ as builtins
 except:

--- a/allensdk/test/internal/test_optimize_manifest.py
+++ b/allensdk/test/internal/test_optimize_manifest.py
@@ -1,7 +1,7 @@
 from allensdk.internal.api.queries.optimize_config_reader import \
     OptimizeConfigReader
 import pytest
-from mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock
 from six import StringIO
 from io import IOBase
 import json

--- a/allensdk/test/internal/test_simulate_manifest.py
+++ b/allensdk/test/internal/test_simulate_manifest.py
@@ -1,7 +1,7 @@
 from allensdk.internal.api.queries.biophysical_module_reader import \
     BiophysicalModuleReader
 import pytest
-from mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open, MagicMock
 from six import StringIO
 from io import IOBase
 import json

--- a/allensdk/test/internal/test_simulate_update_output.py
+++ b/allensdk/test/internal/test_simulate_update_output.py
@@ -1,7 +1,7 @@
 from allensdk.internal.api.queries.biophysical_module_reader import \
     BiophysicalModuleReader
 import pytest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 try:
     import __builtin__ as builtins
 except:

--- a/allensdk/test/internal/tissuecyte_stitching/test_stitcher.py
+++ b/allensdk/test/internal/tissuecyte_stitching/test_stitcher.py
@@ -1,7 +1,7 @@
 import operator as op
 
 import pytest
-import mock
+from unittest import mock
 import numpy as np
 
 import allensdk.internal.mouse_connectivity.tissuecyte_stitching.stitcher as stitcher

--- a/allensdk/test/internal/tissuecyte_stitching/test_tile.py
+++ b/allensdk/test/internal/tissuecyte_stitching/test_tile.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import numpy as np
 
 from allensdk.internal.mouse_connectivity.tissuecyte_stitching.tile import Tile

--- a/allensdk/test/model/test_runner.py
+++ b/allensdk/test/model/test_runner.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 import subprocess
 
@@ -6,9 +7,9 @@ def test_args():
     Test for legacy and newest biophysical model simulation calls
     """
     # Legacy all-active simulation call pattern
-    args_legacy = subprocess.check_output(['python', '-m', 'allensdk.test.model.check_parser', 'manifest.json'])
+    args_legacy = subprocess.check_output([sys.executable, '-m', 'allensdk.test.model.check_parser', 'manifest.json'])
     assert 'stub' not in args_legacy.decode('utf-8')
 
     # Current all-active simulation call pattern
-    args_new = subprocess.check_output(['python', '-m', 'allensdk.test.model.check_parser', 'manifest.json', '--axon_type', 'stub'])
+    args_new = subprocess.check_output([sys.executable, '-m', 'allensdk.test.model.check_parser', 'manifest.json', '--axon_type', 'stub'])
     assert 'stub' in args_new.decode('utf-8')

--- a/allensdk/test/mouse_connectivity/grid/test_base_subimage.py
+++ b/allensdk/test/mouse_connectivity/grid/test_base_subimage.py
@@ -1,6 +1,6 @@
 import sys
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 from allensdk.mouse_connectivity.grid.subimage.base_subimage import (

--- a/allensdk/test/mouse_connectivity/grid/test_cav_subimage.py
+++ b/allensdk/test/mouse_connectivity/grid/test_cav_subimage.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 import numpy as np
 

--- a/allensdk/test/mouse_connectivity/grid/test_classic_subimage.py
+++ b/allensdk/test/mouse_connectivity/grid/test_classic_subimage.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 import numpy as np
 

--- a/allensdk/test/mouse_connectivity/grid/test_image_series_gridder.py
+++ b/allensdk/test/mouse_connectivity/grid/test_image_series_gridder.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from six.moves import range
 
 import numpy as np

--- a/allensdk/test/test_temp_dir.py
+++ b/allensdk/test/test_temp_dir.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import numpy as np
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from allensdk.test_utilities import temp_dir
 
 

--- a/doc_template/examples_root/examples/nb/visual_behavior_compare_across_trial_types.ipynb
+++ b/doc_template/examples_root/examples/nb/visual_behavior_compare_across_trial_types.ipynb
@@ -492,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "f373c7d4",
    "metadata": {
     "execution": {
@@ -513,32 +513,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_3358/3777615979.py:1: DeprecationWarning: Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython display\n",
-      "  from IPython.core.display import display, HTML\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:100% !important; }</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from IPython.core.display import display, HTML\n",
-    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
-   ]
+   "outputs": [],
+   "source": "from IPython.display import display, HTML\ndisplay(HTML(\"<style>.container { width:100% !important; }</style>\"))"
   },
   {
    "cell_type": "code",

--- a/doc_template/examples_root/examples/nb/visual_behavior_mouse_history.ipynb
+++ b/doc_template/examples_root/examples/nb/visual_behavior_mouse_history.ipynb
@@ -425,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "b126e7d6",
    "metadata": {
     "execution": {
@@ -443,32 +443,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_2923/3777615979.py:1: DeprecationWarning: Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython display\n",
-      "  from IPython.core.display import display, HTML\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:100% !important; }</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from IPython.core.display import display, HTML\n",
-    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
-   ]
+   "outputs": [],
+   "source": "from IPython.display import display, HTML\ndisplay(HTML(\"<style>.container { width:100% !important; }</style>\"))"
   },
   {
    "cell_type": "markdown",

--- a/doc_template/examples_root/examples/nb/visual_behavior_neuropixels_LFP_analysis.ipynb
+++ b/doc_template/examples_root/examples/nb/visual_behavior_neuropixels_LFP_analysis.ipynb
@@ -2091,7 +2091,7 @@
     "\n",
     "#Select a unit in V1\n",
     "v1_units = units_on_lfp_chans[units_on_lfp_chans.structure_acronym.str.contains('VISp')]\n",
-    "unit_id = v1_units.index.values[5]\n",
+    "unit_id = v1_units.index.values[0]\n",
     "\n",
     "#Get the peak channel ID for this unit (the channel on which it had the greatest spike amplitude)\n",
     "peak_chan_id = units_on_lfp_chans.loc[unit_id]['peak_channel_id']\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ psycopg2-binary
 hdmf!=3.5.*,!=3.6.*,!=3.7.*,!=3.8.*
 h5py
 matplotlib
-numpy<1.24
-pandas==1.5.3
+numpy
+pandas>=1.5.3,<3
 jinja2
-scipy<1.11
+scipy
 six
 pynrrd
 future
@@ -14,12 +14,13 @@ requests-toolbelt
 simplejson
 scikit-image
 scikit-build
+setuptools<81
 statsmodels
 simpleitk
 argschema
 glymur
-xarray<2023.2.0
-pynwb
+xarray
+pynwb<3
 tables
 seaborn
 aiohttp
@@ -31,3 +32,4 @@ semver
 cachetools
 sqlalchemy
 python-dateutil
+pytz

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,19 +1,11 @@
-pytest>=4.4.0
-pytest-cov>=2.6.1,<3.0.0
-pytest-cover>=3.0.0,<4.0.0
-pytest-pep8>=1.0.6,<2.0.0
-pytest-xdist>=1.14,<2.0.0
-pytest-mock>=1.5.0,<3.0.0
-mock>=1.0.1,<5.0.0
-coverage>=3.7.1,<6.0.0
-moto==3.0.7
-# these overlap with requirements specified in doc_requirements. As long as they are needed, these specifications must be kept in sync
-# TODO: see if we can avoid duplicating these requirements - this will involved surveying CI
-pep8==1.7.0,<2.0.0
-flake8>=1.5.0,<4.0.0
-pylint>=1.5.4,<3.0.0
-jinja2>=2.7.3,<2.12.0
-numpydoc>=0.6.0,<1.0.0
+pytest>=4.4.0,<9
+pytest-cov
+pytest-xdist
+pytest-mock
+coverage
+moto>=3,<5
+flake8
+pylint
+jinja2
+numpydoc
 jupyter>=1.0.0,<2.0.0
-markupsafe==2.0.1
-pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'win32'


### PR DESCRIPTION
# Overview:

Three pinned dependencies blocked installation on 3.12:
- numpy<1.24: no cp312 wheels
- pandas==1.5.3: no cp312 wheels
- scipy<1.11: requires_python<3.12

# Addresses:
<!-- Add a link to the issue on Github board
example:
Addresses issue [#1234](git_hub_ticket_url)-->
Fixes  #2747
Fixes #2744
Fixes #2746 
Fixes #2754 
etc...

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Minimally update the requirements to allow installation on 3.12+:

- numpy<1.24: no cp312 wheels; now uncapped (1.26 is first with 3.12 wheels)
- pandas==1.5.3: no cp312 wheels; now >=1.5.3,<3 (pandas 3.x compat requires more work)
- scipy<1.11: requires_python<3.12; now uncapped
- pynwb<3: breaking pynwb versions was released with extensive API changes, cap this dependency for now

Also some other requirements problems:

- xarray<2023.2.0: unpinned (pure Python, no breakage)
- pytz: added (was transitive via pandas 1.x, now needed explicitly)
- setuptools<81 (was transitive with earlier python versions)

# Changes:

Source fixes for APIs removed in the new versions of dependencies:
- scipy.interpolate.interp2d removed in 1.14: replaced with RectBivariateSpline (same linear interpolation, swapped axis convention) in chisquarerf.py and utilities.py
- ConfigParser.readfp removed in Python 3.12: use read_string directly in application_config.py
- DataFrame.iteritems() removed in pandas 2.0: use items() in behavior_project_cache.py, save_extended_stimulus_presentations_df.py, receptive_field.py
- np.int() removed in numpy 1.24: use builtin int() in DLC_Ellipse_Video.py
- np.NaN, np.NAN → np.nan — removed in numpy 2.x, 49 occurrences across 22 files
- np.Inf → np.inf — removed in numpy 2.x
- np.string_ → np.bytes_ — removed in numpy 2.x, 4 occurrences across 4 files
- np.product → np.prod — removed in numpy 2.x
- np.ediff1d to_bein and to_end → dtype must be the same as ary in numpy 2.x
- np.in1d → np.isin— removed in numpy 2.x
- np.VisibleDeprecationWarning → removed in numpy 2.x, use try except import block in 1 file
- nwbfile.modules → .processing (deprecated alias in pynwb 2.x, removed in 3.x): running_acquisition.py, running_speed.py, nwb_api.py
- IndexSeries unit='None' → 'N/A' (pynwb 2.5+ fixed unit field): templates.py
- np.linalg.norm([array, scalar]) → np.vstack + full_like (numpy 1.24+ rejects inhomogeneous lists): _gaze_mapper.py
- aiohttp.ClientSession created eagerly in init → lazy https://github.com/Property (aiohttp 3.9+ warns when no event loop running): http_engine.py
- groupby().apply() on full DataFrame → select column first (pandas 2.2+ changed groupby-apply behavior): ecephys_project_cache.py
- Some LAPACK implementations return inf instead of raising LinAlgError
  for singular matrices. Add a finite-check fallback so _demix_point
  always falls back to lstsq in these cases.
- DataFrame.append() → pd.concat() (removed in pandas 2.0)
- pd.to_datetime: add format="ISO8601" for mixed-precision timestamps (pandas 2.x rejects mixed microsecond precision without explicit format)
- pd.to_datetime: fix utc="True" (string) → utc=True (bool) bug in behavior_project_cloud_api.py


Test fixes:
- pytest.warns(None) → warnings.catch_warnings (pytest 8 removed
  None sentinel): test_cache.py, test_smart_download.py
- mock.called_once_with (always truthy no-op) → assert_called_once()
  (proper assertion): test_cell_types_cache_unit.py
- Add res.x to MagicMock (scipy.optimize.minimize result accessed
  in numpy 1.24+ array construction): test_fitgaussian2D.py
- rng.choice(inhomogeneous list) → rng.integers + index (numpy 1.24+
  rejects ragged sequences): conftest.py
- Cast obtained dtypes to match expected (pynwb 2.x roundtrip returns
  nullable boolean for float columns): test_write_nwb.py
- Align index dtypes before assert_frame_equal (pandas 2.x infers
  different int dtypes): test_behavior_project_cache.py
- subprocess 'python' → sys.executable (resolves correct venv
  interpreter): test_runner.py
- patch logging.warning instead of using caplog
- The test_demix_raises_warning_for_singular_matrix test was
  platform-dependent: scipy.linalg.solve does not consistently raise
  LinAlgError for singular matrices across LAPACK implementations.
  Move the singular matrix case into test_demix_point to verify
  correctness of the result regardless of which internal path is taken.
- use unittest.mock instead of mock: mock no longer needed in python 3.10
- uncap many of the test dependencies, which were causing the coverage report to be very slow
- Add pandas 2.x datetime regression tests (test_pandas_compat.py)

Notebook fixes:
- IPython.core.display → IPython.display (removed in IPython 8.x)
    in visual_behavior_compare_across_trial_types and
    visual_behavior_mouse_history notebooks

CI changes:
- change CI to use more recent actions
- don't use conda to install python to fix macos issues
- narrow CI matrix to bounds of non-EOL python versions on ubuntu, 3.13 only on windows and mac
- Only calculate coverage on one matrix element
- Use pip cache keyed on requirements.txt and test_requirements.txt
- Switch notebook runner to ubuntu-latest-8x (32GB RAM) for
    ecephys notebooks that peak at ~21GB RSS
- Change notebook workflow trigger to push on master (expensive job
    should not run on every pull request)

# Validation:

Tested: installs and imports cleanly on Python 3.10 and 3.12.

Ran local tests that do not require data, no new test failures occur (some were preexisting)

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](https://github.com/AllenInstitute/AllenSDK/blob/master/CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [X] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [X] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My Pull Request has the latest AllenSDK release candidate branch
      rc/x.y.z as its merge target
- [x] My code passes all AllenSDK tests

# Notes
No active RC branch to merge into, targeting master instead.

This is a near-duplicate of #2768, which I think could be a good merge candidate. However, given the lack of traction with that PR I wanted to make a more focused PR that did the bare minimum to allow installation on 3.12, and to make CI pass. I would be happy with either PR being merged, as long as we can install on 3.12.

Compared to #2768, this PR is similar but also supports numpy 2, which allows this package to run on python 3.13 and get numpy wheels on most platforms. Other test changes and CI changes are minor improvements over #2768, but not substantial. 