### PR TITLE
Upper cap dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "matplotlib",
     "ndx-events",
     "nest_asyncio",
-    "numpy",
+    "numpy<2.5.0",
     "packaging",
     "pandas>=1.5.3,<3",
     "psycopg2-binary",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "cachetools",
     "glymur",
     "h5py",
-    "hdmf!=3.5.*,!=3.6.*,!=3.7.*,!=3.8.*",
+    "hdmf!=3.5.*,!=3.6.*,!=3.7.*,!=3.8.*,<5",
     "jinja2",
     "matplotlib",
     "ndx-events",


### PR DESCRIPTION
Tests were failing - putting an upper cap on HDMF and numpy fixes them. 

An alternative would be to update the tests for compatibility.